### PR TITLE
Make the default width `0.45`

### DIFF
--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry.ts
@@ -1,6 +1,6 @@
 import type { FacingDirection } from "lib/utils/dir"
 
-export const NET_LABEL_HORIZONTAL_WIDTH = 0.5
+export const NET_LABEL_HORIZONTAL_WIDTH = 0.45
 export const NET_LABEL_HORIZONTAL_HEIGHT = 0.2
 
 export function getDimsForOrientation(orientation: FacingDirection) {

--- a/site/examples/example11.page.tsx
+++ b/site/examples/example11.page.tsx
@@ -1,0 +1,119 @@
+import { PipelineDebugger } from "site/components/PipelineDebugger"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "schematic_component_0",
+      center: {
+        x: -1.03,
+        y: 0.765,
+      },
+      width: 1.06,
+      height: 0.388910699999999,
+      pins: [
+        {
+          pinId: "R1.1",
+          x: -1.58,
+          y: 0.765,
+        },
+        {
+          pinId: "R1.2",
+          x: -0.48,
+          y: 0.765,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_1",
+      center: {
+        x: 1.03,
+        y: 0.765,
+      },
+      width: 1.06,
+      height: 0.388910699999999,
+      pins: [
+        {
+          pinId: "R2.1",
+          x: 0.48,
+          y: 0.765,
+        },
+        {
+          pinId: "R2.2",
+          x: 1.58,
+          y: 0.765,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_2",
+      center: {
+        x: -1.03,
+        y: -0.765,
+      },
+      width: 1.06,
+      height: 0.388910699999999,
+      pins: [
+        {
+          pinId: "R3.1",
+          x: -1.58,
+          y: -0.765,
+        },
+        {
+          pinId: "R3.2",
+          x: -0.48,
+          y: -0.765,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_3",
+      center: {
+        x: 1.03,
+        y: -0.765,
+      },
+      width: 0.88,
+      height: 0.53,
+      pins: [
+        {
+          pinId: "J1.1",
+          x: 0.5800000000000001,
+          y: -0.665,
+        },
+        {
+          pinId: "J1.2",
+          x: 1.03,
+          y: -1.0150000000000001,
+        },
+        {
+          pinId: "J1.3",
+          x: 1.48,
+          y: -0.665,
+        },
+      ],
+    },
+  ],
+  directConnections: [
+    {
+      pinIds: ["R2.1", "R3.2"],
+      netId: ".R2 > .pin1 to .R3 > .pin2",
+    },
+    {
+      pinIds: ["R2.2", "R3.1"],
+      netId: ".R2 > .pin2 to .R3 > .pin1",
+    },
+    {
+      pinIds: ["J1.1", "R1.1"],
+      netId: ".J1 > .pin1 to .R1 > .pin1",
+    },
+    {
+      pinIds: ["J1.3", "R1.2"],
+      netId: ".J1 > .pin3 to .R1 > .pin2",
+    },
+  ],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+  maxMspPairDistance: 5,
+}
+
+export default () => <PipelineDebugger inputProblem={inputProblem} />

--- a/site/examples/example12.page.tsx
+++ b/site/examples/example12.page.tsx
@@ -1,0 +1,97 @@
+import { PipelineDebugger } from "site/components/PipelineDebugger"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "schematic_component_0",
+      center: {
+        x: 0,
+        y: 0,
+      },
+      width: 1.4000000000000001,
+      height: 0.8,
+      pins: [
+        {
+          pinId: "J1.1",
+          x: 1.1,
+          y: 0.2,
+        },
+        {
+          pinId: "J1.2",
+          x: 1.1,
+          y: 0,
+        },
+        {
+          pinId: "J1.3",
+          x: 1.1,
+          y: -0.2,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_1",
+      center: {
+        x: 1.0999999999999996,
+        y: -1.7944553499999996,
+      },
+      width: 1.06,
+      height: 0.388910699999999,
+      pins: [
+        {
+          pinId: "R1.1",
+          x: 0.5499999999999996,
+          y: -1.7944553499999996,
+        },
+        {
+          pinId: "R1.2",
+          x: 1.6499999999999997,
+          y: -1.7944553499999996,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_2",
+      center: {
+        x: 2.86,
+        y: 0.01999999999999985,
+      },
+      width: 1.06,
+      height: 0.84,
+      pins: [
+        {
+          pinId: "C1.1",
+          x: 2.3099999999999996,
+          y: 0.01999999999999985,
+        },
+        {
+          pinId: "C1.2",
+          x: 3.41,
+          y: 0.01999999999999985,
+        },
+      ],
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    {
+      netId: "VCC",
+      pinIds: ["J1.1", "C1.1"],
+    },
+    {
+      netId: "OUT",
+      pinIds: ["J1.2", "R1.1"],
+    },
+    {
+      netId: "GND",
+      pinIds: ["J1.3", "R1.2", "C1.2"],
+    },
+  ],
+  availableNetLabelOrientations: {
+    VCC: ["y+"],
+    GND: ["y-"],
+  },
+  maxMspPairDistance: 5,
+}
+
+export default () => <PipelineDebugger inputProblem={inputProblem} />


### PR DESCRIPTION
Having the default width as `0.5` makes the netLabel vanish for this schematic test. (Will create a new issue for this)

<img width="2320" height="1578" alt="image" src="https://github.com/user-attachments/assets/71352654-8a12-4bc1-9920-d290a36b0c32" />


This PR is a kind of a hack so both of these tests net label looks fine - https://github.com/tscircuit/core/pull/1254