### PR TITLE
feat: add a horizontal shift to the netLabel position when it get's obstructed by the chip on placement

### DIFF
--- a/site/examples/example11.page.tsx
+++ b/site/examples/example11.page.tsx
@@ -1,7 +1,7 @@
 import { PipelineDebugger } from "site/components/PipelineDebugger"
 import type { InputProblem } from "lib/types/InputProblem"
 
-const inputProblem: InputProblem = {
+export const inputProblem: InputProblem = {
   chips: [
     {
       chipId: "schematic_component_0",

--- a/site/examples/example12.page.tsx
+++ b/site/examples/example12.page.tsx
@@ -1,7 +1,7 @@
 import { PipelineDebugger } from "site/components/PipelineDebugger"
 import type { InputProblem } from "lib/types/InputProblem"
 
-const inputProblem: InputProblem = {
+export const inputProblem: InputProblem = {
   chips: [
     {
       chipId: "schematic_component_0",

--- a/site/examples/example13.page.tsx
+++ b/site/examples/example13.page.tsx
@@ -1,0 +1,219 @@
+import { PipelineDebugger } from "site/components/PipelineDebugger"
+import type { InputProblem } from "lib/types/InputProblem"
+
+export const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "schematic_component_0",
+      center: {
+        x: 0,
+        y: 0,
+      },
+      width: 1.5,
+      height: 3.75,
+      pins: [
+        {
+          pinId: "PWR1.7",
+          x: 1.15,
+          y: 0.75,
+        },
+        {
+          pinId: "PWR1.6",
+          x: 1.15,
+          y: 0,
+        },
+        {
+          pinId: "PWR1.5",
+          x: 1.15,
+          y: -0.75,
+        },
+        {
+          pinId: "PWR1.4",
+          x: -1.15,
+          y: -1.125,
+        },
+        {
+          pinId: "PWR1.3",
+          x: -1.15,
+          y: -0.375,
+        },
+        {
+          pinId: "PWR1.2",
+          x: -1.15,
+          y: 0.375,
+        },
+        {
+          pinId: "PWR1.1",
+          x: -1.15,
+          y: 1.125,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_1",
+      center: {
+        x: -3,
+        y: 0,
+      },
+      width: 1.06,
+      height: 0.388910699999999,
+      pins: [
+        {
+          pinId: "R6.1",
+          x: -3.55,
+          y: 0,
+        },
+        {
+          pinId: "R6.2",
+          x: -2.45,
+          y: 0,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_2",
+      center: {
+        x: -3,
+        y: -2,
+      },
+      width: 1.06,
+      height: 0.388910699999999,
+      pins: [
+        {
+          pinId: "R7.1",
+          x: -3.55,
+          y: -1.9999999999999998,
+        },
+        {
+          pinId: "R7.2",
+          x: -2.45,
+          y: -1.9999999999999998,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_3",
+      center: {
+        x: -3,
+        y: 2,
+      },
+      width: 1.06,
+      height: 0.388910699999999,
+      pins: [
+        {
+          pinId: "R8.1",
+          x: -3.55,
+          y: 2,
+        },
+        {
+          pinId: "R8.2",
+          x: -2.45,
+          y: 2,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_4",
+      center: {
+        x: 3,
+        y: -1.5,
+      },
+      width: 1.06,
+      height: 0.84,
+      pins: [
+        {
+          pinId: "C6.1",
+          x: 2.45,
+          y: -1.5,
+        },
+        {
+          pinId: "C6.2",
+          x: 3.55,
+          y: -1.5,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_5",
+      center: {
+        x: 3,
+        y: 0,
+      },
+      width: 1.06,
+      height: 0.84,
+      pins: [
+        {
+          pinId: "C7.1",
+          x: 2.45,
+          y: 0,
+        },
+        {
+          pinId: "C7.2",
+          x: 3.55,
+          y: 0,
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_6",
+      center: {
+        x: 4,
+        y: 3,
+      },
+      width: 1.13,
+      height: 0.65,
+      pins: [
+        {
+          pinId: "LED1.1",
+          x: 3.46,
+          y: 3,
+        },
+        {
+          pinId: "LED1.2",
+          x: 4.54,
+          y: 3,
+        },
+      ],
+    },
+  ],
+  directConnections: [
+    {
+      pinIds: ["R6.1", "PWR1.1"],
+      netId: ".R6 > .pin1 to .PWR1 > .OUT",
+    },
+    {
+      pinIds: ["LED1.1", "R8.2"],
+      netId: ".LED1 > .pos to .R8 > .pin2",
+    },
+    {
+      pinIds: ["PWR1.2", "R6.2"],
+      netId: ".PWR1 > .FB to .R6 > .pin2",
+    },
+    {
+      pinIds: ["PWR1.2", "R7.1"],
+      netId: ".PWR1 > .FB to .R7 > .pin1",
+    },
+  ],
+  netConnections: [
+    {
+      netId: "gnd",
+      pinIds: ["PWR1.7", "PWR1.3", "R7.2", "C6.2", "C7.2", "LED1.2"],
+    },
+    {
+      netId: "v5",
+      pinIds: ["PWR1.6", "PWR1.4", "C6.1"],
+    },
+    {
+      netId: "v3_3",
+      pinIds: ["PWR1.1", "R6.1", "R8.1", "C7.1"],
+    },
+  ],
+  availableNetLabelOrientations: {
+    gnd: ["y-"],
+    v5: ["y+"],
+    v3_3: ["y+"],
+  },
+  maxMspPairDistance: 5,
+}
+
+export default () => <PipelineDebugger inputProblem={inputProblem} />

--- a/tests/examples/__snapshots__/example11.snap.svg
+++ b/tests/examples/__snapshots__/example11.snap.svg
@@ -1,0 +1,162 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="R1.1
+x-" data-x="-1.58" data-y="0.765" cx="103.74558303886928" cy="224.94699646643113" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.2
+x+" data-x="-0.48" data-y="0.765" cx="259.2226148409894" cy="224.94699646643113" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R2.1
+x-" data-x="0.48" data-y="0.765" cx="394.9116607773851" cy="224.94699646643113" r="3" fill="hsl(107, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R2.2
+x+" data-x="1.58" data-y="0.765" cx="550.3886925795052" cy="224.94699646643113" r="3" fill="hsl(108, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R3.1
+x-" data-x="-1.58" data-y="-0.765" cx="103.74558303886928" cy="441.2014134275618" r="3" fill="hsl(348, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R3.2
+x+" data-x="-0.48" data-y="-0.765" cx="259.2226148409894" cy="441.2014134275618" r="3" fill="hsl(349, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="J1.1
+x-" data-x="0.5800000000000001" data-y="-0.665" cx="409.0459363957597" cy="427.0671378091873" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="J1.2
+y-" data-x="1.03" data-y="-1.03" cx="472.6501766784452" cy="478.65724381625444" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="J1.3
+x+" data-x="1.48" data-y="-0.665" cx="536.2544169611307" cy="427.0671378091873" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="0.27999999999999997" data-y="0.765" cx="366.64310954063603" cy="224.94699646643113" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1.7800000000000002" data-y="0.765" cx="578.6572438162544" cy="224.94699646643113" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="0.5800000000000001" data-y="-0.665" cx="409.0459363957597" cy="427.0671378091873" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-1.58" data-y="0.765" cx="103.74558303886928" cy="224.94699646643113" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1.48" data-y="-0.665" cx="536.2544169611307" cy="427.0671378091873" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-0.48" data-y="0.765" cx="259.2226148409894" cy="224.94699646643113" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <polyline data-points="0.48,0.765 -0.48,-0.765" data-type="line" data-label="" points="394.9116607773851,224.94699646643113 259.2226148409894,441.2014134275618" fill="none" stroke="hsl(224, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.58,0.765 -1.58,-0.765" data-type="line" data-label="" points="550.3886925795052,224.94699646643113 103.74558303886928,441.2014134275618" fill="none" stroke="hsl(224, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.5800000000000001,-0.665 -1.58,0.765" data-type="line" data-label="" points="409.0459363957597,427.0671378091873 103.74558303886928,224.94699646643113" fill="none" stroke="hsl(168, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.48,-0.665 -0.48,0.765" data-type="line" data-label="" points="536.2544169611307,427.0671378091873 259.2226148409894,224.94699646643113" fill="none" stroke="hsl(168, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.48,0.765 0.27999999999999997,0.765 0,0.765 0,-0.765 -0.27999999999999997,-0.765 -0.48,-0.765" data-type="line" data-label="" points="394.9116607773851,224.94699646643113 366.64310954063603,224.94699646643113 327.0671378091873,224.94699646643113 327.0671378091873,441.2014134275618 287.4911660777385,441.2014134275618 259.2226148409894,441.2014134275618" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.58,0.765 1.7800000000000002,0.765 1.7800000000000002,0 -1.78,0 -1.78,-0.765 -1.58,-0.765" data-type="line" data-label="" points="550.3886925795052,224.94699646643113 578.6572438162544,224.94699646643113 578.6572438162544,333.0742049469965 75.47703180212017,333.0742049469965 75.47703180212017,441.2014134275618 103.74558303886928,441.2014134275618" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="-1.03" data-y="0.765" x="103.74558303886928" y="197.46214134275627" width="155.47703180212014" height="54.969710247349695" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="1.03" data-y="0.765" x="394.9116607773851" y="197.46214134275627" width="155.4770318021201" height="54.969710247349695" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_2" data-x="-1.03" data-y="-0.765" x="103.74558303886928" y="413.716558303887" width="155.47703180212014" height="54.969710247349724" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_3" data-x="1.03" data-y="-0.765" x="409.0459363957597" y="403.74558303886926" width="127.20848056537096" height="74.91166077738518" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="0.27999999999999997" data-y="0.99" x="352.5088339222615" y="161.3427561837456" width="28.26855123674909" height="63.60424028268554" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.7800000000000002" data-y="0.99" x="564.5229681978799" y="161.3427561837456" width="28.26855123674909" height="63.60424028268554" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="0.3540000000000001" data-y="-0.665" x="345.30035335689047" y="412.9328621908127" width="63.60424028268551" height="28.26855123674909" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-1.806" data-y="0.765" x="40" y="210.81272084805656" width="63.60424028268554" height="28.26855123674912" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.706" data-y="-0.665" x="536.3957597173144" y="412.9328621908127" width="63.60424028268562" height="28.26855123674909" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-0.254" data-y="0.765" x="259.36395759717317" y="210.81272084805656" width="63.60424028268551" height="28.26855123674912" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0070750000000000006" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 141.34275618374556,
+        "c": 0,
+        "e": 327.0671378091873,
+        "b": 0,
+        "d": -141.34275618374556,
+        "f": 333.0742049469965
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/examples/__snapshots__/example12.snap.svg
+++ b/tests/examples/__snapshots__/example12.snap.svg
@@ -1,0 +1,145 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="J1.1
+x+" data-x="1.1" data-y="0.2" cx="301.5156017830609" cy="201.4588202080238" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="J1.2
+x+" data-x="1.1" data-y="0" cx="301.5156017830609" cy="225.2329658246657" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="J1.3
+x+" data-x="1.1" data-y="-0.2" cx="301.5156017830609" cy="249.00711144130761" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.1
+x-" data-x="0.5499999999999996" data-y="-1.7944553499999996" cx="236.13670133729568" cy="438.5411797919762" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.2
+x+" data-x="1.6499999999999997" data-y="-1.7944553499999996" cx="366.8945022288261" cy="438.5411797919762" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C1.1
+x-" data-x="2.3099999999999996" data-y="0.01999999999999985" cx="445.34918276374435" cy="222.85555126300153" r="3" fill="hsl(121, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C1.2
+x+" data-x="3.41" data-y="0.01999999999999985" cx="576.1069836552749" cy="222.85555126300153" r="3" fill="hsl(122, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1.3" data-y="0.2" cx="325.28974739970283" cy="201.4588202080238" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1.3" data-y="-0.4486138374999999" cx="325.28974739970283" cy="278.5600193164933" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1.8499999999999996" data-y="-1.7944553499999996" cx="390.668647845468" cy="438.5411797919762" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="3.511" data-y="0.01999999999999985" cx="588.1129271916791" cy="222.85555126300153" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <polyline data-points="1.1,0.2 2.3099999999999996,0.01999999999999985" data-type="line" data-label="" points="301.5156017830609,201.4588202080238 445.34918276374435,222.85555126300153" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.1,0 0.5499999999999996,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,225.2329658246657 236.13670133729568,438.5411797919762" fill="none" stroke="hsl(158, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.1,-0.2 1.6499999999999997,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,249.00711144130761 366.8945022288261,438.5411797919762" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.1,-0.2 3.41,0.01999999999999985" data-type="line" data-label="" points="301.5156017830609,249.00711144130761 576.1069836552749,222.85555126300153" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.6499999999999997,-1.7944553499999996 3.41,0.01999999999999985" data-type="line" data-label="" points="366.8945022288261,438.5411797919762 576.1069836552749,222.85555126300153" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.1,0.2 1.3,0.2 1.7049999999999998,0.2 1.7049999999999998,0.01999999999999985 2.1099999999999994,0.01999999999999985 2.3099999999999996,0.01999999999999985" data-type="line" data-label="" points="301.5156017830609,201.4588202080238 325.28974739970283,201.4588202080238 373.4323922734027,201.4588202080238 373.4323922734027,222.85555126300153 421.5750371471024,222.85555126300153 445.34918276374435,222.85555126300153" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.1,0 1.3,0 1.3,-0.8972276749999998 0.34999999999999964,-0.8972276749999998 0.34999999999999964,-1.7944553499999996 0.5499999999999996,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,225.2329658246657 325.28974739970283,225.2329658246657 325.28974739970283,331.88707280832097 212.36255572065375,331.88707280832097 212.36255572065375,438.5411797919762 236.13670133729568,438.5411797919762" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.6499999999999997,-1.7944553499999996 1.8499999999999996,-1.7944553499999996 1.8499999999999996,-0.2 1.1,-0.2" data-type="line" data-label="" points="366.8945022288261,438.5411797919762 390.668647845468,438.5411797919762 390.668647845468,249.00711144130761 301.5156017830609,249.00711144130761" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40.00000000000003" y="177.6846745913819" width="261.5156017830609" height="95.09658246656761" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="1.0999999999999996" data-y="-1.7944553499999996" x="236.13670133729568" y="415.42613075780093" width="130.75780089153045" height="46.230098068350514" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_2" data-x="2.86" data-y="0.01999999999999985" x="445.34918276374435" y="172.92984546805354" width="130.75780089153056" height="99.85141158989597" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.3" data-y="0.42500000000000004" x="313.40267459138187" y="147.96699257057952" width="23.77414561664193" height="53.49182763744429" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.5250000000000001" data-y="-0.4486138374999999" x="325.28974739970283" y="266.6729465081724" width="53.49182763744432" height="23.774145616641874" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.8499999999999996" data-y="-2.0194553499999994" x="378.78157503714704" y="438.54117979197616" width="23.77414561664193" height="53.49182763744432" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="3.511" data-y="-0.20600000000000016" x="576.2258543833581" y="222.97442199108474" width="23.77414561664193" height="53.49182763744426" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 118.8707280832095,
+        "c": 0,
+        "e": 170.75780089153048,
+        "b": 0,
+        "d": -118.8707280832095,
+        "f": 225.2329658246657
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/examples/__snapshots__/example13.snap.svg
+++ b/tests/examples/__snapshots__/example13.snap.svg
@@ -1,0 +1,316 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="PWR1.7
+x+" data-x="1.15" data-y="0.75" cx="365.01450957632034" cy="299.68659315148" r="3" fill="hsl(159, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PWR1.6
+x+" data-x="1.15" data-y="0" cx="365.01450957632034" cy="348.43876958792805" r="3" fill="hsl(158, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PWR1.5
+x+" data-x="1.15" data-y="-0.75" cx="365.01450957632034" cy="397.1909460243761" r="3" fill="hsl(157, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PWR1.4
+x-" data-x="-1.15" data-y="-1.125" cx="215.507835171213" cy="421.56703424260013" r="3" fill="hsl(156, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PWR1.3
+x-" data-x="-1.15" data-y="-0.375" cx="215.507835171213" cy="372.8148578061521" r="3" fill="hsl(155, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PWR1.2
+x-" data-x="-1.15" data-y="0.375" cx="215.507835171213" cy="324.062681369704" r="3" fill="hsl(154, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PWR1.1
+x-" data-x="-1.15" data-y="1.125" cx="215.507835171213" cy="275.31050493325597" r="3" fill="hsl(153, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R6.1
+x-" data-x="-3.55" data-y="0" cx="59.50087057457921" cy="348.43876958792805" r="3" fill="hsl(351, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R6.2
+x+" data-x="-2.45" data-y="0" cx="131.00406268136967" cy="348.43876958792805" r="3" fill="hsl(352, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R7.1
+x-" data-x="-3.55" data-y="-1.9999999999999998" cx="59.50087057457921" cy="478.4445734184562" r="3" fill="hsl(232, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R7.2
+x+" data-x="-2.45" data-y="-1.9999999999999998" cx="131.00406268136967" cy="478.4445734184562" r="3" fill="hsl(233, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R8.1
+x-" data-x="-3.55" data-y="2" cx="59.50087057457921" cy="218.4329657573999" r="3" fill="hsl(113, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R8.2
+x+" data-x="-2.45" data-y="2" cx="131.00406268136967" cy="218.4329657573999" r="3" fill="hsl(114, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C6.1
+x-" data-x="2.45" data-y="-1.5" cx="449.5182820661637" cy="445.94312246082416" r="3" fill="hsl(246, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C6.2
+x+" data-x="3.55" data-y="-1.5" cx="521.0214741729542" cy="445.94312246082416" r="3" fill="hsl(247, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C7.1
+x-" data-x="2.45" data-y="0" cx="449.5182820661637" cy="348.43876958792805" r="3" fill="hsl(127, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C7.2
+x+" data-x="3.55" data-y="0" cx="521.0214741729542" cy="348.43876958792805" r="3" fill="hsl(128, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="LED1.1
+x-" data-x="3.435" data-y="3" cx="513.5461404526988" cy="153.43006384213584" r="3" fill="hsl(57, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="LED1.2
+x+" data-x="4.5649999999999995" data-y="3" cx="586.9994196169471" cy="153.43006384213584" r="3" fill="hsl(58, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-3.75" data-y="2" cx="46.500290191526375" cy="218.4329657573999" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="2.349" data-y="0" cx="442.952988972722" cy="348.43876958792805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="3.435" data-y="3" cx="513.5461404526988" cy="153.43006384213584" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-2.45" data-y="2" cx="131.00406268136967" cy="218.4329657573999" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-2.25" data-y="0" cx="144.0046430644225" cy="348.43876958792805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-2.25" data-y="-1.9999999999999998" cx="144.0046430644225" cy="478.4445734184562" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1.35" data-y="0" cx="378.0150899593732" cy="348.43876958792805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <polyline data-points="-3.55,0 -1.15,1.125" data-type="line" data-label="" points="59.50087057457921,348.43876958792805 215.507835171213,275.31050493325597" fill="none" stroke="hsl(40, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3.435,3 -2.45,2" data-type="line" data-label="" points="513.5461404526988,153.43006384213584 131.00406268136967,218.4329657573999" fill="none" stroke="hsl(224, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,0.375 -2.45,0" data-type="line" data-label="" points="215.507835171213,324.062681369704 131.00406268136967,348.43876958792805" fill="none" stroke="hsl(272, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,0.375 -3.55,-1.9999999999999998" data-type="line" data-label="" points="215.507835171213,324.062681369704 59.50087057457921,478.4445734184562" fill="none" stroke="hsl(272, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0.75 -1.15,-0.375" data-type="line" data-label="" points="365.01450957632034,299.68659315148 215.507835171213,372.8148578061521" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0.75 -2.45,-1.9999999999999998" data-type="line" data-label="" points="365.01450957632034,299.68659315148 131.00406268136967,478.4445734184562" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0.75 3.55,-1.5" data-type="line" data-label="" points="365.01450957632034,299.68659315148 521.0214741729542,445.94312246082416" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0.75 3.55,0" data-type="line" data-label="" points="365.01450957632034,299.68659315148 521.0214741729542,348.43876958792805" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0.75 4.5649999999999995,3" data-type="line" data-label="" points="365.01450957632034,299.68659315148 586.9994196169471,153.43006384213584" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,-0.375 -2.45,-1.9999999999999998" data-type="line" data-label="" points="215.507835171213,372.8148578061521 131.00406268136967,478.4445734184562" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,-0.375 3.55,-1.5" data-type="line" data-label="" points="215.507835171213,372.8148578061521 521.0214741729542,445.94312246082416" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,-0.375 3.55,0" data-type="line" data-label="" points="215.507835171213,372.8148578061521 521.0214741729542,348.43876958792805" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,-0.375 4.5649999999999995,3" data-type="line" data-label="" points="215.507835171213,372.8148578061521 586.9994196169471,153.43006384213584" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-2.45,-1.9999999999999998 3.55,-1.5" data-type="line" data-label="" points="131.00406268136967,478.4445734184562 521.0214741729542,445.94312246082416" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-2.45,-1.9999999999999998 3.55,0" data-type="line" data-label="" points="131.00406268136967,478.4445734184562 521.0214741729542,348.43876958792805" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-2.45,-1.9999999999999998 4.5649999999999995,3" data-type="line" data-label="" points="131.00406268136967,478.4445734184562 586.9994196169471,153.43006384213584" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="3.55,-1.5 3.55,0" data-type="line" data-label="" points="521.0214741729542,445.94312246082416 521.0214741729542,348.43876958792805" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="3.55,-1.5 4.5649999999999995,3" data-type="line" data-label="" points="521.0214741729542,445.94312246082416 586.9994196169471,153.43006384213584" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="3.55,0 4.5649999999999995,3" data-type="line" data-label="" points="521.0214741729542,348.43876958792805 586.9994196169471,153.43006384213584" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0 -1.15,-1.125" data-type="line" data-label="" points="365.01450957632034,348.43876958792805 215.507835171213,421.56703424260013" fill="none" stroke="hsl(111, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0 2.45,-1.5" data-type="line" data-label="" points="365.01450957632034,348.43876958792805 449.5182820661637,445.94312246082416" fill="none" stroke="hsl(111, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,-1.125 2.45,-1.5" data-type="line" data-label="" points="215.507835171213,421.56703424260013 449.5182820661637,445.94312246082416" fill="none" stroke="hsl(111, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,1.125 -3.55,0" data-type="line" data-label="" points="215.507835171213,275.31050493325597 59.50087057457921,348.43876958792805" fill="none" stroke="hsl(105, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,1.125 -3.55,2" data-type="line" data-label="" points="215.507835171213,275.31050493325597 59.50087057457921,218.4329657573999" fill="none" stroke="hsl(105, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,1.125 2.45,0" data-type="line" data-label="" points="215.507835171213,275.31050493325597 449.5182820661637,348.43876958792805" fill="none" stroke="hsl(105, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.55,0 -3.55,2" data-type="line" data-label="" points="59.50087057457921,348.43876958792805 59.50087057457921,218.4329657573999" fill="none" stroke="hsl(105, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.55,0 2.45,0" data-type="line" data-label="" points="59.50087057457921,348.43876958792805 449.5182820661637,348.43876958792805" fill="none" stroke="hsl(105, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.55,2 2.45,0" data-type="line" data-label="" points="59.50087057457921,218.4329657573999 449.5182820661637,348.43876958792805" fill="none" stroke="hsl(105, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.55,2 -3.75,2 -3.75,1.125 -1.1500000000000004,1.125" data-type="line" data-label="" points="59.50087057457921,218.4329657573999 46.500290191526375,218.4329657573999 46.500290191526375,275.31050493325597 215.50783517121295,275.31050493325597" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-3.55,0 -3.75,0 -3.75,2 -3.55,2" data-type="line" data-label="" points="59.50087057457921,348.43876958792805 46.500290191526375,348.43876958792805 46.500290191526375,218.4329657573999 59.50087057457921,218.4329657573999" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-2.45,0 -2.25,0 -1.8,0 -1.8,0.375 -1.3499999999999999,0.375 -1.15,0.375" data-type="line" data-label="" points="131.00406268136967,348.43876958792805 144.0046430644225,348.43876958792805 173.25594892629132,348.43876958792805 173.25594892629132,324.062681369704 202.5072547881602,324.062681369704 215.507835171213,324.062681369704" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-3.55,-1.9999999999999998 -3.75,-1.9999999999999998 -3.75,-1.1127723250000003 -2.25,-1.1127723250000003 -2.25,0 -2.45,0" data-type="line" data-label="" points="59.50087057457921,478.4445734184562 46.500290191526375,478.4445734184562 46.500290191526375,420.77219988392346 144.0046430644225,420.77219988392346 144.0046430644225,348.43876958792805 131.00406268136967,348.43876958792805" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3.55,0 3.75,0 3.75,-1.5 3.55,-1.5" data-type="line" data-label="" points="521.0214741729542,348.43876958792805 534.022054556007,348.43876958792805 534.022054556007,445.94312246082416 521.0214741729542,445.94312246082416" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0.75 3.75,0.75 3.75,0 3.55,0" data-type="line" data-label="" points="365.01450957632034,299.68659315148 534.022054556007,299.68659315148 534.022054556007,348.43876958792805 521.0214741729542,348.43876958792805" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,-0.375 -1.3499999999999999,-0.375 -1.3499999999999999,2.275 1.35,2.275 1.35,0.75 1.15,0.75" data-type="line" data-label="" points="215.507835171213,372.8148578061521 202.5072547881602,372.8148578061521 202.5072547881602,200.55716773070228 378.0150899593732,200.55716773070228 378.0150899593732,299.68659315148 365.01450957632034,299.68659315148" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-2.45,-1.9999999999999998 -2.25,-1.9999999999999998 -1.8,-1.9999999999999998 -1.8,-0.375 -1.3499999999999999,-0.375 -1.15,-0.375" data-type="line" data-label="" points="131.00406268136967,478.4445734184562 144.0046430644225,478.4445734184562 173.25594892629132,478.4445734184562 173.25594892629132,372.8148578061521 202.5072547881602,372.8148578061521 215.507835171213,372.8148578061521" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="4.5649999999999995,3 4.765,3 4.765,0 3.55,0" data-type="line" data-label="" points="586.9994196169471,153.43006384213584 600,153.43006384213584 600,348.43876958792805 521.0214741729542,348.43876958792805" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.15,0 1.3499999999999999,0 1.8,0 1.8,-1.5 2.25,-1.5 2.45,-1.5" data-type="line" data-label="" points="365.01450957632034,348.43876958792805 378.01508995937314,348.43876958792805 407.266395821242,348.43876958792805 407.266395821242,445.94312246082416 436.51770168311083,445.94312246082416 449.5182820661637,445.94312246082416" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.15,-1.125 -1.3499999999999999,-1.125 -1.3499999999999999,-2.29445535 1.35,-2.29445535 1.35,0 1.15,0" data-type="line" data-label="" points="215.507835171213,421.56703424260013 202.5072547881602,421.56703424260013 202.5072547881602,497.58502565293094 378.0150899593732,497.58502565293094 378.0150899593732,348.43876958792805 365.01450957632034,348.43876958792805" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="215.507835171213" y="226.55832849680792" width="149.50667440510733" height="243.76088218224027" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="-3" data-y="0" x="59.50087057457921" y="335.79860754497975" width="71.50319210679046" height="25.28032408589661" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_2" data-x="-3" data-y="-2" x="59.50087057457921" y="465.80441137550787" width="71.50319210679046" height="25.280324085896666" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_3" data-x="-3" data-y="2" x="59.50087057457921" y="205.79280371445157" width="71.50319210679046" height="25.280324085896666" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_4" data-x="3" data-y="-1.5" x="449.5182820661637" y="418.64190365641326" width="71.5031921067905" height="54.60243760882179" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_5" data-x="3" data-y="0" x="449.5182820661637" y="321.13755078351716" width="71.5031921067905" height="54.60243760882179" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_6" data-x="4" data-y="3" x="513.5461404526988" y="132.30412071967498" width="73.45327916424833" height="42.25188624492168" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-3.75" data-y="2.225" x="39.99999999999997" y="189.18165989553106" width="13.000580383052835" height="29.251305861868843" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="2.349" data-y="0.226" x="436.4526987811956" y="319.12246082414396" width="13.000580383052863" height="29.251305861868843" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="3.209" data-y="3" x="484.22983168891466" y="146.9297736506094" width="29.251305861868843" height="13.000580383052835" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-2.224" data-y="2" x="131.06906558328492" y="211.9326755658735" width="29.251305861868843" height="13.000580383052835" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-2.25" data-y="0.225" x="137.50435287289608" y="319.1874637260592" width="13.000580383052835" height="29.251305861868843" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-2.25" data-y="-2.2249999999999996" x="137.50435287289608" y="478.4445734184562" width="13.000580383052835" height="29.251305861868843" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.35" data-y="0.225" x="371.51479976784674" y="319.1874637260592" width="13.000580383052863" height="29.251305861868843" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.015383928571428571" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 65.00290191526408,
+        "c": 0,
+        "e": 290.26117237376667,
+        "b": 0,
+        "d": -65.00290191526408,
+        "f": 348.43876958792805
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/examples/example11.test.tsx
+++ b/tests/examples/example11.test.tsx
@@ -1,0 +1,12 @@
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import { inputProblem } from "site/examples/example11.page"
+import "tests/fixtures/matcher"
+
+test("example11", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})

--- a/tests/examples/example12.test.tsx
+++ b/tests/examples/example12.test.tsx
@@ -1,0 +1,12 @@
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import { inputProblem } from "site/examples/example12.page"
+import "tests/fixtures/matcher"
+
+test("example12", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})

--- a/tests/examples/example13.test.tsx
+++ b/tests/examples/example13.test.tsx
@@ -1,0 +1,12 @@
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import { inputProblem } from "site/examples/example13.page"
+import "tests/fixtures/matcher"
+
+test("example13", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
ref - https://github.com/tscircuit/core/issues/1262

When the netLabel has `availableNetLabelOrientations` it should be placed in that specific orientation.

**Before:**

<img width="1794" height="1090" alt="image" src="https://github.com/user-attachments/assets/42904fa8-9e69-450c-8549-ec9518091395" />

**After:**

<img width="1656" height="970" alt="image" src="https://github.com/user-attachments/assets/b677decb-1fa4-45c3-91c3-6557c73ae33f" />
