### PR TITLE
fix(solver): Increase overlap detection tolerance

### DIFF
--- a/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
+++ b/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
@@ -89,7 +89,7 @@ export class TraceOverlapShiftSolver extends BaseSolver {
     overlappingTraceSegments: Array<OverlappingTraceSegmentLocator>
   } | null {
     // Detect the next set of overlapping segments between two different net islands.
-    const EPS = 1e-6
+    const EPS = 2e-3
 
     const netIds = Object.keys(this.traceNetIslands)
     // Compare each pair of different nets


### PR DESCRIPTION
/claim #26

Traces with segments that are nearly, but not perfectly, collinear were not being detected as overlapping by the TraceOverlapShiftSolver. This would result in traces overlapping in the final output, particularly on the first or last segments of a trace originating from aligned pins.

The root cause was the EPS (tolerance) for checking collinearity was too strict (1e-6), while path generation could create segments that differed by more than this tolerance (~1.2e-3).

This change increases the EPS to 2e-3, allowing the solver to correctly identify and resolve these overlaps.

https://github.com/user-attachments/assets/54127e44-a615-4f6b-ba3f-215b3e8d674f


