### PR TITLE
feat: use collision-free base elbow paths directly

### DIFF
--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
@@ -83,7 +83,16 @@ export class SchematicTraceSingleLineSolver2 extends BaseSolver {
       { x: pin2.x, y: pin2.y },
     )
 
-    // Seed search
+    // Check if base elbow path has no collisions - if so, use it directly
+    const baseCollision = findFirstCollision(this.baseElbow, this.obstacles)
+    if (!baseCollision) {
+      // No collisions found, use the base elbow path as the solution
+      this.solvedTracePath = this.baseElbow
+      this.solved = true
+      return
+    }
+
+    // Base elbow has collisions, proceed with pathfinding
     this.queue.push({ path: this.baseElbow, collisionChipIds: new Set() })
     this.visited.add(pathKey(this.baseElbow))
   }

--- a/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/collision-free-long-traces.snap.svg
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/collision-free-long-traces.snap.svg
@@ -1,0 +1,86 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="left_pin
+x+" data-x="-4.5" data-y="0" cx="90.90909090909093" cy="288.1818181818182" r="3" fill="hsl(69, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="right_pin
+x-" data-x="4.5" data-y="2" cx="549.090909090909" cy="186.36363636363637" r="3" fill="hsl(34, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <polyline data-points="-4.5,0 -4.3,0 0,0 0,2 4.3,2 4.5,2" data-type="line" data-label="" points="90.90909090909093,288.1818181818182 101.09090909090912,288.1818181818182 320,288.1818181818182 320,186.36363636363637 538.9090909090909,186.36363636363637 549.090909090909,186.36363636363637" fill="none" stroke="red" stroke-width="1" stroke-dasharray="4 4" />
+  </g>
+  <g>
+    <polyline data-points="-4.5,0 4.5,2" data-type="line" data-label="" points="90.90909090909093,288.1818181818182 549.090909090909,186.36363636363637" fill="none" stroke="blue" stroke-width="1" stroke-dasharray="5 5" />
+  </g>
+  <g>
+    <polyline data-points="-4.5,0 -4.3,0 0,0 0,2 4.3,2 4.5,2" data-type="line" data-label="" points="90.90909090909093,288.1818181818182 101.09090909090912,288.1818181818182 320,288.1818181818182 320,186.36363636363637 538.9090909090909,186.36363636363637 549.090909090909,186.36363636363637" fill="none" stroke="green" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="chip_left" data-x="-5" data-y="0" x="40" y="262.72727272727275" width="50.909090909090935" height="50.90909090909088" fill="hsl(162, 100%, 50%, 0.1)" stroke="black" stroke-width="0.019642857142857142" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="chip_right" data-x="5" data-y="2" x="549.090909090909" y="160.90909090909093" width="50.90909090909099" height="50.90909090909088" fill="hsl(337, 100%, 50%, 0.1)" stroke="black" stroke-width="0.019642857142857142" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="obstacle" data-x="0" data-y="-3" x="281.8181818181818" y="402.72727272727275" width="76.36363636363637" height="76.36363636363637" fill="hsl(335, 100%, 50%, 0.1)" stroke="black" stroke-width="0.019642857142857142" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 50.90909090909091,
+        "c": 0,
+        "e": 320,
+        "b": 0,
+        "d": -50.90909090909091,
+        "f": 288.1818181818182
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/diagonal-collision-free.snap.svg
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/diagonal-collision-free.snap.svg
@@ -1,0 +1,89 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="bl_pin
+x+" data-x="-3.5" data-y="-3" cx="102.22222222222223" cy="506.66666666666663" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="tr_pin
+x-" data-x="3.5" data-y="3" cx="537.7777777777778" cy="133.33333333333334" r="3" fill="hsl(292, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <polyline data-points="-3.5,-3 -3.3,-3 0,-3 0,3 3.3,3 3.5,3" data-type="line" data-label="" points="102.22222222222223,506.66666666666663 114.66666666666669,506.66666666666663 320,506.66666666666663 320,133.33333333333334 525.3333333333333,133.33333333333334 537.7777777777778,133.33333333333334" fill="none" stroke="red" stroke-width="1" stroke-dasharray="4 4" />
+  </g>
+  <g>
+    <polyline data-points="-3.5,-3 3.5,3" data-type="line" data-label="" points="102.22222222222223,506.66666666666663 537.7777777777778,133.33333333333334" fill="none" stroke="blue" stroke-width="1" stroke-dasharray="5 5" />
+  </g>
+  <g>
+    <polyline data-points="-3.5,-3 -3.3,-3 0,-3 0,3 3.3,3 3.5,3" data-type="line" data-label="" points="102.22222222222223,506.66666666666663 114.66666666666669,506.66666666666663 320,506.66666666666663 320,133.33333333333334 525.3333333333333,133.33333333333334 537.7777777777778,133.33333333333334" fill="none" stroke="green" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="chip_bl" data-x="-4" data-y="-3" x="40" y="475.55555555555554" width="62.22222222222223" height="62.222222222222285" fill="hsl(301, 100%, 50%, 0.1)" stroke="black" stroke-width="0.016071428571428573" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="chip_tr" data-x="4" data-y="3" x="537.7777777777778" y="102.22222222222223" width="62.22222222222217" height="62.22222222222223" fill="hsl(145, 100%, 50%, 0.1)" stroke="black" stroke-width="0.016071428571428573" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="obstacle1" data-x="-1" data-y="2" x="242.22222222222223" y="180" width="31.111111111111086" height="31.111111111111114" fill="hsl(354, 100%, 50%, 0.1)" stroke="black" stroke-width="0.016071428571428573" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="obstacle2" data-x="1" data-y="-2" x="366.6666666666667" y="428.8888888888889" width="31.111111111111086" height="31.111111111111086" fill="hsl(355, 100%, 50%, 0.1)" stroke="black" stroke-width="0.016071428571428573" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 62.22222222222222,
+        "c": 0,
+        "e": 320,
+        "b": 0,
+        "d": -62.22222222222222,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/solvers/SchematicTraceSingleLineSolver2/collision-free-long-traces.test.ts
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/collision-free-long-traces.test.ts
@@ -1,0 +1,187 @@
+import { expect, test } from "bun:test"
+import { SchematicTraceSingleLineSolver2 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+
+test("long collision-free traces should be used directly - showcasing bounty #68", () => {
+  // This test demonstrates the bounty #68 feature: "Allow long traces that don't cross any other traces"
+  // When the direct elbow path has no collisions, it should be used immediately without pathfinding
+  
+  const inputProblem = {
+    chips: [
+      // Left chip with pin facing right
+      {
+        chipId: "chip_left",
+        center: { x: -5, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [
+          {
+            pinId: "left_pin",
+            x: -4.5, // Right edge of left chip
+            y: 0,
+          },
+        ],
+      },
+      // Right chip with pin facing left - far away to create a long trace
+      {
+        chipId: "chip_right", 
+        center: { x: 5, y: 2 },
+        width: 1,
+        height: 1,
+        pins: [
+          {
+            pinId: "right_pin",
+            x: 4.5, // Left edge of right chip
+            y: 2,
+          },
+        ],
+      },
+      // Obstacle chip that doesn't interfere with the direct path
+      {
+        chipId: "obstacle",
+        center: { x: 0, y: -3 },
+        width: 1.5,
+        height: 1.5,
+        pins: [],
+      },
+    ],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+
+  const chipMap = {
+    chip_left: inputProblem.chips[0],
+    chip_right: inputProblem.chips[1], 
+    obstacle: inputProblem.chips[2],
+  }
+
+  const pins = [
+    {
+      pinId: "left_pin",
+      x: -4.5,
+      y: 0,
+      chipId: "chip_left",
+      _facingDirection: "x+" as const, // Facing right
+    },
+    {
+      pinId: "right_pin", 
+      x: 4.5,
+      y: 2,
+      chipId: "chip_right",
+      _facingDirection: "x-" as const, // Facing left
+    },
+  ]
+
+  const solver = new SchematicTraceSingleLineSolver2({
+    inputProblem: inputProblem as any,
+    chipMap: chipMap as any,
+    pins: pins as any,
+  })
+
+  // Should be solved immediately since the long trace has no collisions
+  expect(solver.solved).toBe(true)
+  expect(solver.solvedTracePath).not.toBeNull()
+  expect(solver.solvedTracePath?.length).toBeGreaterThan(2) // Elbow path has multiple points
+  
+  // The path should be the collision-free base elbow path
+  expect(solver.solvedTracePath).toEqual(solver.baseElbow)
+  
+  // Verify the path connects the pins correctly
+  const path = solver.solvedTracePath!
+  expect(path[0]).toEqual({ x: -4.5, y: 0 })
+  expect(path[path.length - 1]).toEqual({ x: 4.5, y: 2 })
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})
+
+test("collision-free diagonal connection with obstacles nearby", () => {
+  // Another test case showing long traces work when obstacles don't interfere
+  
+  const inputProblem = {
+    chips: [
+      // Bottom-left chip
+      {
+        chipId: "chip_bl",
+        center: { x: -4, y: -3 },
+        width: 1,
+        height: 1,
+        pins: [
+          {
+            pinId: "bl_pin",
+            x: -3.5, // Right edge
+            y: -3,
+          },
+        ],
+      },
+      // Top-right chip - creating a diagonal long trace
+      {
+        chipId: "chip_tr",
+        center: { x: 4, y: 3 },
+        width: 1,
+        height: 1,
+        pins: [
+          {
+            pinId: "tr_pin",
+            x: 3.5, // Left edge
+            y: 3,
+          },
+        ],
+      },
+      // Obstacle chips that don't block the path (positioned away from the elbow)
+      {
+        chipId: "obstacle1",
+        center: { x: -1, y: 2 },
+        width: 0.5,
+        height: 0.5,
+        pins: [],
+      },
+      {
+        chipId: "obstacle2", 
+        center: { x: 1, y: -2 },
+        width: 0.5,
+        height: 0.5,
+        pins: [],
+      },
+    ],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+
+  const chipMap = {
+    chip_bl: inputProblem.chips[0],
+    chip_tr: inputProblem.chips[1],
+    obstacle1: inputProblem.chips[2],
+    obstacle2: inputProblem.chips[3],
+  }
+
+  const pins = [
+    {
+      pinId: "bl_pin",
+      x: -3.5,
+      y: -3,
+      chipId: "chip_bl",
+      _facingDirection: "x+" as const,
+    },
+    {
+      pinId: "tr_pin",
+      x: 3.5,
+      y: 3,
+      chipId: "chip_tr", 
+      _facingDirection: "x-" as const,
+    },
+  ]
+
+  const solver = new SchematicTraceSingleLineSolver2({
+    inputProblem: inputProblem as any,
+    chipMap: chipMap as any,
+    pins: pins as any,
+  })
+
+  // Should be solved immediately with collision-free elbow
+  expect(solver.solved).toBe(true)
+  expect(solver.solvedTracePath).not.toBeNull()
+  expect(solver.solvedTracePath).toEqual(solver.baseElbow)
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path, "diagonal-collision-free")
+})

--- a/tests/solvers/SchematicTraceSingleLineSolver2/collision-free-long-traces.test.ts
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/collision-free-long-traces.test.ts
@@ -4,7 +4,7 @@ import { SchematicTraceSingleLineSolver2 } from "lib/solvers/SchematicTraceLines
 test("long collision-free traces should be used directly - showcasing bounty #68", () => {
   // This test demonstrates the bounty #68 feature: "Allow long traces that don't cross any other traces"
   // When the direct elbow path has no collisions, it should be used immediately without pathfinding
-  
+
   const inputProblem = {
     chips: [
       // Left chip with pin facing right
@@ -23,7 +23,7 @@ test("long collision-free traces should be used directly - showcasing bounty #68
       },
       // Right chip with pin facing left - far away to create a long trace
       {
-        chipId: "chip_right", 
+        chipId: "chip_right",
         center: { x: 5, y: 2 },
         width: 1,
         height: 1,
@@ -51,7 +51,7 @@ test("long collision-free traces should be used directly - showcasing bounty #68
 
   const chipMap = {
     chip_left: inputProblem.chips[0],
-    chip_right: inputProblem.chips[1], 
+    chip_right: inputProblem.chips[1],
     obstacle: inputProblem.chips[2],
   }
 
@@ -64,7 +64,7 @@ test("long collision-free traces should be used directly - showcasing bounty #68
       _facingDirection: "x+" as const, // Facing right
     },
     {
-      pinId: "right_pin", 
+      pinId: "right_pin",
       x: 4.5,
       y: 2,
       chipId: "chip_right",
@@ -82,10 +82,10 @@ test("long collision-free traces should be used directly - showcasing bounty #68
   expect(solver.solved).toBe(true)
   expect(solver.solvedTracePath).not.toBeNull()
   expect(solver.solvedTracePath?.length).toBeGreaterThan(2) // Elbow path has multiple points
-  
+
   // The path should be the collision-free base elbow path
   expect(solver.solvedTracePath).toEqual(solver.baseElbow)
-  
+
   // Verify the path connects the pins correctly
   const path = solver.solvedTracePath!
   expect(path[0]).toEqual({ x: -4.5, y: 0 })
@@ -96,7 +96,7 @@ test("long collision-free traces should be used directly - showcasing bounty #68
 
 test("collision-free diagonal connection with obstacles nearby", () => {
   // Another test case showing long traces work when obstacles don't interfere
-  
+
   const inputProblem = {
     chips: [
       // Bottom-left chip
@@ -136,7 +136,7 @@ test("collision-free diagonal connection with obstacles nearby", () => {
         pins: [],
       },
       {
-        chipId: "obstacle2", 
+        chipId: "obstacle2",
         center: { x: 1, y: -2 },
         width: 0.5,
         height: 0.5,
@@ -167,7 +167,7 @@ test("collision-free diagonal connection with obstacles nearby", () => {
       pinId: "tr_pin",
       x: 3.5,
       y: 3,
-      chipId: "chip_tr", 
+      chipId: "chip_tr",
       _facingDirection: "x-" as const,
     },
   ]
@@ -183,5 +183,8 @@ test("collision-free diagonal connection with obstacles nearby", () => {
   expect(solver.solvedTracePath).not.toBeNull()
   expect(solver.solvedTracePath).toEqual(solver.baseElbow)
 
-  expect(solver).toMatchSolverSnapshot(import.meta.path, "diagonal-collision-free")
+  expect(solver).toMatchSolverSnapshot(
+    import.meta.path,
+    "diagonal-collision-free",
+  )
 })

--- a/tests/solvers/SchematicTraceSingleLineSolver2/collision-free-optimization.test.ts
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/collision-free-optimization.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { SchematicTraceSingleLineSolver2 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+
+test("collision-free base elbow should be used directly without pathfinding", () => {
+  // Simple test case where pins are far apart with no obstacles in between
+  const inputProblem = {
+    chips: [
+      {
+        chipId: "chip1",
+        center: { x: -2, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [
+          {
+            pinId: "pin1",
+            x: -1.5,
+            y: 0,
+          },
+        ],
+      },
+      {
+        chipId: "chip2", 
+        center: { x: 2, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [
+          {
+            pinId: "pin2",
+            x: 1.5,
+            y: 0,
+          },
+        ],
+      },
+    ],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+
+  const chipMap = {
+    chip1: inputProblem.chips[0],
+    chip2: inputProblem.chips[1],
+  }
+
+  const pins = [
+    {
+      pinId: "pin1",
+      x: -1.5,
+      y: 0,
+      chipId: "chip1",
+      _facingDirection: "x+" as const,
+    },
+    {
+      pinId: "pin2", 
+      x: 1.5,
+      y: 0,
+      chipId: "chip2",
+      _facingDirection: "x-" as const,
+    },
+  ]
+
+  const solver = new SchematicTraceSingleLineSolver2({
+    inputProblem: inputProblem as any,
+    chipMap: chipMap as any,
+    pins: pins as any,
+  })
+
+  // Should be solved immediately since there are no collisions
+  expect(solver.solved).toBe(true)
+  expect(solver.solvedTracePath).not.toBeNull()
+  expect(solver.solvedTracePath?.length).toBeGreaterThan(0)
+})

--- a/tests/solvers/SchematicTraceSingleLineSolver2/collision-free-optimization.test.ts
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/collision-free-optimization.test.ts
@@ -19,7 +19,7 @@ test("collision-free base elbow should be used directly without pathfinding", ()
         ],
       },
       {
-        chipId: "chip2", 
+        chipId: "chip2",
         center: { x: 2, y: 0 },
         width: 1,
         height: 1,
@@ -51,7 +51,7 @@ test("collision-free base elbow should be used directly without pathfinding", ()
       _facingDirection: "x+" as const,
     },
     {
-      pinId: "pin2", 
+      pinId: "pin2",
       x: 1.5,
       y: 0,
       chipId: "chip2",


### PR DESCRIPTION
## Allow straight-line traces when no collisions exist

**Fixes:** Allow drawing traces using the default `calculateElbow` path when there are no direct collisions, eliminating unnecessary complex routing.

### Changes
- Added early collision detection for base elbow paths in `SchematicTraceSingleLineSolver2`
- When the default elbow path has no collisions, use it directly instead of complex pathfinding
- Maintains full backward compatibility - existing pathfinding used when collisions exist
- Improves performance for collision-free cases

### Testing
- All existing tests pass (38/43 tests, 5 skipped as expected)
- Added new test verifying collision-free optimization works correctly
- Verified no regressions in complex routing scenarios
<img width="673" height="301" alt="image" src="https://github.com/user-attachments/assets/9fb94d1c-a399-42ad-b2b4-6ce6dad4a76b" />

<img width="903" height="254" alt="image" src="https://github.com/user-attachments/assets/88d1aecf-ae38-4c57-9cbc-39ca93a4ecb9" />


### Impact
This will create cleaner, more direct traces in circuits like the boost converter example, where many connections can use straight-line routing without obstruction.
/fixes #68
/claim #68