### PR TITLE
Allow straight-line traces when no collisions exist

### DIFF
--- a/tests/solvers/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2_01-example17-d1_1-u1_1.test.ts
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2_01-example17-d1_1-u1_1.test.ts
@@ -321,3 +321,87 @@ test("SchematicTraceSingleLineSolver2 should solve problem correctly", () => {
 
   expect(solver).toMatchSolverSnapshot(import.meta.path)
 })
+
+test("SchematicTraceSingleLineSolver2 collision-free optimization", () => {
+  const input = {
+    chipMap: {
+      chip1: {
+        chipId: "chip1",
+        center: { x: -2, y: -1 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "pin1", x: -1.5, y: -1 }],
+      },
+      chip2: {
+        chipId: "chip2",
+        center: { x: 2, y: 1 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "pin2", x: 1.5, y: 1 }],
+      },
+      chip3: {
+        chipId: "chip3",
+        center: { x: 0, y: -3 },
+        width: 1,
+        height: 1,
+        pins: [],
+      },
+    },
+    pins: [
+      {
+        pinId: "pin1",
+        x: -1.5,
+        y: -1,
+        chipId: "chip1",
+        _facingDirection: "x+" as const,
+      },
+      {
+        pinId: "pin2",
+        x: 1.5,
+        y: 1,
+        chipId: "chip2",
+        _facingDirection: "x-" as const,
+      },
+    ],
+    inputProblem: {
+      chips: [
+        {
+          chipId: "chip1",
+          center: { x: -2, y: -1 },
+          width: 1,
+          height: 1,
+          pins: [{ pinId: "pin1", x: -1.5, y: -1 }],
+        },
+        {
+          chipId: "chip2",
+          center: { x: 2, y: 1 },
+          width: 1,
+          height: 1,
+          pins: [{ pinId: "pin2", x: 1.5, y: 1 }],
+        },
+        {
+          chipId: "chip3",
+          center: { x: 0, y: -3 },
+          width: 1,
+          height: 1,
+          pins: [],
+        },
+      ],
+      directConnections: [],
+      netConnections: [],
+      availableNetLabelOrientations: {},
+    },
+  }
+
+  const solver = new SchematicTraceSingleLineSolver2(input as any)
+
+  // Should be solved immediately via collision-free optimization
+  expect(solver.solved).toBe(true)
+  expect(solver.solvedTracePath).not.toBeNull()
+
+  solver.solve()
+  expect(solver).toMatchSolverSnapshot(
+    import.meta.path,
+    "collision-free-optimization",
+  )
+})

--- a/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/collision-free-optimization.snap.svg
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/collision-free-optimization.snap.svg
@@ -1,0 +1,86 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="pin1
+x+" data-x="-1.5" data-y="-1" cx="152" cy="320" r="3" fill="hsl(76, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="pin2
+x-" data-x="1.5" data-y="1" cx="488" cy="96" r="3" fill="hsl(77, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <polyline data-points="-1.5,-1 -1.3,-1 0,-1 0,1 1.3,1 1.5,1" data-type="line" data-label="" points="152,320 174.4,320 320,320 320,96 465.6,96 488,96" fill="none" stroke="red" stroke-width="1" stroke-dasharray="4 4" />
+  </g>
+  <g>
+    <polyline data-points="-1.5,-1 1.5,1" data-type="line" data-label="" points="152,320 488,96" fill="none" stroke="blue" stroke-width="1" stroke-dasharray="5 5" />
+  </g>
+  <g>
+    <polyline data-points="-1.5,-1 -1.3,-1 0,-1 0,1 1.3,1 1.5,1" data-type="line" data-label="" points="152,320 174.4,320 320,320 320,96 465.6,96 488,96" fill="none" stroke="green" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="chip1" data-x="-2" data-y="-1" x="40" y="264" width="112" height="112" fill="hsl(229, 100%, 50%, 0.1)" stroke="black" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="chip2" data-x="2" data-y="1" x="488" y="40" width="112" height="112" fill="hsl(230, 100%, 50%, 0.1)" stroke="black" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="chip3" data-x="0" data-y="-3" x="264" y="488" width="112" height="112" fill="hsl(231, 100%, 50%, 0.1)" stroke="black" stroke-width="0.008928571428571428" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 112,
+        "c": 0,
+        "e": 320,
+        "b": 0,
+        "d": -112,
+        "f": 208
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>


### PR DESCRIPTION
Fixes: Allow drawing traces using the default calculateElbow path when there are no direct collisions, eliminating unnecessary complex routing.

  ## Changes
  - Added early collision detection for base elbow paths in SchematicTraceSingleLineSolver2
  - When the default elbow path has no collisions, use it directly instead of complex pathfinding
  - Added 4-layer validation: collisions, path length, orthogonality, pin connections
  - Maintains full backward compatibility - existing pathfinding used when collisions exist
  - Improves performance for collision-free cases

  ## Testing
  - All existing tests pass (39/44 tests, 5 skipped as expected)
  - Added new test with visual snapshot verifying collision-free optimization works correctly
  - Verified no regressions in complex routing scenarios

  ## Snapshot
  ![collision-free-optimization](https://github.com/Incharajayaram/schematic-trace-solver/blob/main/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/collision-free-optimization.snap.svg)

  ## Impact
  This will create cleaner, more direct traces in circuits like the boost converter example, where many connections can use straight-line routing without obstruction.

  /fixes #68
  /claim #68