### PR TITLE
feat: merge same-net trace lines that are close together (Issue #34)

### DIFF
--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -20,6 +20,7 @@ import { expandChipsToFitPins } from "./expandChipsToFitPins"
 import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import { TraceCombineSolver } from "../TraceCombineSolver/TraceCombineSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -68,7 +69,9 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   netLabelPlacementSolver?: NetLabelPlacementSolver
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
+
   traceCleanupSolver?: TraceCleanupSolver
+  traceCombineSolver?: TraceCombineSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -206,11 +209,22 @@ export class SchematicTracePipelineSolver extends BaseSolver {
         },
       ]
     }),
+    definePipelineStep("traceCombineSolver", TraceCombineSolver, (instance) => {
+      return [
+        {
+          inputTraces:
+            instance.traceCleanupSolver?.getOutput().traces ??
+            instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces,
+          inputProblem: instance.inputProblem,
+        },
+      ]
+    }),
     definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.traceCombineSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts
+++ b/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts
@@ -90,64 +90,33 @@ export class TraceCombineSolver extends BaseSolver {
     t1: SolvedTracePath,
     t2: SolvedTracePath,
   ): SolvedTracePath | null {
-    // Try all 4 combinations of connectivity:
-    // End of t1 -> Start of t2
-    // End of t1 -> End of t2 (reverse t2)
-    // Start of t1 -> Start of t2 (reverse t1)
-    // Start of t1 -> End of t2 (reverse t1, reverse t2? or just t2->t1)
+    // 1. Try connecting end-to-end (touching)
+    let mergedPath = this.tryConnectTouchingTraces(t1.tracePath, t2.tracePath)
 
-    // Helper to check connection
-    const checkConnection = (
-      pathA: { x: number; y: number }[],
-      pathB: { x: number; y: number }[],
-    ) => {
-      // Check if pathA ends where pathB starts
-      // And potentially overlap
-      const endA = pathA[pathA.length - 1]
-      const startB = pathB[0]
-
-      if (
-        Math.abs(endA.x - startB.x) < 1e-4 &&
-        Math.abs(endA.y - startB.y) < 1e-4
-      ) {
-        return { type: "touch" }
-      }
-
-      // Check for overlap
-      // Iterate backwards from end of A, and forwards from start of B
-      // to find matching sequence.
-      // Simplified: Check if last segment of A overlaps first segment of B
-      // Just basic endpoint check for now as reproduction case just meets at a point/segment.
-
-      // If they share a segment:
-      // pathA: ... -> P_pre -> P_end
-      // pathB: P_start -> P_post -> ...
-      // If P_end == P_start AND P_pre == P_post, they overlap.
-
-      if (pathA.length > 1 && pathB.length > 1) {
-        const prevA = pathA[pathA.length - 2]
-        const nextB = pathB[1]
-
-        // Compare (prevA->endA) with (startB->nextB)
-        // If they are same segment, they overlap.
-        // We know endA approx startB? No we need to check if they overlap.
-        // If endA == nextB and prevA == startB? That's full overlap of segment.
-        // But typically we look for:
-        // A: ... -> X -> Y
-        // B: X -> Y -> ...
-        // OR
-        // A: ... -> X -> Y
-        // B: Y -> Z -> ... (Touch)
-
-        // Let's rely on points being identical for overlap.
-        // Find index in B where A ends?
-      }
-      return null
+    // 2. If not touching, try merging close parallel traces
+    if (!mergedPath) {
+      mergedPath = this.tryCombineParallelTraces(t1.tracePath, t2.tracePath)
     }
 
-    const p1 = t1.tracePath
-    const p2 = t2.tracePath
+    if (mergedPath) {
+      return {
+        ...t1,
+        tracePath: mergedPath,
+        mspConnectionPairIds: [
+          ...t1.mspConnectionPairIds,
+          ...t2.mspConnectionPairIds,
+        ],
+        pinIds: [...new Set([...t1.pinIds, ...t2.pinIds])],
+      }
+    }
 
+    return null
+  }
+
+  private tryConnectTouchingTraces(
+    p1: { x: number; y: number }[],
+    p2: { x: number; y: number }[],
+  ): { x: number; y: number }[] | null {
     // Define reverse paths
     const p1Rev = [...p1].reverse()
     const p2Rev = [...p2].reverse()
@@ -205,24 +174,91 @@ export class TraceCombineSolver extends BaseSolver {
       return null
     }
 
-    let mergedPath = tryMerge(p1, p2)
-    if (!mergedPath) mergedPath = tryMerge(p1, p2Rev)
-    if (!mergedPath) mergedPath = tryMerge(p1Rev, p2)
-    if (!mergedPath) mergedPath = tryMerge(p1Rev, p2Rev)
+    let merged = tryMerge(p1, p2)
+    if (!merged) merged = tryMerge(p1, p2Rev)
+    if (!merged) merged = tryMerge(p1Rev, p2)
+    if (!merged) merged = tryMerge(p1Rev, p2Rev)
 
-    if (mergedPath) {
-      return {
-        ...t1,
-        tracePath: mergedPath,
-        mspConnectionPairIds: [
-          ...t1.mspConnectionPairIds,
-          ...t2.mspConnectionPairIds,
-        ],
-        pinIds: [...new Set([...t1.pinIds, ...t2.pinIds])],
+    return merged
+  }
+
+  private tryCombineParallelTraces(
+    p1: { x: number; y: number }[],
+    p2: { x: number; y: number }[],
+  ): { x: number; y: number }[] | null {
+    const CLOSE_THRESHOLD = 0.05 // Threshold for "close together"
+
+    const isStraightLine = (path: { x: number; y: number }[]) => {
+      if (path.length < 2) return null
+
+      let isHoriz = true
+      let isVert = true
+      const y0 = path[0].y
+      const x0 = path[0].x
+
+      const xs = path.map((p) => p.x)
+      const ys = path.map((p) => p.y)
+
+      for (let i = 1; i < path.length; i++) {
+        if (Math.abs(path[i].y - y0) > 1e-4) isHoriz = false
+        if (Math.abs(path[i].x - x0) > 1e-4) isVert = false
       }
+
+      if (isHoriz) {
+        return {
+          type: "h" as const,
+          val: y0,
+          min: Math.min(...xs),
+          max: Math.max(...xs),
+        }
+      }
+      if (isVert) {
+        return {
+          type: "v" as const,
+          val: x0,
+          min: Math.min(...ys),
+          max: Math.max(...ys),
+        }
+      }
+      return null
     }
 
-    return null
+    const info1 = isStraightLine(p1)
+    const info2 = isStraightLine(p2)
+
+    if (!info1 || !info2 || info1.type !== info2.type) return null
+
+    // Check distance between parallel lines
+    if (Math.abs(info1.val - info2.val) > CLOSE_THRESHOLD) return null
+
+    // Check for overlap or touch (using small epsilon for touch)
+    const overlapStart = Math.max(info1.min, info2.min)
+    const overlapEnd = Math.min(info1.max, info2.max)
+
+    // Epsilon choice: 1e-4. If overlapEnd >= overlapStart - epsilon, they at least touch.
+    // If we want STRICTLY "close parallel" to imply some overlap:
+    // If they are just touching tip-to-tip, `tryConnectTouchingTraces` should have handled it?
+    // Not necessarily if they are slightly offset in Y (parallel offset but touching in X).
+    // So let's allow "touching in projection" too.
+    if (overlapEnd < overlapStart - 1e-4) return null
+
+    // Align to average center
+    const newVal = (info1.val + info2.val) / 2
+    const newMin = Math.min(info1.min, info2.min)
+    const newMax = Math.max(info1.max, info2.max)
+
+    const newPath =
+      info1.type === "h"
+        ? [
+          { x: newMin, y: newVal },
+          { x: newMax, y: newVal },
+        ]
+        : [
+          { x: newVal, y: newMin },
+          { x: newVal, y: newMax },
+        ]
+
+    return newPath
   }
 
   override visualize(): GraphicsObject {

--- a/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts
+++ b/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts
@@ -1,0 +1,251 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem, PinId } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { GraphicsObject } from "graphics-debug"
+
+export class TraceCombineSolver extends BaseSolver {
+  inputTraces: SolvedTracePath[]
+  inputProblem: InputProblem
+  outputTraces: SolvedTracePath[] = []
+
+  constructor(params: {
+    inputTraces: SolvedTracePath[]
+    inputProblem: InputProblem
+  }) {
+    super()
+    this.inputTraces = params.inputTraces
+    this.inputProblem = params.inputProblem
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof TraceCombineSolver
+  >[0] {
+    return {
+      inputTraces: this.inputTraces,
+      inputProblem: this.inputProblem,
+    }
+  }
+
+  override _step() {
+    // Group traces by netId
+    const tracesByNet = new Map<string, SolvedTracePath[]>()
+
+    for (const trace of this.inputTraces) {
+      // Use globalConnNetId or dcConnNetId as the grouping key
+      // Generally globalConnNetId is the best identifier for "same electrical net"
+      const netId = trace.globalConnNetId || trace.dcConnNetId
+      if (!tracesByNet.has(netId)) {
+        tracesByNet.set(netId, [])
+      }
+      tracesByNet.get(netId)!.push(trace)
+    }
+
+    this.outputTraces = []
+
+    for (const [netId, traces] of tracesByNet) {
+      this.outputTraces.push(...this.combineTracesForNet(traces))
+    }
+
+    this.solved = true
+  }
+
+  private combineTracesForNet(traces: SolvedTracePath[]): SolvedTracePath[] {
+    if (traces.length < 2) return traces
+
+    let currentTraces = [...traces]
+    let changed = true
+
+    while (changed) {
+      changed = false
+      const nextTraces: SolvedTracePath[] = []
+      const processed = new Set<number>()
+
+      for (let i = 0; i < currentTraces.length; i++) {
+        if (processed.has(i)) continue
+
+        let mergedTrace = currentTraces[i]
+
+        for (let j = i + 1; j < currentTraces.length; j++) {
+          if (processed.has(j)) continue
+
+          const otherTrace = currentTraces[j]
+
+          const combined = this.tryCombineTraces(mergedTrace, otherTrace)
+
+          if (combined) {
+            mergedTrace = combined
+            processed.add(j) // Mark as merged
+            changed = true
+          }
+        }
+        nextTraces.push(mergedTrace)
+      }
+      currentTraces = nextTraces
+    }
+
+    return currentTraces
+  }
+
+  private tryCombineTraces(
+    t1: SolvedTracePath,
+    t2: SolvedTracePath,
+  ): SolvedTracePath | null {
+    // Try all 4 combinations of connectivity:
+    // End of t1 -> Start of t2
+    // End of t1 -> End of t2 (reverse t2)
+    // Start of t1 -> Start of t2 (reverse t1)
+    // Start of t1 -> End of t2 (reverse t1, reverse t2? or just t2->t1)
+
+    // Helper to check connection
+    const checkConnection = (
+      pathA: { x: number; y: number }[],
+      pathB: { x: number; y: number }[],
+    ) => {
+      // Check if pathA ends where pathB starts
+      // And potentially overlap
+      const endA = pathA[pathA.length - 1]
+      const startB = pathB[0]
+
+      if (
+        Math.abs(endA.x - startB.x) < 1e-4 &&
+        Math.abs(endA.y - startB.y) < 1e-4
+      ) {
+        return { type: "touch" }
+      }
+
+      // Check for overlap
+      // Iterate backwards from end of A, and forwards from start of B
+      // to find matching sequence.
+      // Simplified: Check if last segment of A overlaps first segment of B
+      // Just basic endpoint check for now as reproduction case just meets at a point/segment.
+
+      // If they share a segment:
+      // pathA: ... -> P_pre -> P_end
+      // pathB: P_start -> P_post -> ...
+      // If P_end == P_start AND P_pre == P_post, they overlap.
+
+      if (pathA.length > 1 && pathB.length > 1) {
+        const prevA = pathA[pathA.length - 2]
+        const nextB = pathB[1]
+
+        // Compare (prevA->endA) with (startB->nextB)
+        // If they are same segment, they overlap.
+        // We know endA approx startB? No we need to check if they overlap.
+        // If endA == nextB and prevA == startB? That's full overlap of segment.
+        // But typically we look for:
+        // A: ... -> X -> Y
+        // B: X -> Y -> ...
+        // OR
+        // A: ... -> X -> Y
+        // B: Y -> Z -> ... (Touch)
+
+        // Let's rely on points being identical for overlap.
+        // Find index in B where A ends?
+      }
+      return null
+    }
+
+    const p1 = t1.tracePath
+    const p2 = t2.tracePath
+
+    // Define reverse paths
+    const p1Rev = [...p1].reverse()
+    const p2Rev = [...p2].reverse()
+
+    const tryMerge = (
+      pathA: { x: number; y: number }[],
+      pathB: { x: number; y: number }[],
+    ) => {
+      // Find finding common point
+      // We want to merge if they share a sequence of points at the boundary.
+      // Start from end of A, look for match in B's start.
+
+      // Optimization: Only check if A's last point exists in B?
+      // Or B's first point exists in A?
+      // In the reproduction case:
+      // A: ... -> P_overlap_start -> P_overlap_end
+      // B: P_overlap_start -> P_overlap_end -> ... (Wait, B is reverse?)
+
+      // Let's match from the End of A.
+      // Iterate A backwards from end.
+      for (let i = pathA.length - 1; i >= 0; i--) {
+        const ptA = pathA[i]
+        // Check if this point matches pathB[0]
+        if (
+          Math.abs(ptA.x - pathB[0].x) < 1e-4 &&
+          Math.abs(ptA.y - pathB[0].y) < 1e-4
+        ) {
+          // Potential match point.
+          // Verify if the sequence matches up to end of A
+          // pathA[i ... end] should match pathB[0 ... len]
+          const overlapLen = pathA.length - i
+          if (overlapLen > pathB.length) continue // Can't overlap more than B has
+
+          let match = true
+          for (let k = 0; k < overlapLen; k++) {
+            const pa = pathA[i + k]
+            const pb = pathB[k]
+            if (Math.abs(pa.x - pb.x) > 1e-4 || Math.abs(pa.y - pb.y) > 1e-4) {
+              match = false
+              break
+            }
+          }
+
+          if (match) {
+            // MERGE!
+            // Result: pathA[0...i] + pathB
+            // Ensure we don't duplicate the overlapping part?
+            // pathA[0...i] excludes the matching start point pathA[i]?
+            // So pathA.slice(0, i) + pathB.
+            const newPath = [...pathA.slice(0, i), ...pathB]
+            return newPath
+          }
+        }
+      }
+      return null
+    }
+
+    let mergedPath = tryMerge(p1, p2)
+    if (!mergedPath) mergedPath = tryMerge(p1, p2Rev)
+    if (!mergedPath) mergedPath = tryMerge(p1Rev, p2)
+    if (!mergedPath) mergedPath = tryMerge(p1Rev, p2Rev)
+
+    if (mergedPath) {
+      return {
+        ...t1,
+        tracePath: mergedPath,
+        mspConnectionPairIds: [
+          ...t1.mspConnectionPairIds,
+          ...t2.mspConnectionPairIds,
+        ],
+        pinIds: [...new Set([...t1.pinIds, ...t2.pinIds])],
+      }
+    }
+
+    return null
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics: GraphicsObject = {
+      lines: [],
+      points: [],
+      texts: [],
+    }
+
+    for (const trace of this.outputTraces) {
+      graphics.lines!.push({
+        points: trace.tracePath.map((p) => ({ x: p.x, y: p.y })),
+        strokeColor: "orange", // Distinct color for combined traces
+        strokeWidth: 0.05,
+      })
+    }
+
+    return graphics
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+}

--- a/site/examples/example28-issue34-parallel-traces.page.tsx
+++ b/site/examples/example28-issue34-parallel-traces.page.tsx
@@ -1,0 +1,43 @@
+
+import type { InputProblem } from "lib/types/InputProblem"
+import { PipelineDebugger } from "site/components/PipelineDebugger"
+
+export const inputProblem: InputProblem = {
+    chips: [
+        {
+            chipId: "U1",
+            center: { x: 0, y: 0 },
+            width: 0.5,
+            height: 0.5,
+            pins: [
+                { pinId: "U1.1", x: -1, y: 0.01 },
+                { pinId: "U1.2", x: 1, y: 0.01 },
+            ],
+        },
+        {
+            chipId: "U2",
+            center: { x: 0, y: 1 },
+            width: 0.5,
+            height: 0.5,
+            pins: [
+                { pinId: "U2.1", x: -1, y: -0.01 },
+                { pinId: "U2.2", x: 1, y: -0.01 },
+            ],
+        },
+    ],
+    directConnections: [
+        {
+            pinIds: ["U1.1", "U1.2"],
+            netId: "NET1",
+        },
+        {
+            pinIds: ["U2.1", "U2.2"],
+            netId: "NET1",
+        },
+    ],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+    maxMspPairDistance: 5,
+}
+
+export default () => <PipelineDebugger inputProblem={inputProblem} />

--- a/tests/__snapshots__/issue34_snapshot.snap.svg
+++ b/tests/__snapshots__/issue34_snapshot.snap.svg
@@ -1,0 +1,109 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="U1.1
+x-" data-x="-1" data-y="0.01" cx="157.38148984198648" cy="459.0519187358917" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U1.2
+x+" data-x="1" data-y="0.01" cx="518.5553047404064" cy="459.0519187358917" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U2.1
+x-" data-x="-1" data-y="-0.01" cx="157.38148984198648" cy="462.6636568848759" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U2.2
+x+" data-x="1" data-y="-0.01" cx="518.5553047404064" cy="462.6636568848759" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-1.2" data-y="-0.01" cx="121.26410835214449" cy="462.6636568848759" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1" data-y="0.01" cx="518.5553047404064" cy="459.0519187358917" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1" data-y="-0.01" cx="518.5553047404064" cy="462.6636568848759" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <polyline data-points="-1,0.01 1,0.01" data-type="line" data-label="" points="157.38148984198648,459.0519187358917 518.5553047404064,459.0519187358917" fill="none" stroke="hsl(100, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1,-0.01 1,-0.01" data-type="line" data-label="" points="157.38148984198648,462.6636568848759 518.5553047404064,462.6636568848759" fill="none" stroke="hsl(100, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1,-0.01 -1.2,-0.01 -1.2,0.01 -1,0.01 -1.2,0.01 -1.2,-0.45 1.2000000000000002,-0.45 1.2000000000000002,0.01 1,0.01 1.2,0.01 1.2,-0.01 1,-0.01" data-type="line" data-label="" points="157.38148984198648,462.6636568848759 121.26410835214449,462.6636568848759 121.26410835214449,459.0519187358917 157.38148984198648,459.0519187358917 121.26410835214449,459.0519187358917 121.26410835214449,542.1218961625283 554.6726862302484,542.1218961625283 554.6726862302484,459.0519187358917 518.5553047404064,459.0519187358917 554.6726862302484,459.0519187358917 554.6726862302484,462.6636568848759 518.5553047404064,462.6636568848759" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="U1" data-x="0" data-y="0" x="157.38148984198648" y="415.7110609480813" width="361.17381489841995" height="90.293453724605" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0055375" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="U2" data-x="0" data-y="1" x="157.38148984198648" y="97.87810383747183" width="361.17381489841995" height="364.78555304740405" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0055375" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-1.425" data-y="-0.01" x="40" y="444.6049661399549" width="81.26410835214449" height="36.11738148984199" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0055375" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.226" data-y="0.01" x="518.7358916478556" y="440.9932279909707" width="81.26410835214438" height="36.11738148984199" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0055375" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.226" data-y="-0.01" x="518.7358916478556" y="444.6049661399549" width="81.26410835214438" height="36.11738148984199" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0055375" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 180.58690744920995,
+        "c": 0,
+        "e": 337.9683972911964,
+        "b": 0,
+        "d": -180.58690744920995,
+        "f": 460.8577878103838
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/issue34_snapshot.test.ts
+++ b/tests/issue34_snapshot.test.ts
@@ -1,0 +1,16 @@
+
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/index"
+import { inputProblem } from "site/examples/example28-issue34-parallel-traces.page.tsx"
+
+test("snapshot for issue #34 parallel trace merge", async () => {
+    const solver = new SchematicTracePipelineSolver(inputProblem)
+    solver.solve()
+
+    // Ensure it's solved and we have the expected combined trace
+    const combinedTraces = solver.traceCombineSolver?.getOutput().traces ?? []
+    expect(combinedTraces.length).toBe(1)
+
+    // @ts-ignore
+    await expect(solver).toMatchSolverSnapshot(import.meta.path)
+})

--- a/tests/reproduction_issue_29.test.ts
+++ b/tests/reproduction_issue_29.test.ts
@@ -1,0 +1,62 @@
+import type { InputProblem } from "lib/types/InputProblem"
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/index"
+
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "U1",
+      center: { x: 0, y: 0 },
+      width: 0.5,
+      height: 0.5,
+      pins: [
+        {
+          pinId: "U1.1",
+          x: -1,
+          y: 0,
+        },
+        {
+          pinId: "U1.2",
+          x: 0,
+          y: 0,
+        },
+        {
+          pinId: "U1.3",
+          x: 1,
+          y: 0,
+        },
+      ],
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    {
+      pinIds: ["U1.1", "U1.2", "U1.3"],
+      netId: "NET1",
+    },
+  ],
+  availableNetLabelOrientations: {},
+  maxMspPairDistance: 2,
+}
+
+test("SchematicTracePipelineSolver should combine collinear trace segments", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  solver.solve()
+
+  // Currently (Pre-fix) expected to have 2 traces: (-1,0)->(0,0) and (0,0)->(1,0)
+  // After fix, should have 1 trace: (-1,0)->(1,0)
+
+  // Check output of TraceCombineSolver
+  const combinedTraces = solver.traceCombineSolver?.getOutput().traces ?? []
+
+  if (combinedTraces.length > 0) {
+    // Expect 1 consolidated trace for this problem.
+    expect(combinedTraces.length).toBe(1)
+  } else {
+    expect(true).toBe(false)
+  }
+
+  // Verify that initially we had multiple segments (confirming the issue existed before this phase)
+  const initialTraces = solver.schematicTraceLinesSolver!.solvedTracePaths
+  expect(initialTraces.length).toBeGreaterThan(1)
+})

--- a/tests/reproduction_issue_34.test.ts
+++ b/tests/reproduction_issue_34.test.ts
@@ -1,0 +1,54 @@
+
+import { test, expect } from "bun:test"
+import { TraceCombineSolver } from "../lib/solvers/TraceCombineSolver/TraceCombineSolver"
+import type { SolvedTracePath } from "../lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "../lib/types/InputProblem"
+
+const mockInputProblem: InputProblem = {
+    chips: [],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+}
+
+test("TraceCombineSolver should merge close parallel traces", () => {
+    const trace1: SolvedTracePath = {
+        mspPairId: "1",
+        mspConnectionPairIds: ["1"],
+        globalConnNetId: "NET1",
+        pinIds: [],
+        tracePath: [
+            { x: 0, y: 0 },
+            { x: 10, y: 0 },
+        ],
+    } as any
+
+    const trace2: SolvedTracePath = {
+        mspPairId: "2",
+        mspConnectionPairIds: ["2"],
+        globalConnNetId: "NET1", // Same net
+        pinIds: [],
+        tracePath: [
+            { x: 2, y: 0.01 }, // Very close Y
+            { x: 12, y: 0.01 },
+        ],
+    } as any
+
+    const solver = new TraceCombineSolver({
+        inputTraces: [trace1, trace2],
+        inputProblem: mockInputProblem,
+    })
+
+    solver.solve()
+
+    const output = solver.getOutput()
+
+    // Should assume they are merged because they are on the same net and very close?
+    expect(output.traces.length).toBe(1)
+
+    // Verify alignment
+    const merged = output.traces[0]
+    // Y should be consistent
+    const uniqueYs = new Set(merged.tracePath.map(p => p.y))
+    expect(uniqueYs.size).toBe(1)
+})


### PR DESCRIPTION
# Fix: Merge Close Parallel Trace Lines (Issue #34)

## Description
This PR addresses Issue #34 by enhancing the [TraceCombineSolver](cci:2://file:///C:/Users/JoeGia/.gemini/antigravity/scratch/schematic-trace-solver/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts:5:0-286:1) to identify and merge trace segments that are parallel and remain in very close proximity (within a 0.05 threshold), even if they are not strictly collinear or touching end-to-end.

Previously, [TraceCombineSolver](cci:2://file:///C:/Users/JoeGia/.gemini/antigravity/scratch/schematic-trace-solver/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts:5:0-286:1) only handled collinear segments that were touching or overlapping. This improvement handles cases where traces might be slightly offset (e.g. due to floating point differences or grid alignment), consolidating them into a single clean trace aligned to their average center.

## Changes
- **Core Logic:** Added [tryCombineParallelTraces](cci:1://file:///C:/Users/JoeGia/.gemini/antigravity/scratch/schematic-trace-solver/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts:184:2-261:3) method to [TraceCombineSolver](cci:2://file:///C:/Users/JoeGia/.gemini/antigravity/scratch/schematic-trace-solver/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts:5:0-286:1).
  - Detects parallel traces (Horizontal/Vertical).
  - Checks for proximity (threshold: 0.05).
  - Merges them into a single trace aligned to the average coordinate of the two.
- **Integration:** Updated [combineTracesForNet](cci:1://file:///C:/Users/JoeGia/.gemini/antigravity/scratch/schematic-trace-solver/lib/solvers/TraceCombineSolver/TraceCombineSolver.ts:51:2-86:3) logic to attempt parallel merging if end-to-end connection fails.
- **Tests:** Added `tests/reproduction_issue_34.test.ts` to verify that close parallel traces are correctly merged into one.

## Verification
- **New Test:** Verified that `tests/reproduction_issue_34.test.ts` passes (merges 2 close parallel traces into 1).
- **Regressions:** Verified that existing tests (including Issue #29 tests) still pass with no regressions.

## Related Issue
Closes #34
/claim #34