### PR TITLE
fix: remove extra trace lines from post-processing step

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,13 +4,36 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+const EPS = 1e-9
+
+const isDuplicate = (a: Point, b: Point): boolean =>
+  Math.abs(a.x - b.x) < EPS && Math.abs(a.y - b.y) < EPS
+
+/**
+ * Remove duplicate consecutive points from a path.
+ * These can appear after path concatenation in _applyBestRoute.
+ */
+const removeDuplicateConsecutivePoints = (path: Point[]): Point[] => {
+  if (path.length < 2) return path
+  const result: Point[] = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    if (!isDuplicate(result[result.length - 1], path[i])) {
+      result.push(path[i])
+    }
+  }
+  return result
+}
+
 export const simplifyPath = (path: Point[]): Point[] => {
-  if (path.length < 3) return path
-  const newPath: Point[] = [path[0]]
-  for (let i = 1; i < path.length - 1; i++) {
+  // First remove any duplicate consecutive points
+  const deduped = removeDuplicateConsecutivePoints(path)
+
+  if (deduped.length < 3) return deduped
+  const newPath: Point[] = [deduped[0]]
+  for (let i = 1; i < deduped.length - 1; i++) {
     const p1 = newPath[newPath.length - 1]
-    const p2 = path[i]
-    const p3 = path[i + 1]
+    const p2 = deduped[i]
+    const p3 = deduped[i + 1]
     if (
       (isVertical(p1, p2) && isVertical(p2, p3)) ||
       (isHorizontal(p1, p2) && isHorizontal(p2, p3))
@@ -19,7 +42,7 @@ export const simplifyPath = (path: Point[]): Point[] => {
     }
     newPath.push(p2)
   }
-  newPath.push(path[path.length - 1])
+  newPath.push(deduped[deduped.length - 1])
 
   if (newPath.length < 3) return newPath
   const finalPath: Point[] = [newPath[0]]

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -23,6 +23,27 @@ import { visualizeTightRectangle } from "../visualizeTightRectangle"
 import { visualizeCandidates } from "./visualizeCandidates"
 import { mergeGraphicsObjects } from "../mergeGraphicsObjects"
 import { visualizeCollision } from "./visualizeCollision"
+const EPS = 1e-9
+
+/**
+ * Remove duplicate consecutive points from a path.
+ * Path concatenation in _applyBestRoute can produce duplicate points
+ * at the junctions, which render as zero-length extra trace segments.
+ */
+const removeDuplicateConsecutivePoints = (
+  path: Array<{ x: number; y: number }>,
+) => {
+  if (path.length < 2) return path
+  const result = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    const prev = result[result.length - 1]
+    const curr = path[i]
+    if (Math.abs(prev.x - curr.x) >= EPS || Math.abs(prev.y - curr.y) >= EPS) {
+      result.push(curr)
+    }
+  }
+  return result
+}
 
 /**
  * Defines the input structure for the UntangleTraceSubsolver.
@@ -258,11 +279,11 @@ export class UntangleTraceSubsolver extends BaseSolver {
           p.x === this.currentLShape!.p2.x && p.y === this.currentLShape!.p2.y,
       )
       if (p2Index !== -1) {
-        const newTracePath = [
+        const newTracePath = removeDuplicateConsecutivePoints([
           ...originalTrace.tracePath.slice(0, p2Index),
           ...bestRoute,
           ...originalTrace.tracePath.slice(p2Index + 1),
-        ]
+        ])
         this.input.allTraces[traceIndex] = {
           ...originalTrace,
           tracePath: newTracePath,

--- a/tests/assets/example_issue78.json
+++ b/tests/assets/example_issue78.json
@@ -1,0 +1,98 @@
+{
+  "chips": [
+    {
+      "chipId": "schematic_component_0",
+      "center": { "x": 0, "y": 0 },
+      "width": 2.4000000000000004,
+      "height": 1,
+      "pins": [
+        { "pinId": "U1.1", "x": 1.2000000000000002, "y": -0.30000000000000004 },
+        {
+          "pinId": "U1.2",
+          "x": -1.2000000000000002,
+          "y": -0.30000000000000004
+        },
+        { "pinId": "U1.3", "x": 1.2000000000000002, "y": 0.09999999999999998 },
+        { "pinId": "U1.4", "x": -1.2000000000000002, "y": 0.30000000000000004 },
+        { "pinId": "U1.5", "x": -1.2000000000000002, "y": 0.10000000000000003 },
+        {
+          "pinId": "U1.6",
+          "x": -1.2000000000000002,
+          "y": -0.09999999999999998
+        },
+        { "pinId": "U1.7", "x": 1.2000000000000002, "y": -0.10000000000000003 },
+        { "pinId": "U1.8", "x": 1.2000000000000002, "y": 0.30000000000000004 }
+      ]
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": { "x": 2.45, "y": 1.0 },
+      "width": 1.0999999999999996,
+      "height": 0.84,
+      "pins": [
+        { "pinId": "R1.1", "x": 2.45, "y": 1.42 },
+        { "pinId": "R1.2", "x": 2.45, "y": 0.58 }
+      ]
+    },
+    {
+      "chipId": "schematic_component_2",
+      "center": { "x": 3.0, "y": -0.10000000000000009 },
+      "width": 1.1,
+      "height": 0.388910699999999,
+      "pins": [
+        { "pinId": "R2.1", "x": 3.55, "y": -0.10000000000000002 },
+        { "pinId": "R2.2", "x": 2.45, "y": -0.10000000000000016 }
+      ]
+    },
+    {
+      "chipId": "schematic_component_3",
+      "center": { "x": -1.5, "y": -3.0 },
+      "width": 1.06,
+      "height": 1.1,
+      "pins": [
+        { "pinId": "C1.1", "x": -1.5, "y": -2.45 },
+        { "pinId": "C1.2", "x": -1.5, "y": -3.55 }
+      ]
+    },
+    {
+      "chipId": "schematic_component_4",
+      "center": { "x": -2.75, "y": 0 },
+      "width": 1.06,
+      "height": 1.1,
+      "pins": [
+        { "pinId": "C2.1", "x": -2.75, "y": 0.55 },
+        { "pinId": "C2.2", "x": -2.75, "y": -0.55 }
+      ]
+    },
+    {
+      "chipId": "schematic_component_5",
+      "center": { "x": 1.5, "y": -3.2 },
+      "width": 1.2,
+      "height": 0.8,
+      "pins": [
+        { "pinId": "J1.1", "x": 0.9, "y": -2.9 },
+        { "pinId": "J1.2", "x": 0.9, "y": -3.2 },
+        { "pinId": "J1.3", "x": 0.9, "y": -3.5 }
+      ]
+    }
+  ],
+  "directConnections": [
+    { "pinIds": ["U1.5", "C2.1"], "netId": "U1.CTRL to C2.pin1" },
+    { "pinIds": ["U1.6", "U1.2"], "netId": "U1.THRES to U1.TRIG" },
+    { "pinIds": ["R1.2", "U1.7"], "netId": "R1.pin2 to U1.DISCH" },
+    { "pinIds": ["U1.7", "R2.2"], "netId": "U1.DISCH to R2.pin2" },
+    { "pinIds": ["R2.1", "U1.6"], "netId": "R2.pin1 to U1.THRES" },
+    { "pinIds": ["U1.6", "C1.1"], "netId": "U1.THRES to C1.pin1" },
+    { "pinIds": ["U1.3", "J1.2"], "netId": "U1.OUT to J1.OUT" },
+    { "pinIds": ["R1.2", "U1.8"], "netId": "R1.pin2 to U1.VCC" }
+  ],
+  "netConnections": [
+    { "netId": "GND", "pinIds": ["U1.1", "C1.2", "C2.2", "J1.3"] },
+    { "netId": "VCC", "pinIds": ["U1.4", "U1.8", "R1.1", "J1.1"] }
+  ],
+  "availableNetLabelOrientations": {
+    "VCC": ["y+"],
+    "GND": ["y-"]
+  },
+  "maxMspPairDistance": 6
+}

--- a/tests/examples/__snapshots__/example_issue78.snap.svg
+++ b/tests/examples/__snapshots__/example_issue78.snap.svg
@@ -1,0 +1,286 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="U1.1
+x+" data-x="1.2000000000000002" data-y="-0.30000000000000004" cx="391.8653576437588" cy="250.0981767180926" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U1.2
+x-" data-x="-1.2000000000000002" data-y="-0.30000000000000004" cx="203.36605890603084" cy="250.0981767180926" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U1.3
+x+" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="391.8653576437588" cy="218.68162692847127" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U1.4
+x-" data-x="-1.2000000000000002" data-y="0.30000000000000004" cx="203.36605890603084" cy="202.9733520336606" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U1.5
+x-" data-x="-1.2000000000000002" data-y="0.10000000000000003" cx="203.36605890603084" cy="218.68162692847127" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U1.6
+x-" data-x="-1.2000000000000002" data-y="-0.09999999999999998" cx="203.36605890603084" cy="234.38990182328192" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U1.7
+x+" data-x="1.2000000000000002" data-y="-0.10000000000000003" cx="391.8653576437588" cy="234.38990182328192" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="U1.8
+x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="391.8653576437588" cy="202.9733520336606" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.1
+y+" data-x="2.45" data-y="1.42" cx="490.0420757363254" cy="115.00701262272094" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.2
+y-" data-x="2.45" data-y="0.58" cx="490.0420757363254" cy="180.9817671809257" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R2.1
+x+" data-x="3.55" data-y="-0.10000000000000002" cx="576.437587657784" cy="234.38990182328192" r="3" fill="hsl(107, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R2.2
+x-" data-x="2.45" data-y="-0.10000000000000016" cx="490.0420757363254" cy="234.38990182328195" r="3" fill="hsl(108, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C1.1
+y+" data-x="-1.5" data-y="-2.45" cx="179.80364656381488" cy="418.9621318373072" r="3" fill="hsl(121, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C1.2
+y-" data-x="-1.5" data-y="-3.55" cx="179.80364656381488" cy="505.3576437587658" r="3" fill="hsl(122, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C2.1
+y+" data-x="-2.75" data-y="0.55" cx="81.62692847124828" cy="183.33800841514727" r="3" fill="hsl(2, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C2.2
+y-" data-x="-2.75" data-y="-0.55" cx="81.62692847124828" cy="269.7335203366059" r="3" fill="hsl(3, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="J1.1
+x-" data-x="0.9" data-y="-2.9" cx="368.30294530154276" cy="454.3057503506311" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="J1.2
+x-" data-x="0.9" data-y="-3.2" cx="368.30294530154276" cy="477.86816269284714" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="J1.3
+x-" data-x="0.9" data-y="-3.5" cx="368.30294530154276" cy="501.43057503506304" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-0.2999999999999998" data-y="-3.75" cx="274.05329593267885" cy="521.0659186535764" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="3.75" data-y="-0.09999999999999998" cx="592.1458625525946" cy="234.38990182328192" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1.5000000000000004" data-y="0.09999999999999998" cx="415.4277699859748" cy="218.68162692847127" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-1.4000000000000001" data-y="0.30000000000000004" cx="187.6577840112202" cy="202.9733520336606" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-1.5875000000000001" data-y="0.09999999999999987" cx="172.93127629733522" cy="218.68162692847127" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,0.10000000000000003 -2.75,0.55" data-type="line" data-label="" points="203.36605890603084,218.68162692847127 81.62692847124828,183.33800841514727" fill="none" stroke="hsl(296, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,-0.09999999999999998 -1.2000000000000002,-0.30000000000000004" data-type="line" data-label="" points="203.36605890603084,234.38990182328192 203.36605890603084,250.0981767180926" fill="none" stroke="hsl(168, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="2.45,0.58 1.2000000000000002,-0.10000000000000003" data-type="line" data-label="" points="490.0420757363254,180.9817671809257 391.8653576437588,234.38990182328192" fill="none" stroke="hsl(248, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,-0.10000000000000003 2.45,-0.10000000000000016" data-type="line" data-label="" points="391.8653576437588,234.38990182328192 490.0420757363254,234.38990182328195" fill="none" stroke="hsl(160, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3.55,-0.10000000000000002 -1.2000000000000002,-0.09999999999999998" data-type="line" data-label="" points="576.437587657784,234.38990182328192 203.36605890603084,234.38990182328192" fill="none" stroke="hsl(24, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,-0.09999999999999998 -1.5,-2.45" data-type="line" data-label="" points="203.36605890603084,234.38990182328192 179.80364656381488,418.9621318373072" fill="none" stroke="hsl(168, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,0.09999999999999998 0.9,-3.2" data-type="line" data-label="" points="391.8653576437588,218.68162692847127 368.30294530154276,477.86816269284714" fill="none" stroke="hsl(56, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="2.45,0.58 1.2000000000000002,0.30000000000000004" data-type="line" data-label="" points="490.0420757363254,180.9817671809257 391.8653576437588,202.9733520336606" fill="none" stroke="hsl(312, 100%, 50%, 0.8)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 -1.5,-3.55" data-type="line" data-label="" points="391.8653576437588,250.0981767180926 179.80364656381488,505.3576437587658" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 -2.75,-0.55" data-type="line" data-label="" points="391.8653576437588,250.0981767180926 81.62692847124828,269.7335203366059" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 0.9,-3.5" data-type="line" data-label="" points="391.8653576437588,250.0981767180926 368.30294530154276,501.43057503506304" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.5,-3.55 -2.75,-0.55" data-type="line" data-label="" points="179.80364656381488,505.3576437587658 81.62692847124828,269.7335203366059" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.5,-3.55 0.9,-3.5" data-type="line" data-label="" points="179.80364656381488,505.3576437587658 368.30294530154276,501.43057503506304" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-2.75,-0.55 0.9,-3.5" data-type="line" data-label="" points="81.62692847124828,269.7335203366059 368.30294530154276,501.43057503506304" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,0.30000000000000004 1.2000000000000002,0.30000000000000004" data-type="line" data-label="" points="203.36605890603084,202.9733520336606 391.8653576437588,202.9733520336606" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,0.30000000000000004 2.45,1.42" data-type="line" data-label="" points="203.36605890603084,202.9733520336606 490.0420757363254,115.00701262272094" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,0.30000000000000004 0.9,-2.9" data-type="line" data-label="" points="203.36605890603084,202.9733520336606 368.30294530154276,454.3057503506311" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,0.30000000000000004 2.45,1.42" data-type="line" data-label="" points="391.8653576437588,202.9733520336606 490.0420757363254,115.00701262272094" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,0.30000000000000004 0.9,-2.9" data-type="line" data-label="" points="391.8653576437588,202.9733520336606 368.30294530154276,454.3057503506311" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="2.45,1.42 0.9,-2.9" data-type="line" data-label="" points="490.0420757363254,115.00701262272094 368.30294530154276,454.3057503506311" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,0.09999999999999987 -1.975,0.09999999999999987 -1.975,0.7500000000000002 -2.75,0.7500000000000002 -2.75,0.55" data-type="line" data-label="" points="203.36605890603084,218.68162692847127 142.49649368863956,218.68162692847127 142.49649368863956,167.62973352033663 81.62692847124828,167.62973352033663 81.62692847124828,183.33800841514727" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,-0.2999999999999998 -1.5,-0.2999999999999998 -1.5,-2.45" data-type="line" data-label="" points="203.36605890603084,250.09817671809256 179.80364656381488,250.09817671809256 179.80364656381488,418.9621318373072" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,-0.09999999999999998 -1.4000000000000001,-0.09999999999999998 -1.4000000000000001,-0.30000000000000004 -1.2000000000000002,-0.30000000000000004" data-type="line" data-label="" points="203.36605890603084,234.38990182328192 187.6577840112202,234.38990182328192 187.6577840112202,250.0981767180926 203.36605890603084,250.0981767180926" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3.55,-0.10000000000000002 3.75,-0.09999999999999998 3.75,-0.7 -1.4000000000000001,-0.7 -1.4000000000000001,-0.09999999999999998 -1.2000000000000002,-0.09999999999999998" data-type="line" data-label="" points="576.437587657784,234.38990182328192 592.1458625525946,234.38990182328192 592.1458625525946,281.5147265077139 187.6577840112202,281.5147265077139 187.6577840112202,234.38990182328192 203.36605890603084,234.38990182328192" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,-0.10000000000000003 1.3000000000000003,-0.10000000000000003 1.3000000000000003,-1.5 0.6,-1.5 0.6,-2.9 0.9,-2.9" data-type="line" data-label="" points="391.8653576437588,234.38990182328192 399.7194950911641,234.38990182328192 399.7194950911641,344.3478260869565 344.7405329593268,344.3478260869565 344.7405329593268,454.3057503506311 368.30294530154276,454.3057503506311" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,0.30000000000000004 1.3,0.30000000000000004 1.3,-0.10000000000000003 1.2000000000000002,-0.10000000000000003" data-type="line" data-label="" points="391.8653576437588,202.9733520336606 399.7194950911641,202.9733520336606 399.7194950911641,234.38990182328192 391.8653576437588,234.38990182328192" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="2.45,-0.10000000000000016 1.2000000000000002,-0.10000000000000003" data-type="line" data-label="" points="490.0420757363254,234.38990182328195 391.8653576437588,234.38990182328192" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="2.45,0.58 2.45,0.2399999999999999 2.25,0.2399999999999999 2.25,-0.10000000000000016 2.45,-0.10000000000000016" data-type="line" data-label="" points="490.0420757363254,180.9817671809257 490.0420757363254,207.68583450210383 474.33380084151474,207.68583450210383 474.33380084151474,234.38990182328195 490.0420757363254,234.38990182328195" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="2.45,1.42 2.45,1.6199999999999997 1.7000000000000004,1.6199999999999997 1.7000000000000004,1.8199999999999998 2.6500000000000004,1.82 2.6500000000000004,0.3799999999999998 2.45,0.3799999999999998 2.45,0.58" data-type="line" data-label="" points="490.0420757363254,115.00701262272094 490.0420757363254,99.29873772791031 431.13604488078545,99.29873772791031 431.13604488078545,83.59046283309962 505.75035063113603,83.59046283309962 505.75035063113603,196.69004207573636 490.0420757363254,196.69004207573636 490.0420757363254,180.9817671809257" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-1.2000000000000002,0.30000000000000004 -1.4000000000000001,0.30000000000000004 -1.4000000000000001,1.6199999999999999 2.45,1.6199999999999999 2.45,1.42" data-type="line" data-label="" points="203.36605890603084,202.9733520336606 187.6577840112202,202.9733520336606 187.6577840112202,99.29873772791028 490.0420757363254,99.29873772791028 490.0420757363254,115.00701262272094" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,0.09999999999999998 1.5000000000000004,0.09999999999999998 1.5000000000000004,-1.55 1.6000000000000003,-1.55 1.6000000000000003,-3.1 0.7999999999999999,-3.1 0.7999999999999999,-3.2 0.9,-3.2" data-type="line" data-label="" points="391.8653576437588,218.68162692847127 415.4277699859748,218.68162692847127 415.4277699859748,348.2748948106592 423.28190743338007,348.2748948106592 423.28190743338007,470.01402524544176 360.44880785413744,470.01402524544176 360.44880785413744,477.86816269284714 368.30294530154276,477.86816269284714" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.8999999999999995,-3.5 -0.2999999999999998,-3.5 -0.2999999999999998,-3.75 -1.5,-3.75 -1.5,-3.55" data-type="line" data-label="" points="368.30294530154276,501.43057503506304 274.05329593267885,501.43057503506304 274.05329593267885,521.0659186535764 179.80364656381488,521.0659186535764 179.80364656381488,505.3576437587658" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.4000000000000004,-0.30000000000000004 1.4000000000000004,-1.9 0.7,-1.9 0.7,-3.5 0.9,-3.5" data-type="line" data-label="" points="391.8653576437588,250.0981767180926 407.5736325385694,250.0981767180926 407.5736325385694,375.76437587657784 352.5946704067321,375.76437587657784 352.5946704067321,501.43057503506304 368.30294530154276,501.43057503506304" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-2.75,-0.55 -2.75,-0.7500000000000002 1.4000000000000004,-0.7500000000000002 1.4000000000000004,-0.30000000000000004 1.2000000000000002,-0.30000000000000004" data-type="line" data-label="" points="81.62692847124828,269.7335203366059 81.62692847124828,285.44179523141656 407.5736325385694,285.44179523141656 407.5736325385694,250.0981767180926 391.8653576437588,250.0981767180926" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="203.36605890603084" y="187.26507713884996" width="188.49929873772794" height="78.54137447405327" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="2.45" data-y="1" x="446.8443197755961" y="115.00701262272094" width="86.39551192145859" height="65.97475455820475" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_2" data-x="3" data-y="-0.10000000000000009" x="490.0420757363254" y="219.11711136044886" width="86.39551192145859" height="30.545580925666115" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_3" data-x="-1.5" data-y="-3" x="138.17671809256663" y="418.9621318373072" width="83.2538569424965" height="86.39551192145859" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_4" data-x="-2.75" data-y="0" x="40" y="183.33800841514727" width="83.25385694249655" height="86.39551192145865" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_5" data-x="1.5" data-y="-3.2" x="368.30294530154276" y="446.45161290322585" width="94.24964936886397" height="62.83309957924257" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-0.2999999999999998" data-y="-3.975" x="266.19915848527353" y="521.0659186535764" width="15.708274894810643" height="35.34361851332392" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="3.75" data-y="0.12500000000000003" x="584.2917251051892" y="199.04628330995794" width="15.708274894810756" height="35.343618513323975" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="1.5000000000000004" data-y="0.32499999999999996" x="407.5736325385694" y="183.3380084151473" width="15.7082748948107" height="35.343618513323975" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-1.6250000000000002" data-y="0.30000000000000004" x="152.31416549789623" y="195.11921458625528" width="35.343618513323975" height="15.708274894810643" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="-1.5875000000000001" data-y="0.32499999999999984" x="165.07713884992987" y="183.3380084151473" width="15.708274894810671" height="35.343618513323975" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.012732142857142859" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 78.54137447405328,
+        "c": 0,
+        "e": 297.6157082748948,
+        "b": 0,
+        "d": -78.54137447405328,
+        "f": 226.5357643758766
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/examples/example_issue78.test.ts
+++ b/tests/examples/example_issue78.test.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import "tests/fixtures/matcher"
+import inputProblem from "../assets/example_issue78.json"
+
+/**
+ * Reproduction for issue #78: "Fix extra trace lines in post-processing step"
+ *
+ * NE555 timer circuit with a J1 connector and maxMspPairDistance=6.
+ * The UntangleTraceSubsolver reroutes L-shaped corners and the path
+ * concatenation in _applyBestRoute() can produce duplicate consecutive
+ * points or redundant collinear intermediate points, which render as
+ * extra short line segments in the schematic output.
+ *
+ * This test verifies that all trace paths are clean after solving:
+ * no duplicate consecutive points and no collinear intermediate points.
+ */
+test("example_issue78: NE555 with J1 connector should have clean trace paths", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  const traces = solver.traceCleanupSolver!.getOutput().traces
+
+  for (const trace of traces) {
+    const path = trace.tracePath
+
+    // No duplicate consecutive points (would render as zero-length segments)
+    for (let i = 0; i < path.length - 1; i++) {
+      const p1 = path[i]
+      const p2 = path[i + 1]
+      const dist = Math.sqrt((p2.x - p1.x) ** 2 + (p2.y - p1.y) ** 2)
+      expect(dist).toBeGreaterThan(1e-9)
+    }
+
+    // No redundant collinear intermediate points (would render as extra segments)
+    for (let i = 0; i < path.length - 2; i++) {
+      const p1 = path[i]
+      const p2 = path[i + 1]
+      const p3 = path[i + 2]
+      const isCollinearH =
+        Math.abs(p1.y - p2.y) < 1e-9 && Math.abs(p2.y - p3.y) < 1e-9
+      const isCollinearV =
+        Math.abs(p1.x - p2.x) < 1e-9 && Math.abs(p2.x - p3.x) < 1e-9
+      expect(isCollinearH || isCollinearV).toBe(false)
+    }
+  }
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})

--- a/tests/functions/simplifyPath.test.ts
+++ b/tests/functions/simplifyPath.test.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "bun:test"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+test("simplifyPath removes duplicate consecutive points", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 0 }, // duplicate
+    { x: 1, y: 1 },
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("simplifyPath removes collinear horizontal points", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 }, // collinear with neighbors
+    { x: 3, y: 0 },
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+  ])
+})
+
+test("simplifyPath removes collinear vertical points", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 0, y: 1 },
+    { x: 0, y: 2 }, // collinear with neighbors
+    { x: 0, y: 3 },
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 0, y: 3 },
+  ])
+})
+
+test("simplifyPath preserves L-shaped turns", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 }, // turn point - should be preserved
+    { x: 2, y: 1 },
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual(path)
+})
+
+test("simplifyPath handles path with only two points", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 1 },
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual(path)
+})
+
+test("simplifyPath handles empty and single-point paths", () => {
+  expect(simplifyPath([])).toEqual([])
+  expect(simplifyPath([{ x: 0, y: 0 }])).toEqual([{ x: 0, y: 0 }])
+})
+
+test("simplifyPath handles duplicate at start of path", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 0, y: 0 }, // duplicate at start
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("simplifyPath handles duplicate at end of path", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 1, y: 1 }, // duplicate at end
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("simplifyPath handles combined duplicates and collinear points", () => {
+  // Simulates what _applyBestRoute can produce: path concatenation with
+  // both duplicate consecutive points and collinear intermediate points
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 0 }, // duplicate from concatenation
+    { x: 1, y: 1 },
+    { x: 2, y: 1 },
+    { x: 3, y: 1 }, // collinear
+    { x: 4, y: 1 },
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 4, y: 1 },
+  ])
+})


### PR DESCRIPTION
## Summary

Fixes #78

When `UntangleTraceSubsolver._applyBestRoute()` reroutes L-shaped corners, it concatenates path segments:

```typescript
const newTracePath = [
  ...originalTrace.tracePath.slice(0, p2Index),
  ...bestRoute,
  ...originalTrace.tracePath.slice(p2Index + 1),
]
```

This can produce **duplicate consecutive points** at the junctions (where the old path meets the rerouted segment), which render as zero-length extra trace line segments in the schematic output.

### Fix

1. **`UntangleTraceSubsolver`**: Added `removeDuplicateConsecutivePoints()` after path concatenation in `_applyBestRoute()` to strip duplicate junction points
2. **`simplifyPath`**: Enhanced with duplicate consecutive point preprocessing before the existing collinear point removal

### Key difference from prior PRs (#100, #119)

Those PRs applied the full `simplifyPath` (including collinear removal) in `_applyBestRoute()`, which changed the timing of path simplification relative to downstream `minimizeTurns` and `balanceZShapes` — causing the example29 snapshot to change. This was seen as a regression.

This PR applies **only duplicate point removal** in `_applyBestRoute()`, which is the minimal fix needed. Collinear simplification still happens at the correct time downstream. **Zero existing snapshots change.**

### Tests

- **9 new unit tests** for `simplifyPath` covering duplicates, collinear points, and combined cases
- **New integration test** (`example_issue78`): NE555 timer circuit with J1 connector and `maxMspPairDistance=6`, verifying all trace paths are clean (no duplicates, no collinear intermediate points)
- **All 59 existing tests pass, 0 snapshot regressions**

/claim #78

🤖 Generated with [Claude Code](https://claude.ai/code)

*AI Disclosure: This PR was developed using Claude Code (claude-opus-4-6). All code was reviewed and tested before submission.*