### PR TITLE
docs: fix wording in minimum spanning tree explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pins, there is guaranteed to be a routed trace between them.
 
 Net connections will not be routed, net labels are placed instead.
 
-The solver first constructs minimum spanning tree to determine what pin-pairs
+The solver first constructs a minimum spanning tree to determine what pin-pairs
 to draw via the `MspConnectionPairSolver`. If there are two pins A and B that both connect to C, this phase will
 determine how to route traces to minimize overlap or crossings. e.g. we may
 decide to route a trace from A to B, then B to C OR we may decide to route a


### PR DESCRIPTION
## What I noticed\nThe README sentence describing the MST phase was missing an article ("constructs minimum spanning tree").\n\n## What I changed\nUpdated it to "constructs a minimum spanning tree".\n\n## Why this is worth fixing\nThis paragraph explains a core routing concept. Small grammar fixes here make technical docs easier to parse for first-time contributors.