### PR TITLE
fix: new phase to combine same-net trace segments that are close together

### DIFF
--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -20,6 +20,7 @@ import { expandChipsToFitPins } from "./expandChipsToFitPins"
 import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import { TraceSegmentCombinerSolver } from "../TraceSegmentCombinerSolver/TraceSegmentCombinerSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string


### PR DESCRIPTION
Fixes #29

## Changes
- `lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts`
- `lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts`

## Summary
Automated fix for: New Phase To combine same-net trace segments that are close together