### PR TITLE
fix: remove spurious extra trace lines from duplicate consecutive points (issue #78)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,13 +4,38 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+const EPS = 1e-9
+
+/**
+ * Remove consecutive duplicate points (within epsilon) from a path.
+ * Zero-length segments caused by duplicate points render as spurious extra
+ * trace lines, so this cleanup should be applied whenever a new trace path
+ * is assembled from spliced segments.
+ */
+export const removeDuplicateConsecutivePoints = (path: Point[]): Point[] => {
+  if (path.length < 2) return path
+  const result: Point[] = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    const prev = result[result.length - 1]
+    const curr = path[i]
+    if (Math.abs(prev.x - curr.x) > EPS || Math.abs(prev.y - curr.y) > EPS) {
+      result.push(curr)
+    }
+  }
+  return result
+}
+
 export const simplifyPath = (path: Point[]): Point[] => {
-  if (path.length < 3) return path
-  const newPath: Point[] = [path[0]]
-  for (let i = 1; i < path.length - 1; i++) {
+  // First remove exact duplicate consecutive points so the collinear check
+  // below does not produce degenerate zero-length segments.
+  const deduped = removeDuplicateConsecutivePoints(path)
+
+  if (deduped.length < 3) return deduped
+  const newPath: Point[] = [deduped[0]]
+  for (let i = 1; i < deduped.length - 1; i++) {
     const p1 = newPath[newPath.length - 1]
-    const p2 = path[i]
-    const p3 = path[i + 1]
+    const p2 = deduped[i]
+    const p3 = deduped[i + 1]
     if (
       (isVertical(p1, p2) && isVertical(p2, p3)) ||
       (isHorizontal(p1, p2) && isHorizontal(p2, p3))
@@ -19,7 +44,7 @@ export const simplifyPath = (path: Point[]): Point[] => {
     }
     newPath.push(p2)
   }
-  newPath.push(path[path.length - 1])
+  newPath.push(deduped[deduped.length - 1])
 
   if (newPath.length < 3) return newPath
   const finalPath: Point[] = [newPath[0]]

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -8,6 +8,7 @@ import { getTraceObstacles } from "./getTraceObstacles"
 import { findIntersectionsWithObstacles } from "./findIntersectionsWithObstacles"
 import { generateLShapeRerouteCandidates } from "./generateLShapeRerouteCandidates"
 import { isPathColliding, type CollisionInfo } from "./isPathColliding"
+import { removeDuplicateConsecutivePoints } from "../simplifyPath"
 import {
   generateRectangleCandidates,
   type Rectangle,
@@ -258,11 +259,15 @@ export class UntangleTraceSubsolver extends BaseSolver {
           p.x === this.currentLShape!.p2.x && p.y === this.currentLShape!.p2.y,
       )
       if (p2Index !== -1) {
-        const newTracePath = [
+        // Splice the rerouted segment into the original path.  When the
+        // slice boundaries coincide with points in bestRoute the concatenation
+        // produces consecutive duplicate points that render as spurious extra
+        // trace lines (issue #78).  Remove them before storing.
+        const newTracePath = removeDuplicateConsecutivePoints([
           ...originalTrace.tracePath.slice(0, p2Index),
           ...bestRoute,
           ...originalTrace.tracePath.slice(p2Index + 1),
-        ]
+        ])
         this.input.allTraces[traceIndex] = {
           ...originalTrace,
           tracePath: newTracePath,

--- a/tests/examples/__snapshots__/example21.snap.svg
+++ b/tests/examples/__snapshots__/example21.snap.svg
@@ -2,242 +2,209 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="CORNERS.1
-x-" data-x="-1.4" data-y="-0.6" cx="65.61715719826601" cy="313.6436230892083" r="3" fill="hsl(65, 100%, 50%, 0.8)" />
+x-" data-x="-1.4" data-y="-0.6" cx="65.61715719826601" cy="304.0292037417294" r="3" fill="hsl(65, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="CORNERS.2
-x-" data-x="-1.4" data-y="0.6" cx="65.61715719826601" cy="236.98380104950945" r="3" fill="hsl(66, 100%, 50%, 0.8)" />
+x-" data-x="-1.4" data-y="0.6" cx="65.61715719826601" cy="227.36938170203058" r="3" fill="hsl(66, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="CORNERS.3
-x+" data-x="1.4" data-y="0.6" cx="244.49007529089664" cy="236.98380104950945" r="3" fill="hsl(67, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="0.6" cx="244.49007529089664" cy="227.36938170203058" r="3" fill="hsl(67, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="CORNERS.4
-x+" data-x="1.4" data-y="-0.6" cx="244.49007529089664" cy="313.6436230892083" r="3" fill="hsl(68, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="-0.6" cx="244.49007529089664" cy="304.0292037417294" r="3" fill="hsl(68, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U100.1
-x-" data-x="3.785" data-y="-0.29999999999999993" cx="396.8514715947981" cy="294.4786675792836" r="3" fill="hsl(175, 100%, 50%, 0.8)" />
+x-" data-x="3.785" data-y="-0.29999999999999993" cx="396.8514715947981" cy="284.8642482318047" r="3" fill="hsl(175, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U100.2
-y-" data-x="4.785" data-y="-1.2999999999999998" cx="460.73465662788044" cy="358.36185261236596" r="3" fill="hsl(176, 100%, 50%, 0.8)" />
+y-" data-x="4.785" data-y="-1.2999999999999998" cx="460.73465662788044" cy="348.74743326488704" r="3" fill="hsl(176, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U100.3
-x-" data-x="3.785" data-y="-0.4999999999999999" cx="396.8514715947981" cy="307.25530458590003" r="3" fill="hsl(177, 100%, 50%, 0.8)" />
+x-" data-x="3.785" data-y="-0.4999999999999999" cx="396.8514715947981" cy="297.64088523842116" r="3" fill="hsl(177, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U100.5
-x+" data-x="5.785" data-y="-0.3999999999999999" cx="524.6178416609628" cy="300.86698608259184" r="3" fill="hsl(179, 100%, 50%, 0.8)" />
+x+" data-x="5.785" data-y="-0.3999999999999999" cx="524.6178416609628" cy="291.25256673511296" r="3" fill="hsl(179, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C101.1
-y+" data-x="6.7" data-y="-0.39999999999999925" cx="583.0709559662332" cy="300.8669860825918" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+y+" data-x="6.7" data-y="-0.39999999999999925" cx="583.0709559662332" cy="291.2525667351129" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C101.2
-y-" data-x="6.7" data-y="-1.4999999999999993" cx="583.0709559662332" cy="371.13848961898236" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+y-" data-x="6.7" data-y="-1.4999999999999993" cx="583.0709559662332" cy="361.5240702715035" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C100.1
-y+" data-x="2.8699999999999997" data-y="-1.2" cx="338.39835728952767" cy="351.9735341090577" r="3" fill="hsl(337, 100%, 50%, 0.8)" />
+y+" data-x="2.8699999999999997" data-y="-1.2" cx="338.39835728952767" cy="342.35911476157884" r="3" fill="hsl(337, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C100.2
-y-" data-x="2.8699999999999997" data-y="-2.3" cx="338.39835728952767" cy="422.2450376454483" r="3" fill="hsl(338, 100%, 50%, 0.8)" />
+y-" data-x="2.8699999999999997" data-y="-2.3" cx="338.39835728952767" cy="412.6306182979694" r="3" fill="hsl(338, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R100.1
-y+" data-x="2.9752723250000006" data-y="0.6000000000000003" cx="345.1234887063655" cy="236.98380104950942" r="3" fill="hsl(82, 100%, 50%, 0.8)" />
+y+" data-x="2.9752723250000006" data-y="0.6000000000000003" cx="345.1234887063655" cy="227.36938170203055" r="3" fill="hsl(82, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R100.2
-y-" data-x="2.9752723250000006" data-y="-0.4999999999999998" cx="345.1234887063655" cy="307.25530458590003" r="3" fill="hsl(83, 100%, 50%, 0.8)" />
+y-" data-x="2.9752723250000006" data-y="-0.4999999999999998" cx="345.1234887063655" cy="297.64088523842116" r="3" fill="hsl(83, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-1.551" data-y="-0.651" cx="55.97079625827058" cy="316.9016655258955" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.4" data-y="-0.6" cx="65.61715719826601" cy="304.0292037417294" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.551" data-y="-0.651" cx="254.13643623089206" cy="316.9016655258955" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.4" data-y="-0.6" cx="244.49007529089664" cy="304.0292037417294" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="2.8699999999999997" data-y="-2.5" cx="338.39835728952767" cy="435.0216746520648" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="2.8699999999999997" data-y="-2.5" cx="338.39835728952767" cy="425.4072553045859" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-1.6004999999999998" data-y="0.6" cx="52.808578599133014" cy="236.98380104950945" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.6004999999999998" data-y="0.6" cx="52.808578599133014" cy="227.36938170203058" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="2.9752723250000006" data-y="0.8000000000000005" cx="345.1234887063655" cy="224.20716404289294" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="2.9752723250000006" data-y="0.8000000000000005" cx="345.1234887063655" cy="214.59274469541407" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="6.2425" data-y="-0.19999999999999923" cx="553.844398813598" cy="288.09034907597527" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="6.2425" data-y="-0.19999999999999923" cx="553.844398813598" cy="278.4759297284964" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="1.501" data-y="1.001" cx="250.94227697923793" cy="211.36664385124342" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.4" data-y="0.6" cx="244.49007529089664" cy="227.36938170203058" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="2.9752723250000006" data-y="-0.5999999999999999" cx="345.1234887063655" cy="313.6436230892083" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="2.9752723250000006" data-y="-0.5999999999999999" cx="345.1234887063655" cy="304.0292037417294" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="6.7,-0.39999999999999925 5.785,-0.3999999999999999" data-type="line" data-label="" points="583.0709559662332,300.8669860825918 524.6178416609628,300.86698608259184" fill="none" stroke="hsl(176, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="6.7,-0.39999999999999925 5.785,-0.3999999999999999" data-type="line" data-label="" points="583.0709559662332,291.2525667351129 524.6178416609628,291.25256673511296" fill="none" stroke="hsl(176, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.8699999999999997,-1.2 3.785,-0.29999999999999993" data-type="line" data-label="" points="338.39835728952767,351.9735341090577 396.8514715947981,294.4786675792836" fill="none" stroke="hsl(8, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="2.8699999999999997,-1.2 3.785,-0.29999999999999993" data-type="line" data-label="" points="338.39835728952767,342.35911476157884 396.8514715947981,284.8642482318047" fill="none" stroke="hsl(8, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.9752723250000006,-0.4999999999999998 3.785,-0.4999999999999999" data-type="line" data-label="" points="345.1234887063655,307.25530458590003 396.8514715947981,307.25530458590003" fill="none" stroke="hsl(272, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="2.9752723250000006,-0.4999999999999998 3.785,-0.4999999999999999" data-type="line" data-label="" points="345.1234887063655,297.64088523842116 396.8514715947981,297.64088523842116" fill="none" stroke="hsl(272, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 1.4,-0.6" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 244.49007529089664,313.6436230892083" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.6 1.4,-0.6" data-type="line" data-label="" points="65.61715719826601,304.0292037417294 244.49007529089664,304.0292037417294" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 4.785,-1.2999999999999998" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 460.73465662788044,358.36185261236596" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.6 4.785,-1.2999999999999998" data-type="line" data-label="" points="65.61715719826601,304.0292037417294 460.73465662788044,348.74743326488704" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 6.7,-1.4999999999999993" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 583.0709559662332,371.13848961898236" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.6 6.7,-1.4999999999999993" data-type="line" data-label="" points="65.61715719826601,304.0292037417294 583.0709559662332,361.5240702715035" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 2.8699999999999997,-2.3" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 338.39835728952767,422.2450376454483" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.6 2.8699999999999997,-2.3" data-type="line" data-label="" points="65.61715719826601,304.0292037417294 338.39835728952767,412.6306182979694" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.6 4.785,-1.2999999999999998" data-type="line" data-label="" points="244.49007529089664,313.6436230892083 460.73465662788044,358.36185261236596" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.6 4.785,-1.2999999999999998" data-type="line" data-label="" points="244.49007529089664,304.0292037417294 460.73465662788044,348.74743326488704" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.6 6.7,-1.4999999999999993" data-type="line" data-label="" points="244.49007529089664,313.6436230892083 583.0709559662332,371.13848961898236" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.6 6.7,-1.4999999999999993" data-type="line" data-label="" points="244.49007529089664,304.0292037417294 583.0709559662332,361.5240702715035" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.6 2.8699999999999997,-2.3" data-type="line" data-label="" points="244.49007529089664,313.6436230892083 338.39835728952767,422.2450376454483" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.6 2.8699999999999997,-2.3" data-type="line" data-label="" points="244.49007529089664,304.0292037417294 338.39835728952767,412.6306182979694" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="4.785,-1.2999999999999998 6.7,-1.4999999999999993" data-type="line" data-label="" points="460.73465662788044,358.36185261236596 583.0709559662332,371.13848961898236" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4.785,-1.2999999999999998 6.7,-1.4999999999999993" data-type="line" data-label="" points="460.73465662788044,348.74743326488704 583.0709559662332,361.5240702715035" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="4.785,-1.2999999999999998 2.8699999999999997,-2.3" data-type="line" data-label="" points="460.73465662788044,358.36185261236596 338.39835728952767,422.2450376454483" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4.785,-1.2999999999999998 2.8699999999999997,-2.3" data-type="line" data-label="" points="460.73465662788044,348.74743326488704 338.39835728952767,412.6306182979694" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="6.7,-1.4999999999999993 2.8699999999999997,-2.3" data-type="line" data-label="" points="583.0709559662332,371.13848961898236 338.39835728952767,422.2450376454483" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="6.7,-1.4999999999999993 2.8699999999999997,-2.3" data-type="line" data-label="" points="583.0709559662332,361.5240702715035 338.39835728952767,412.6306182979694" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.6 3.785,-0.29999999999999993" data-type="line" data-label="" points="65.61715719826601,236.98380104950945 396.8514715947981,294.4786675792836" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.6 3.785,-0.29999999999999993" data-type="line" data-label="" points="65.61715719826601,227.36938170203058 396.8514715947981,284.8642482318047" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.6 2.8699999999999997,-1.2" data-type="line" data-label="" points="65.61715719826601,236.98380104950945 338.39835728952767,351.9735341090577" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.6 2.8699999999999997,-1.2" data-type="line" data-label="" points="65.61715719826601,227.36938170203058 338.39835728952767,342.35911476157884" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.6 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="65.61715719826601,236.98380104950945 345.1234887063655,236.98380104950942" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.6 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="65.61715719826601,227.36938170203058 345.1234887063655,227.36938170203055" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="3.785,-0.29999999999999993 2.8699999999999997,-1.2" data-type="line" data-label="" points="396.8514715947981,294.4786675792836 338.39835728952767,351.9735341090577" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="3.785,-0.29999999999999993 2.8699999999999997,-1.2" data-type="line" data-label="" points="396.8514715947981,284.8642482318047 338.39835728952767,342.35911476157884" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="3.785,-0.29999999999999993 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="396.8514715947981,294.4786675792836 345.1234887063655,236.98380104950942" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="3.785,-0.29999999999999993 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="396.8514715947981,284.8642482318047 345.1234887063655,227.36938170203055" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="2.8699999999999997,-1.2 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="338.39835728952767,351.9735341090577 345.1234887063655,236.98380104950942" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="2.8699999999999997,-1.2 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="338.39835728952767,342.35911476157884 345.1234887063655,227.36938170203055" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,0.6 5.785,-0.3999999999999999" data-type="line" data-label="" points="244.49007529089664,236.98380104950945 524.6178416609628,300.86698608259184" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,0.6 5.785,-0.3999999999999999" data-type="line" data-label="" points="244.49007529089664,227.36938170203058 524.6178416609628,291.25256673511296" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,0.6 6.7,-0.39999999999999925" data-type="line" data-label="" points="244.49007529089664,236.98380104950945 583.0709559662332,300.8669860825918" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,0.6 6.7,-0.39999999999999925" data-type="line" data-label="" points="244.49007529089664,227.36938170203058 583.0709559662332,291.2525667351129" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="5.785,-0.3999999999999999 6.7,-0.39999999999999925" data-type="line" data-label="" points="524.6178416609628,300.86698608259184 583.0709559662332,300.8669860825918" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="5.785,-0.3999999999999999 6.7,-0.39999999999999925" data-type="line" data-label="" points="524.6178416609628,291.25256673511296 583.0709559662332,291.2525667351129" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="3.785,-0.4999999999999999 2.9752723250000006,-0.4999999999999998" data-type="line" data-label="" points="396.8514715947981,307.25530458590003 345.1234887063655,307.25530458590003" fill="none" stroke="hsl(345, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="3.785,-0.4999999999999999 2.9752723250000006,-0.4999999999999998" data-type="line" data-label="" points="396.8514715947981,297.64088523842116 345.1234887063655,297.64088523842116" fill="none" stroke="hsl(345, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="5.785,-0.3999999999999999 6.2425,-0.3999999999999999 6.2425,-0.19999999999999923 6.7,-0.19999999999999923 6.7,-0.39999999999999925" data-type="line" data-label="" points="524.6178416609628,300.86698608259184 553.844398813598,300.86698608259184 553.844398813598,288.09034907597527 583.0709559662332,288.09034907597527 583.0709559662332,300.8669860825918" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="5.785,-0.3999999999999999 6.2425,-0.3999999999999999 6.2425,-0.19999999999999923 6.7,-0.19999999999999923 6.7,-0.39999999999999925" data-type="line" data-label="" points="524.6178416609628,291.25256673511296 553.844398813598,291.25256673511296 553.844398813598,278.4759297284964 583.0709559662332,278.4759297284964 583.0709559662332,291.2525667351129" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.9752723250000006,0.6000000000000003 2.9752723250000006,0.8000000000000005 3.3801361625000004,0.8000000000000005 3.3801361625000004,-0.30000000000000004 3.785,-0.30000000000000004" data-type="line" data-label="" points="345.1234887063655,236.98380104950942 345.1234887063655,224.20716404289294 370.9874801505818,224.20716404289294 370.9874801505818,294.4786675792836 396.8514715947981,294.4786675792836" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="2.9752723250000006,0.6000000000000003 2.9752723250000006,0.8000000000000005 3.3801361625000004,0.8000000000000005 3.3801361625000004,-0.30000000000000004 3.785,-0.30000000000000004" data-type="line" data-label="" points="345.1234887063655,227.36938170203055 345.1234887063655,214.59274469541407 370.9874801505818,214.59274469541407 370.9874801505818,284.8642482318047 396.8514715947981,284.8642482318047" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.9752723250000006,-0.4999999999999998 2.9752723250000006,-0.7 3.585,-0.7 3.585,-0.4999999999999998 3.785,-0.4999999999999998" data-type="line" data-label="" points="345.1234887063655,307.25530458590003 345.1234887063655,320.03194159251655 384.0748345881816,320.03194159251655 384.0748345881816,307.25530458590003 396.8514715947981,307.25530458590003" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="2.9752723250000006,-0.4999999999999998 2.9752723250000006,-0.7 3.585,-0.7 3.585,-0.4999999999999998 3.785,-0.4999999999999998" data-type="line" data-label="" points="345.1234887063655,297.64088523842116 345.1234887063655,310.4175222450377 384.0748345881816,310.4175222450377 384.0748345881816,297.64088523842116 396.8514715947981,297.64088523842116" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="4.785,-1.2999999999999998 4.785,-1.6999999999999993 6.7,-1.6999999999999993 6.7,-1.4999999999999991" data-type="line" data-label="" points="460.73465662788044,358.36185261236596 460.73465662788044,383.9151266255989 583.0709559662332,383.9151266255989 583.0709559662332,371.13848961898236" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="4.785,-1.2999999999999998 4.785,-1.6999999999999993 6.7,-1.6999999999999993 6.7,-1.4999999999999991" data-type="line" data-label="" points="460.73465662788044,348.74743326488704 460.73465662788044,374.30070727811994 583.0709559662332,374.30070727811994 583.0709559662332,361.5240702715035" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.8699999999999997,-2.3 2.8699999999999997,-2.5 6.700000000000001,-2.5 6.700000000000001,-1.4999999999999991" data-type="line" data-label="" points="338.39835728952767,422.2450376454483 338.39835728952767,435.0216746520648 583.0709559662332,435.0216746520648 583.0709559662332,371.13848961898236" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="2.8699999999999997,-2.3 2.8699999999999997,-2.5 6.700000000000001,-2.5 6.700000000000001,-1.4999999999999991" data-type="line" data-label="" points="338.39835728952767,412.6306182979694 338.39835728952767,425.4072553045859 583.0709559662332,425.4072553045859 583.0709559662332,361.5240702715035" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.6 -1.8009999999999997,0.6 -1.8009999999999997,-1.1 2.8699999999999997,-1.1 2.8699999999999997,-1.2" data-type="line" data-label="" points="65.61715719826601,236.98380104950945 40,236.98380104950945 40,345.58521560574945 338.39835728952767,345.58521560574945 338.39835728952767,351.9735341090577" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-1.4,0.6 -1.8009999999999997,0.6 -1.8009999999999997,-1.1 2.8699999999999997,-1.1 2.8699999999999997,-1.2" data-type="line" data-label="" points="65.61715719826601,227.36938170203058 40,227.36938170203058 40,335.97079625827064 338.39835728952767,335.97079625827064 338.39835728952767,342.35911476157884" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 -1.551,-0.6 -1.551,-0.651" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 55.97079625827058,313.6436230892083 55.97079625827058,316.9016655258955" fill="none" stroke="purple" stroke-width="1" />
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="65.61715719826601" y="201.81610768879764" width="178.87291809263064" height="127.76637006616474" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.6 1.551,-0.6 1.551,-0.651" data-type="line" data-label="" points="244.49007529089664,313.6436230892083 254.13643623089206,313.6436230892083 254.13643623089206,316.9016655258955" fill="none" stroke="purple" stroke-width="1" />
+    <rect data-type="rect" data-label="schematic_component_1" data-x="4.785" data-y="-0.3999999999999999" x="396.8514715947981" y="233.7577002053388" width="127.76637006616465" height="114.98973305954823" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <polyline data-points="1.4,0.6 1.501,0.6 1.501,1.001" data-type="line" data-label="" points="244.49007529089664,236.98380104950945 250.94227697923793,236.98380104950945 250.94227697923793,211.36664385124342" fill="none" stroke="purple" stroke-width="1" />
+    <rect data-type="rect" data-label="schematic_component_2" data-x="6.7" data-y="-0.9499999999999993" x="566.1419119324663" y="291.2525667351129" width="33.858088067533686" height="70.27150353639058" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="65.61715719826601" y="211.43052703627652" width="178.87291809263064" height="127.76637006616474" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="schematic_component_3" data-x="2.8699999999999997" data-y="-1.75" x="321.4693132557609" y="342.35911476157884" width="33.85808806753363" height="70.27150353639058" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="4.785" data-y="-0.3999999999999999" x="396.8514715947981" y="243.37211955281768" width="127.76637006616465" height="114.98973305954829" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="schematic_component_4" data-x="2.9752723250000006" data-y="0.050000000000000266" x="334.91957608943653" y="227.36938170203055" width="20.407825233858034" height="70.27150353639061" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_2" data-x="6.7" data-y="-0.9499999999999993" x="566.1419119324663" y="300.8669860825918" width="33.858088067533686" height="70.27150353639058" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="" data-x="-1.5509999999999997" data-y="-0.6" x="46.38831850330824" y="297.64088523842116" width="19.164955509924695" height="12.776637006616511" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_3" data-x="2.8699999999999997" data-y="-1.75" x="321.4693132557609" y="351.9735341090577" width="33.85808806753363" height="70.27150353639058" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="" data-x="1.5509999999999997" data-y="-0.6" x="244.5539584759297" y="297.64088523842116" width="19.16495550992468" height="12.776637006616511" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_4" data-x="2.9752723250000006" data-y="0.050000000000000266" x="334.91957608943653" y="236.98380104950942" width="20.407825233858034" height="70.27150353639061" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="" data-x="2.8699999999999997" data-y="-2.65" x="332.0100387862194" y="425.4072553045859" width="12.776637006616511" height="19.164955509924766" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net3
-available orientations: y-" data-x="-1.551" data-y="-0.801" x="49.58247775496234" y="316.9016655258955" width="12.776637006616482" height="19.16495550992471" fill="#00000066" stroke="#000000" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="" data-x="-1.6004999999999998" data-y="0.75" x="46.42026009582477" y="208.20442619210587" width="12.776637006616482" height="19.16495550992471" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net3
-available orientations: y-" data-x="1.551" data-y="-0.801" x="247.7481177275838" y="316.9016655258955" width="12.776637006616511" height="19.16495550992471" fill="#00000066" stroke="#000000" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="" data-x="2.9752723250000006" data-y="0.9500000000000005" x="338.7351702030573" y="195.42778918548936" width="12.776637006616454" height="19.16495550992471" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net3
-available orientations: y-" data-x="2.8699999999999997" data-y="-2.65" x="332.0100387862194" y="435.0216746520648" width="12.776637006616511" height="19.164955509924653" fill="#00000066" stroke="#000000" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="" data-x="6.2425" data-y="7.771561172376096e-16" x="547.4560803102897" y="252.9226557152635" width="12.776637006616397" height="25.553274013232908" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: VIN
-globalConnNetId: connectivity_net1
-available orientations: y+" data-x="-1.6004999999999998" data-y="0.75" x="46.42026009582477" y="217.81884553958474" width="12.776637006616482" height="19.16495550992471" fill="#ef444466" stroke="#ef4444" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="" data-x="1.6009999999999998" data-y="0.6" x="244.5539584759297" y="220.98106319872235" width="25.553274013232937" height="12.776637006616454" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: VIN
-globalConnNetId: connectivity_net1
-available orientations: y+" data-x="2.9752723250000006" data-y="0.9500000000000005" x="338.7351702030573" y="205.04220853296823" width="12.776637006616454" height="19.16495550992471" fill="#ef444466" stroke="#ef4444" stroke-width="0.01565357142857143" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="netId: VOUT
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="6.2425" data-y="7.771561172376096e-16" x="547.4560803102897" y="262.53707506274236" width="12.776637006616397" height="25.553274013232908" fill="#ef444466" stroke="#ef4444" stroke-width="0.01565357142857143" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="netId: VOUT
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="1.501" data-y="1.2009999999999998" x="244.5539584759297" y="185.8133698380105" width="12.776637006616482" height="25.553274013232937" fill="#ef444466" stroke="#ef4444" stroke-width="0.01565357142857143" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="netId: LDO_EN
-globalConnNetId: connectivity_net2
-available orientations: x-, x+" data-x="2.675272325000001" data-y="-0.5999999999999999" x="306.79357768651613" y="307.25530458590003" width="38.32991101984936" height="12.776637006616511" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="" data-x="2.675272325000001" data-y="-0.5999999999999999" x="306.79357768651613" y="297.64088523842116" width="38.32991101984936" height="12.776637006616454" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -272,7 +239,7 @@ available orientations: x-, x+" data-x="2.675272325000001" data-y="-0.5999999999
         "e": 155.05361624458132,
         "b": 0,
         "d": -63.88318503308236,
-        "f": 275.31371206935887
+        "f": 265.69929272188
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example21.snap.svg
+++ b/tests/examples/__snapshots__/example21.snap.svg
@@ -2,209 +2,242 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="CORNERS.1
-x-" data-x="-1.4" data-y="-0.6" cx="65.61715719826601" cy="304.0292037417294" r="3" fill="hsl(65, 100%, 50%, 0.8)" />
+x-" data-x="-1.4" data-y="-0.6" cx="65.61715719826601" cy="313.6436230892083" r="3" fill="hsl(65, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="CORNERS.2
-x-" data-x="-1.4" data-y="0.6" cx="65.61715719826601" cy="227.36938170203058" r="3" fill="hsl(66, 100%, 50%, 0.8)" />
+x-" data-x="-1.4" data-y="0.6" cx="65.61715719826601" cy="236.98380104950945" r="3" fill="hsl(66, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="CORNERS.3
-x+" data-x="1.4" data-y="0.6" cx="244.49007529089664" cy="227.36938170203058" r="3" fill="hsl(67, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="0.6" cx="244.49007529089664" cy="236.98380104950945" r="3" fill="hsl(67, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="CORNERS.4
-x+" data-x="1.4" data-y="-0.6" cx="244.49007529089664" cy="304.0292037417294" r="3" fill="hsl(68, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="-0.6" cx="244.49007529089664" cy="313.6436230892083" r="3" fill="hsl(68, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U100.1
-x-" data-x="3.785" data-y="-0.29999999999999993" cx="396.8514715947981" cy="284.8642482318047" r="3" fill="hsl(175, 100%, 50%, 0.8)" />
+x-" data-x="3.785" data-y="-0.29999999999999993" cx="396.8514715947981" cy="294.4786675792836" r="3" fill="hsl(175, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U100.2
-y-" data-x="4.785" data-y="-1.2999999999999998" cx="460.73465662788044" cy="348.74743326488704" r="3" fill="hsl(176, 100%, 50%, 0.8)" />
+y-" data-x="4.785" data-y="-1.2999999999999998" cx="460.73465662788044" cy="358.36185261236596" r="3" fill="hsl(176, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U100.3
-x-" data-x="3.785" data-y="-0.4999999999999999" cx="396.8514715947981" cy="297.64088523842116" r="3" fill="hsl(177, 100%, 50%, 0.8)" />
+x-" data-x="3.785" data-y="-0.4999999999999999" cx="396.8514715947981" cy="307.25530458590003" r="3" fill="hsl(177, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U100.5
-x+" data-x="5.785" data-y="-0.3999999999999999" cx="524.6178416609628" cy="291.25256673511296" r="3" fill="hsl(179, 100%, 50%, 0.8)" />
+x+" data-x="5.785" data-y="-0.3999999999999999" cx="524.6178416609628" cy="300.86698608259184" r="3" fill="hsl(179, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C101.1
-y+" data-x="6.7" data-y="-0.39999999999999925" cx="583.0709559662332" cy="291.2525667351129" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+y+" data-x="6.7" data-y="-0.39999999999999925" cx="583.0709559662332" cy="300.8669860825918" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C101.2
-y-" data-x="6.7" data-y="-1.4999999999999993" cx="583.0709559662332" cy="361.5240702715035" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+y-" data-x="6.7" data-y="-1.4999999999999993" cx="583.0709559662332" cy="371.13848961898236" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C100.1
-y+" data-x="2.8699999999999997" data-y="-1.2" cx="338.39835728952767" cy="342.35911476157884" r="3" fill="hsl(337, 100%, 50%, 0.8)" />
+y+" data-x="2.8699999999999997" data-y="-1.2" cx="338.39835728952767" cy="351.9735341090577" r="3" fill="hsl(337, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C100.2
-y-" data-x="2.8699999999999997" data-y="-2.3" cx="338.39835728952767" cy="412.6306182979694" r="3" fill="hsl(338, 100%, 50%, 0.8)" />
+y-" data-x="2.8699999999999997" data-y="-2.3" cx="338.39835728952767" cy="422.2450376454483" r="3" fill="hsl(338, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R100.1
-y+" data-x="2.9752723250000006" data-y="0.6000000000000003" cx="345.1234887063655" cy="227.36938170203055" r="3" fill="hsl(82, 100%, 50%, 0.8)" />
+y+" data-x="2.9752723250000006" data-y="0.6000000000000003" cx="345.1234887063655" cy="236.98380104950942" r="3" fill="hsl(82, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R100.2
-y-" data-x="2.9752723250000006" data-y="-0.4999999999999998" cx="345.1234887063655" cy="297.64088523842116" r="3" fill="hsl(83, 100%, 50%, 0.8)" />
+y-" data-x="2.9752723250000006" data-y="-0.4999999999999998" cx="345.1234887063655" cy="307.25530458590003" r="3" fill="hsl(83, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.4" data-y="-0.6" cx="65.61715719826601" cy="304.0292037417294" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="-1.551" data-y="-0.651" cx="55.97079625827058" cy="316.9016655258955" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.4" data-y="-0.6" cx="244.49007529089664" cy="304.0292037417294" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="1.551" data-y="-0.651" cx="254.13643623089206" cy="316.9016655258955" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="2.8699999999999997" data-y="-2.5" cx="338.39835728952767" cy="425.4072553045859" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="2.8699999999999997" data-y="-2.5" cx="338.39835728952767" cy="435.0216746520648" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.6004999999999998" data-y="0.6" cx="52.808578599133014" cy="227.36938170203058" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-1.6004999999999998" data-y="0.6" cx="52.808578599133014" cy="236.98380104950945" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="2.9752723250000006" data-y="0.8000000000000005" cx="345.1234887063655" cy="214.59274469541407" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="2.9752723250000006" data-y="0.8000000000000005" cx="345.1234887063655" cy="224.20716404289294" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="6.2425" data-y="-0.19999999999999923" cx="553.844398813598" cy="278.4759297284964" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="6.2425" data-y="-0.19999999999999923" cx="553.844398813598" cy="288.09034907597527" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.4" data-y="0.6" cx="244.49007529089664" cy="227.36938170203058" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="1.501" data-y="1.001" cx="250.94227697923793" cy="211.36664385124342" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="2.9752723250000006" data-y="-0.5999999999999999" cx="345.1234887063655" cy="304.0292037417294" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="2.9752723250000006" data-y="-0.5999999999999999" cx="345.1234887063655" cy="313.6436230892083" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="6.7,-0.39999999999999925 5.785,-0.3999999999999999" data-type="line" data-label="" points="583.0709559662332,291.2525667351129 524.6178416609628,291.25256673511296" fill="none" stroke="hsl(176, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="6.7,-0.39999999999999925 5.785,-0.3999999999999999" data-type="line" data-label="" points="583.0709559662332,300.8669860825918 524.6178416609628,300.86698608259184" fill="none" stroke="hsl(176, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.8699999999999997,-1.2 3.785,-0.29999999999999993" data-type="line" data-label="" points="338.39835728952767,342.35911476157884 396.8514715947981,284.8642482318047" fill="none" stroke="hsl(8, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="2.8699999999999997,-1.2 3.785,-0.29999999999999993" data-type="line" data-label="" points="338.39835728952767,351.9735341090577 396.8514715947981,294.4786675792836" fill="none" stroke="hsl(8, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.9752723250000006,-0.4999999999999998 3.785,-0.4999999999999999" data-type="line" data-label="" points="345.1234887063655,297.64088523842116 396.8514715947981,297.64088523842116" fill="none" stroke="hsl(272, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="2.9752723250000006,-0.4999999999999998 3.785,-0.4999999999999999" data-type="line" data-label="" points="345.1234887063655,307.25530458590003 396.8514715947981,307.25530458590003" fill="none" stroke="hsl(272, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 1.4,-0.6" data-type="line" data-label="" points="65.61715719826601,304.0292037417294 244.49007529089664,304.0292037417294" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.6 1.4,-0.6" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 244.49007529089664,313.6436230892083" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 4.785,-1.2999999999999998" data-type="line" data-label="" points="65.61715719826601,304.0292037417294 460.73465662788044,348.74743326488704" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.6 4.785,-1.2999999999999998" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 460.73465662788044,358.36185261236596" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 6.7,-1.4999999999999993" data-type="line" data-label="" points="65.61715719826601,304.0292037417294 583.0709559662332,361.5240702715035" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.6 6.7,-1.4999999999999993" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 583.0709559662332,371.13848961898236" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.6 2.8699999999999997,-2.3" data-type="line" data-label="" points="65.61715719826601,304.0292037417294 338.39835728952767,412.6306182979694" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.6 2.8699999999999997,-2.3" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 338.39835728952767,422.2450376454483" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.6 4.785,-1.2999999999999998" data-type="line" data-label="" points="244.49007529089664,304.0292037417294 460.73465662788044,348.74743326488704" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.6 4.785,-1.2999999999999998" data-type="line" data-label="" points="244.49007529089664,313.6436230892083 460.73465662788044,358.36185261236596" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.6 6.7,-1.4999999999999993" data-type="line" data-label="" points="244.49007529089664,304.0292037417294 583.0709559662332,361.5240702715035" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.6 6.7,-1.4999999999999993" data-type="line" data-label="" points="244.49007529089664,313.6436230892083 583.0709559662332,371.13848961898236" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.6 2.8699999999999997,-2.3" data-type="line" data-label="" points="244.49007529089664,304.0292037417294 338.39835728952767,412.6306182979694" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.6 2.8699999999999997,-2.3" data-type="line" data-label="" points="244.49007529089664,313.6436230892083 338.39835728952767,422.2450376454483" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="4.785,-1.2999999999999998 6.7,-1.4999999999999993" data-type="line" data-label="" points="460.73465662788044,348.74743326488704 583.0709559662332,361.5240702715035" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4.785,-1.2999999999999998 6.7,-1.4999999999999993" data-type="line" data-label="" points="460.73465662788044,358.36185261236596 583.0709559662332,371.13848961898236" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="4.785,-1.2999999999999998 2.8699999999999997,-2.3" data-type="line" data-label="" points="460.73465662788044,348.74743326488704 338.39835728952767,412.6306182979694" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4.785,-1.2999999999999998 2.8699999999999997,-2.3" data-type="line" data-label="" points="460.73465662788044,358.36185261236596 338.39835728952767,422.2450376454483" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="6.7,-1.4999999999999993 2.8699999999999997,-2.3" data-type="line" data-label="" points="583.0709559662332,361.5240702715035 338.39835728952767,412.6306182979694" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="6.7,-1.4999999999999993 2.8699999999999997,-2.3" data-type="line" data-label="" points="583.0709559662332,371.13848961898236 338.39835728952767,422.2450376454483" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.6 3.785,-0.29999999999999993" data-type="line" data-label="" points="65.61715719826601,227.36938170203058 396.8514715947981,284.8642482318047" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.6 3.785,-0.29999999999999993" data-type="line" data-label="" points="65.61715719826601,236.98380104950945 396.8514715947981,294.4786675792836" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.6 2.8699999999999997,-1.2" data-type="line" data-label="" points="65.61715719826601,227.36938170203058 338.39835728952767,342.35911476157884" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.6 2.8699999999999997,-1.2" data-type="line" data-label="" points="65.61715719826601,236.98380104950945 338.39835728952767,351.9735341090577" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.6 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="65.61715719826601,227.36938170203058 345.1234887063655,227.36938170203055" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.6 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="65.61715719826601,236.98380104950945 345.1234887063655,236.98380104950942" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="3.785,-0.29999999999999993 2.8699999999999997,-1.2" data-type="line" data-label="" points="396.8514715947981,284.8642482318047 338.39835728952767,342.35911476157884" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="3.785,-0.29999999999999993 2.8699999999999997,-1.2" data-type="line" data-label="" points="396.8514715947981,294.4786675792836 338.39835728952767,351.9735341090577" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="3.785,-0.29999999999999993 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="396.8514715947981,284.8642482318047 345.1234887063655,227.36938170203055" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="3.785,-0.29999999999999993 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="396.8514715947981,294.4786675792836 345.1234887063655,236.98380104950942" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="2.8699999999999997,-1.2 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="338.39835728952767,342.35911476157884 345.1234887063655,227.36938170203055" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="2.8699999999999997,-1.2 2.9752723250000006,0.6000000000000003" data-type="line" data-label="" points="338.39835728952767,351.9735341090577 345.1234887063655,236.98380104950942" fill="none" stroke="hsl(27, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,0.6 5.785,-0.3999999999999999" data-type="line" data-label="" points="244.49007529089664,227.36938170203058 524.6178416609628,291.25256673511296" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,0.6 5.785,-0.3999999999999999" data-type="line" data-label="" points="244.49007529089664,236.98380104950945 524.6178416609628,300.86698608259184" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,0.6 6.7,-0.39999999999999925" data-type="line" data-label="" points="244.49007529089664,227.36938170203058 583.0709559662332,291.2525667351129" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,0.6 6.7,-0.39999999999999925" data-type="line" data-label="" points="244.49007529089664,236.98380104950945 583.0709559662332,300.8669860825918" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="5.785,-0.3999999999999999 6.7,-0.39999999999999925" data-type="line" data-label="" points="524.6178416609628,291.25256673511296 583.0709559662332,291.2525667351129" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="5.785,-0.3999999999999999 6.7,-0.39999999999999925" data-type="line" data-label="" points="524.6178416609628,300.86698608259184 583.0709559662332,300.8669860825918" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="3.785,-0.4999999999999999 2.9752723250000006,-0.4999999999999998" data-type="line" data-label="" points="396.8514715947981,297.64088523842116 345.1234887063655,297.64088523842116" fill="none" stroke="hsl(345, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="3.785,-0.4999999999999999 2.9752723250000006,-0.4999999999999998" data-type="line" data-label="" points="396.8514715947981,307.25530458590003 345.1234887063655,307.25530458590003" fill="none" stroke="hsl(345, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="5.785,-0.3999999999999999 6.2425,-0.3999999999999999 6.2425,-0.19999999999999923 6.7,-0.19999999999999923 6.7,-0.39999999999999925" data-type="line" data-label="" points="524.6178416609628,291.25256673511296 553.844398813598,291.25256673511296 553.844398813598,278.4759297284964 583.0709559662332,278.4759297284964 583.0709559662332,291.2525667351129" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="5.785,-0.3999999999999999 6.2425,-0.3999999999999999 6.2425,-0.19999999999999923 6.7,-0.19999999999999923 6.7,-0.39999999999999925" data-type="line" data-label="" points="524.6178416609628,300.86698608259184 553.844398813598,300.86698608259184 553.844398813598,288.09034907597527 583.0709559662332,288.09034907597527 583.0709559662332,300.8669860825918" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.9752723250000006,0.6000000000000003 2.9752723250000006,0.8000000000000005 3.3801361625000004,0.8000000000000005 3.3801361625000004,-0.30000000000000004 3.785,-0.30000000000000004" data-type="line" data-label="" points="345.1234887063655,227.36938170203055 345.1234887063655,214.59274469541407 370.9874801505818,214.59274469541407 370.9874801505818,284.8642482318047 396.8514715947981,284.8642482318047" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="2.9752723250000006,0.6000000000000003 2.9752723250000006,0.8000000000000005 3.3801361625000004,0.8000000000000005 3.3801361625000004,-0.30000000000000004 3.785,-0.30000000000000004" data-type="line" data-label="" points="345.1234887063655,236.98380104950942 345.1234887063655,224.20716404289294 370.9874801505818,224.20716404289294 370.9874801505818,294.4786675792836 396.8514715947981,294.4786675792836" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.9752723250000006,-0.4999999999999998 2.9752723250000006,-0.7 3.585,-0.7 3.585,-0.4999999999999998 3.785,-0.4999999999999998" data-type="line" data-label="" points="345.1234887063655,297.64088523842116 345.1234887063655,310.4175222450377 384.0748345881816,310.4175222450377 384.0748345881816,297.64088523842116 396.8514715947981,297.64088523842116" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="2.9752723250000006,-0.4999999999999998 2.9752723250000006,-0.7 3.585,-0.7 3.585,-0.4999999999999998 3.785,-0.4999999999999998" data-type="line" data-label="" points="345.1234887063655,307.25530458590003 345.1234887063655,320.03194159251655 384.0748345881816,320.03194159251655 384.0748345881816,307.25530458590003 396.8514715947981,307.25530458590003" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="4.785,-1.2999999999999998 4.785,-1.6999999999999993 6.7,-1.6999999999999993 6.7,-1.4999999999999991" data-type="line" data-label="" points="460.73465662788044,348.74743326488704 460.73465662788044,374.30070727811994 583.0709559662332,374.30070727811994 583.0709559662332,361.5240702715035" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="4.785,-1.2999999999999998 4.785,-1.6999999999999993 6.7,-1.6999999999999993 6.7,-1.4999999999999991" data-type="line" data-label="" points="460.73465662788044,358.36185261236596 460.73465662788044,383.9151266255989 583.0709559662332,383.9151266255989 583.0709559662332,371.13848961898236" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.8699999999999997,-2.3 2.8699999999999997,-2.5 6.700000000000001,-2.5 6.700000000000001,-1.4999999999999991" data-type="line" data-label="" points="338.39835728952767,412.6306182979694 338.39835728952767,425.4072553045859 583.0709559662332,425.4072553045859 583.0709559662332,361.5240702715035" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="2.8699999999999997,-2.3 2.8699999999999997,-2.5 6.700000000000001,-2.5 6.700000000000001,-1.4999999999999991" data-type="line" data-label="" points="338.39835728952767,422.2450376454483 338.39835728952767,435.0216746520648 583.0709559662332,435.0216746520648 583.0709559662332,371.13848961898236" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.6 -1.8009999999999997,0.6 -1.8009999999999997,-1.1 2.8699999999999997,-1.1 2.8699999999999997,-1.2" data-type="line" data-label="" points="65.61715719826601,227.36938170203058 40,227.36938170203058 40,335.97079625827064 338.39835728952767,335.97079625827064 338.39835728952767,342.35911476157884" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-1.4,0.6 -1.8009999999999997,0.6 -1.8009999999999997,-1.1 2.8699999999999997,-1.1 2.8699999999999997,-1.2" data-type="line" data-label="" points="65.61715719826601,236.98380104950945 40,236.98380104950945 40,345.58521560574945 338.39835728952767,345.58521560574945 338.39835728952767,351.9735341090577" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="65.61715719826601" y="201.81610768879764" width="178.87291809263064" height="127.76637006616474" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <polyline data-points="-1.4,-0.6 -1.551,-0.6 -1.551,-0.651" data-type="line" data-label="" points="65.61715719826601,313.6436230892083 55.97079625827058,313.6436230892083 55.97079625827058,316.9016655258955" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="4.785" data-y="-0.3999999999999999" x="396.8514715947981" y="233.7577002053388" width="127.76637006616465" height="114.98973305954823" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <polyline data-points="1.4,-0.6 1.551,-0.6 1.551,-0.651" data-type="line" data-label="" points="244.49007529089664,313.6436230892083 254.13643623089206,313.6436230892083 254.13643623089206,316.9016655258955" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_2" data-x="6.7" data-y="-0.9499999999999993" x="566.1419119324663" y="291.2525667351129" width="33.858088067533686" height="70.27150353639058" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <polyline data-points="1.4,0.6 1.501,0.6 1.501,1.001" data-type="line" data-label="" points="244.49007529089664,236.98380104950945 250.94227697923793,236.98380104950945 250.94227697923793,211.36664385124342" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_3" data-x="2.8699999999999997" data-y="-1.75" x="321.4693132557609" y="342.35911476157884" width="33.85808806753363" height="70.27150353639058" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="65.61715719826601" y="211.43052703627652" width="178.87291809263064" height="127.76637006616474" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_4" data-x="2.9752723250000006" data-y="0.050000000000000266" x="334.91957608943653" y="227.36938170203055" width="20.407825233858034" height="70.27150353639061" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="schematic_component_1" data-x="4.785" data-y="-0.3999999999999999" x="396.8514715947981" y="243.37211955281768" width="127.76637006616465" height="114.98973305954829" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="-1.5509999999999997" data-y="-0.6" x="46.38831850330824" y="297.64088523842116" width="19.164955509924695" height="12.776637006616511" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="schematic_component_2" data-x="6.7" data-y="-0.9499999999999993" x="566.1419119324663" y="300.8669860825918" width="33.858088067533686" height="70.27150353639058" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="1.5509999999999997" data-y="-0.6" x="244.5539584759297" y="297.64088523842116" width="19.16495550992468" height="12.776637006616511" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="schematic_component_3" data-x="2.8699999999999997" data-y="-1.75" x="321.4693132557609" y="351.9735341090577" width="33.85808806753363" height="70.27150353639058" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="2.8699999999999997" data-y="-2.65" x="332.0100387862194" y="425.4072553045859" width="12.776637006616511" height="19.164955509924766" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="schematic_component_4" data-x="2.9752723250000006" data-y="0.050000000000000266" x="334.91957608943653" y="236.98380104950942" width="20.407825233858034" height="70.27150353639061" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="-1.6004999999999998" data-y="0.75" x="46.42026009582477" y="208.20442619210587" width="12.776637006616482" height="19.16495550992471" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net3
+available orientations: y-" data-x="-1.551" data-y="-0.801" x="49.58247775496234" y="316.9016655258955" width="12.776637006616482" height="19.16495550992471" fill="#00000066" stroke="#000000" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="2.9752723250000006" data-y="0.9500000000000005" x="338.7351702030573" y="195.42778918548936" width="12.776637006616454" height="19.16495550992471" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net3
+available orientations: y-" data-x="1.551" data-y="-0.801" x="247.7481177275838" y="316.9016655258955" width="12.776637006616511" height="19.16495550992471" fill="#00000066" stroke="#000000" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="6.2425" data-y="7.771561172376096e-16" x="547.4560803102897" y="252.9226557152635" width="12.776637006616397" height="25.553274013232908" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net3
+available orientations: y-" data-x="2.8699999999999997" data-y="-2.65" x="332.0100387862194" y="435.0216746520648" width="12.776637006616511" height="19.164955509924653" fill="#00000066" stroke="#000000" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="1.6009999999999998" data-y="0.6" x="244.5539584759297" y="220.98106319872235" width="25.553274013232937" height="12.776637006616454" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="netId: VIN
+globalConnNetId: connectivity_net1
+available orientations: y+" data-x="-1.6004999999999998" data-y="0.75" x="46.42026009582477" y="217.81884553958474" width="12.776637006616482" height="19.16495550992471" fill="#ef444466" stroke="#ef4444" stroke-width="0.01565357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="2.675272325000001" data-y="-0.5999999999999999" x="306.79357768651613" y="297.64088523842116" width="38.32991101984936" height="12.776637006616454" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
+    <rect data-type="rect" data-label="netId: VIN
+globalConnNetId: connectivity_net1
+available orientations: y+" data-x="2.9752723250000006" data-y="0.9500000000000005" x="338.7351702030573" y="205.04220853296823" width="12.776637006616454" height="19.16495550992471" fill="#ef444466" stroke="#ef4444" stroke-width="0.01565357142857143" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VOUT
+globalConnNetId: connectivity_net0
+available orientations: y+" data-x="6.2425" data-y="7.771561172376096e-16" x="547.4560803102897" y="262.53707506274236" width="12.776637006616397" height="25.553274013232908" fill="#ef444466" stroke="#ef4444" stroke-width="0.01565357142857143" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VOUT
+globalConnNetId: connectivity_net0
+available orientations: y+" data-x="1.501" data-y="1.2009999999999998" x="244.5539584759297" y="185.8133698380105" width="12.776637006616482" height="25.553274013232937" fill="#ef444466" stroke="#ef4444" stroke-width="0.01565357142857143" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: LDO_EN
+globalConnNetId: connectivity_net2
+available orientations: x-, x+" data-x="2.675272325000001" data-y="-0.5999999999999999" x="306.79357768651613" y="307.25530458590003" width="38.32991101984936" height="12.776637006616511" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01565357142857143" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -239,7 +272,7 @@ y-" data-x="2.9752723250000006" data-y="-0.4999999999999998" cx="345.12348870636
         "e": 155.05361624458132,
         "b": 0,
         "d": -63.88318503308236,
-        "f": 265.69929272188
+        "f": 275.31371206935887
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/functions/removeDuplicateConsecutivePoints.test.ts
+++ b/tests/functions/removeDuplicateConsecutivePoints.test.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "bun:test"
+import {
+  removeDuplicateConsecutivePoints,
+  simplifyPath,
+} from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+/**
+ * Unit tests for removeDuplicateConsecutivePoints.
+ *
+ * This utility is the core fix for issue #78: when UntangleTraceSubsolver
+ * splices a rerouted segment back into the original trace path the junction
+ * points appear twice (once at the end of the left slice and again at the
+ * start of bestRoute, or at the end of bestRoute and the start of the right
+ * slice).  Those zero-length duplicate segments render as extra trace lines
+ * in the schematic viewer.
+ */
+
+test("removeDuplicateConsecutivePoints: removes exact duplicate consecutive points", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 }, // duplicate of next
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+  ]
+  const result = removeDuplicateConsecutivePoints(path)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+  ])
+})
+
+test("removeDuplicateConsecutivePoints: removes points within epsilon (1e-9)", () => {
+  const eps = 5e-10 // less than 1e-9
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1 + eps, y: eps }, // near-duplicate of previous
+    { x: 2, y: 0 },
+  ]
+  const result = removeDuplicateConsecutivePoints(path)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+  ])
+})
+
+test("removeDuplicateConsecutivePoints: keeps non-duplicate points unchanged", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 2, y: 1 },
+  ]
+  const result = removeDuplicateConsecutivePoints(path)
+  expect(result).toEqual(path)
+})
+
+test("removeDuplicateConsecutivePoints: handles empty path", () => {
+  expect(removeDuplicateConsecutivePoints([])).toEqual([])
+})
+
+test("removeDuplicateConsecutivePoints: handles single-point path", () => {
+  const path = [{ x: 1, y: 2 }]
+  expect(removeDuplicateConsecutivePoints(path)).toEqual(path)
+})
+
+test("removeDuplicateConsecutivePoints: removes all duplicates in a run", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+    { x: 1, y: 1 },
+  ]
+  expect(removeDuplicateConsecutivePoints(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("removeDuplicateConsecutivePoints: does NOT remove non-consecutive duplicates", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 0, y: 0 }, // same as first but NOT consecutive
+  ]
+  const result = removeDuplicateConsecutivePoints(path)
+  expect(result).toEqual(path)
+})
+
+test("simplifyPath: duplicate boundary points from _applyBestRoute splice are removed", () => {
+  // Simulate the splice that _applyBestRoute performs (issue #78 root cause).
+  // Original path: A - B - C - D
+  // p2 = B (index 1); bestRoute = [A, mid, C]
+  // Naive splice: slice(0,1)=[A], bestRoute=[A,mid,C], slice(2)=[C,D]
+  //   => [A, A, mid, C, C, D]  -- has two pairs of consecutive duplicates
+  // After fix: [A, mid, C, D]
+
+  const A = { x: 0, y: 0 }
+  const mid = { x: 0, y: 1 }
+  const C = { x: 1, y: 1 }
+  const D = { x: 2, y: 1 }
+
+  const originalPath = [A, { x: 1, y: 0 }, C, D]
+  const p2Index = 1
+  const bestRoute = [A, mid, C]
+
+  const spliced = [
+    ...originalPath.slice(0, p2Index), // [A]
+    ...bestRoute, // [A, mid, C] — A duplicates end of left slice
+    ...originalPath.slice(p2Index + 1), // [C, D]  — C duplicates end of bestRoute
+  ]
+  // spliced = [A, A, mid, C, C, D]
+
+  const cleaned = simplifyPath(spliced)
+
+  // No consecutive duplicate points in the result
+  for (let i = 1; i < cleaned.length; i++) {
+    const prev = cleaned[i - 1]
+    const curr = cleaned[i]
+    expect(prev.x === curr.x && prev.y === curr.y).toBe(false)
+  }
+
+  // simplifyPath also removes collinear intermediate points so mid→C→D
+  // (all at y=1, going right) collapses to mid→D.  The key invariant is
+  // no consecutive duplicates and the path starts at A and ends at D.
+  expect(cleaned[0]).toEqual(A)
+  expect(cleaned[cleaned.length - 1]).toEqual(D)
+})

--- a/tests/solvers/TraceCleanupSolver/TraceCleanupSolver_repro78.test.ts
+++ b/tests/solvers/TraceCleanupSolver/TraceCleanupSolver_repro78.test.ts
@@ -1,0 +1,91 @@
+import type { InputProblem } from "lib/types/InputProblem"
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/index"
+
+/**
+ * Regression test for issue #78: "Fix extra trace lines in post-processing step"
+ *
+ * When UntangleTraceSubsolver reroutes an L-shaped turn it splices a bestRoute
+ * segment into the original trace path:
+ *
+ *   newTracePath = [...slice(0, p2Index), ...bestRoute, ...slice(p2Index + 1)]
+ *
+ * The last point of the left slice equals the first point of bestRoute (p1),
+ * and the last point of bestRoute (p3) equals the first point of the right
+ * slice.  Those duplicate points produce zero-length segments that render as
+ * spurious extra trace lines in the schematic viewer.
+ *
+ * The fix calls removeDuplicateConsecutivePoints() on the assembled path so
+ * that the duplicate boundary points are eliminated before the trace is stored.
+ */
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "U1",
+      center: { x: 0, y: 0 },
+      width: 1.0,
+      height: 2.0,
+      pins: [
+        { pinId: "U1.1", x: -0.5, y: 0.5 },
+        { pinId: "U1.2", x: -0.5, y: -0.5 },
+      ],
+    },
+    {
+      chipId: "U2",
+      center: { x: 4, y: 0 },
+      width: 1.0,
+      height: 2.0,
+      pins: [
+        { pinId: "U2.1", x: 3.5, y: 0.5 },
+        { pinId: "U2.2", x: 3.5, y: -0.5 },
+      ],
+    },
+    {
+      chipId: "U3",
+      center: { x: 2, y: 3 },
+      width: 1.0,
+      height: 2.0,
+      pins: [
+        { pinId: "U3.1", x: 1.5, y: 3.5 },
+        { pinId: "U3.2", x: 1.5, y: 2.5 },
+      ],
+    },
+  ],
+  directConnections: [
+    { netId: "NET_A", pinIds: ["U1.1", "U2.1"] },
+    { netId: "NET_B", pinIds: ["U1.2", "U3.2"] },
+  ],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+  maxMspPairDistance: 10,
+}
+
+test("SchematicTracePipelineSolver_repro78: no duplicate consecutive points in solved traces", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  solver.solve()
+  expect(solver.solved).toBe(true)
+
+  const EPS = 1e-9
+
+  // Collect all trace paths from every sub-solver that may produce them
+  const traceCleanupSolver = solver.traceCleanupSolver
+  if (!traceCleanupSolver) return
+
+  for (const trace of traceCleanupSolver.getOutput().traces) {
+    const path = trace.tracePath
+    for (let i = 1; i < path.length; i++) {
+      const prev = path[i - 1]
+      const curr = path[i]
+      const dx = Math.abs(curr.x - prev.x)
+      const dy = Math.abs(curr.y - prev.y)
+      const isDuplicate = dx <= EPS && dy <= EPS
+      expect(isDuplicate).toBe(false)
+    }
+  }
+})
+
+test("SchematicTracePipelineSolver_repro78: solver completes without error", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  expect(() => solver.solve()).not.toThrow()
+  expect(solver.solved).toBe(true)
+})


### PR DESCRIPTION
/claim #78

## Root Cause

\`UntangleTraceSubsolver._applyBestRoute()\` splices a rerouted segment back into the original trace path by concatenating three slices. The last point of the left slice equals \`bestRoute[0]\` (p1), and \`bestRoute[last]\` equals the first point of the right slice (p3). These consecutive duplicate boundary points produce zero-length segments that render as spurious extra trace lines.

## Fix

1. Add \`removeDuplicateConsecutivePoints()\` to \`simplifyPath.ts\` — filters consecutive points within 1e-9 epsilon, exported for reuse across the codebase.
2. Call it at the start of \`simplifyPath()\` so degenerate zero-length segments are eliminated even when \`simplifyPath\` is called directly.
3. Wrap the assembled path in \`_applyBestRoute()\` with \`removeDuplicateConsecutivePoints()\`.

## Tests Added

- 8 unit tests for \`removeDuplicateConsecutivePoints\` (empty path, single point, exact duplicates, epsilon threshold, non-consecutive duplicates, run of duplicates, integration with splice pattern)
- Regression test asserting no consecutive duplicate points survive in the pipeline solver output

All 67 tests pass. SVG snapshots updated.