### PR TITLE
feat: merge close same-net trace segments after cleanup

### DIFF
--- a/lib/solvers/SameNetSegmentMergingSolver/SameNetSegmentMergingSolver.ts
+++ b/lib/solvers/SameNetSegmentMergingSolver/SameNetSegmentMergingSolver.ts
@@ -1,0 +1,361 @@
+import type { GraphicsObject } from "graphics-debug"
+import type { Point } from "@tscircuit/math-utils"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
+import { simplifyPath } from "../TraceCleanupSolver/simplifyPath"
+import {
+  isHorizontal,
+  isVertical,
+} from "../SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+
+const EPS = 1e-6
+const DEFAULT_MERGE_DISTANCE = 0.15
+const MAX_PASSES = 8
+
+type Orientation = "horizontal" | "vertical"
+
+type SegmentRef = {
+  traceIndex: number
+  segmentIndex: number
+  orientation: Orientation
+  axisCoord: number
+  rangeStart: number
+  rangeEnd: number
+  canMove: boolean
+  span: number
+}
+
+export class SameNetSegmentMergingSolver extends BaseSolver {
+  inputProblem: InputProblem
+  mergeDistance: number
+  outputTraces: SolvedTracePath[]
+
+  constructor(params: {
+    inputProblem: InputProblem
+    allTraces: SolvedTracePath[]
+    mergeDistance?: number
+  }) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.mergeDistance = params.mergeDistance ?? DEFAULT_MERGE_DISTANCE
+    this.outputTraces = params.allTraces.map((trace) => ({
+      ...trace,
+      tracePath: trace.tracePath.map((point) => ({ ...point })),
+      mspConnectionPairIds: [...trace.mspConnectionPairIds],
+      pinIds: [...trace.pinIds],
+      pins: trace.pins.map((pin) => ({ ...pin })) as typeof trace.pins,
+    }))
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetSegmentMergingSolver
+  >[0] {
+    return {
+      inputProblem: this.inputProblem,
+      allTraces: this.outputTraces,
+      mergeDistance: this.mergeDistance,
+    }
+  }
+
+  override _step() {
+    let changed = false
+
+    for (let passIndex = 0; passIndex < MAX_PASSES; passIndex++) {
+      const passChanged = this.runMergePass()
+      if (!passChanged) break
+      changed = true
+    }
+
+    if (changed) {
+      this.outputTraces = this.outputTraces.map((trace) => ({
+        ...trace,
+        tracePath: normalizePath(trace.tracePath),
+      }))
+    }
+
+    this.solved = true
+  }
+
+  private runMergePass(): boolean {
+    let changed = false
+    const tracesByNet = new Map<string, number[]>()
+
+    for (const [traceIndex, trace] of this.outputTraces.entries()) {
+      if (!tracesByNet.has(trace.globalConnNetId)) {
+        tracesByNet.set(trace.globalConnNetId, [])
+      }
+      tracesByNet.get(trace.globalConnNetId)!.push(traceIndex)
+    }
+
+    for (const traceIndexes of tracesByNet.values()) {
+      if (traceIndexes.length < 2) continue
+
+      for (const orientation of ["horizontal", "vertical"] as const) {
+        changed =
+          this.snapMovableSegmentsToAnchors(traceIndexes, orientation) ||
+          changed
+        changed =
+          this.snapFreeSegmentsTogether(traceIndexes, orientation) || changed
+      }
+    }
+
+    return changed
+  }
+
+  private snapMovableSegmentsToAnchors(
+    traceIndexes: number[],
+    orientation: Orientation,
+  ): boolean {
+    const segments = this.collectSegments(traceIndexes, orientation)
+    const anchors = segments.filter((segment) => !segment.canMove)
+    const movables = segments.filter((segment) => segment.canMove)
+
+    if (anchors.length === 0 || movables.length === 0) return false
+
+    const assignments = new Map<
+      string,
+      { targetCoord: number; distance: number }
+    >()
+
+    for (const segment of movables) {
+      let bestAnchor: SegmentRef | null = null
+      let bestDistance = Number.POSITIVE_INFINITY
+
+      for (const anchor of anchors) {
+        if (!areSegmentsCompatible(segment, anchor, this.mergeDistance))
+          continue
+        const distance = Math.abs(segment.axisCoord - anchor.axisCoord)
+        if (distance + EPS < bestDistance) {
+          bestDistance = distance
+          bestAnchor = anchor
+        }
+      }
+
+      if (bestAnchor) {
+        assignments.set(getSegmentKey(segment), {
+          targetCoord: bestAnchor.axisCoord,
+          distance: bestDistance,
+        })
+      }
+    }
+
+    let changed = false
+    for (const segment of movables) {
+      const assignment = assignments.get(getSegmentKey(segment))
+      if (!assignment) continue
+      changed =
+        this.applySegmentMove(segment, assignment.targetCoord) || changed
+    }
+
+    return changed
+  }
+
+  private snapFreeSegmentsTogether(
+    traceIndexes: number[],
+    orientation: Orientation,
+  ): boolean {
+    const segments = this.collectSegments(traceIndexes, orientation).filter(
+      (segment) => segment.canMove,
+    )
+
+    if (segments.length < 2) return false
+
+    const parent = segments.map((_, index) => index)
+    const find = (index: number): number => {
+      if (parent[index] !== index) {
+        parent[index] = find(parent[index]!)
+      }
+      return parent[index]!
+    }
+    const union = (a: number, b: number) => {
+      const rootA = find(a)
+      const rootB = find(b)
+      if (rootA !== rootB) parent[rootB] = rootA
+    }
+
+    for (let i = 0; i < segments.length; i++) {
+      for (let j = i + 1; j < segments.length; j++) {
+        if (
+          areSegmentsCompatible(segments[i]!, segments[j]!, this.mergeDistance)
+        ) {
+          union(i, j)
+        }
+      }
+    }
+
+    const groups = new Map<number, SegmentRef[]>()
+    for (let i = 0; i < segments.length; i++) {
+      const root = find(i)
+      if (!groups.has(root)) groups.set(root, [])
+      groups.get(root)!.push(segments[i]!)
+    }
+
+    let changed = false
+
+    for (const group of groups.values()) {
+      if (group.length < 2) continue
+      const totalSpan = group.reduce((sum, segment) => sum + segment.span, 0)
+      if (totalSpan < EPS) continue
+
+      const targetCoord =
+        group.reduce(
+          (sum, segment) => sum + segment.axisCoord * segment.span,
+          0,
+        ) / totalSpan
+
+      for (const segment of group) {
+        changed = this.applySegmentMove(segment, targetCoord) || changed
+      }
+    }
+
+    return changed
+  }
+
+  private collectSegments(
+    traceIndexes: number[],
+    orientation: Orientation,
+  ): SegmentRef[] {
+    const segments: SegmentRef[] = []
+
+    for (const traceIndex of traceIndexes) {
+      const trace = this.outputTraces[traceIndex]!
+      const lastPointIndex = trace.tracePath.length - 1
+
+      for (
+        let segmentIndex = 0;
+        segmentIndex < trace.tracePath.length - 1;
+        segmentIndex++
+      ) {
+        const a = trace.tracePath[segmentIndex]!
+        const b = trace.tracePath[segmentIndex + 1]!
+
+        const isMatchingOrientation =
+          orientation === "horizontal"
+            ? isHorizontal(a, b, EPS)
+            : isVertical(a, b, EPS)
+        if (!isMatchingOrientation) continue
+
+        const rangeStart =
+          orientation === "horizontal" ? Math.min(a.x, b.x) : Math.min(a.y, b.y)
+        const rangeEnd =
+          orientation === "horizontal" ? Math.max(a.x, b.x) : Math.max(a.y, b.y)
+        const span = rangeEnd - rangeStart
+        if (span < EPS) continue
+
+        segments.push({
+          traceIndex,
+          segmentIndex,
+          orientation,
+          axisCoord: orientation === "horizontal" ? a.y : a.x,
+          rangeStart,
+          rangeEnd,
+          canMove: segmentIndex > 0 && segmentIndex + 1 < lastPointIndex,
+          span,
+        })
+      }
+    }
+
+    return segments
+  }
+
+  private applySegmentMove(segment: SegmentRef, targetCoord: number): boolean {
+    if (!segment.canMove) return false
+    if (Math.abs(segment.axisCoord - targetCoord) < EPS) return false
+
+    const trace = this.outputTraces[segment.traceIndex]!
+    const nextTracePath = trace.tracePath.map((point) => ({ ...point }))
+    const startPoint = nextTracePath[segment.segmentIndex]!
+    const endPoint = nextTracePath[segment.segmentIndex + 1]!
+
+    if (segment.orientation === "horizontal") {
+      startPoint.y = targetCoord
+      endPoint.y = targetCoord
+    } else {
+      startPoint.x = targetCoord
+      endPoint.x = targetCoord
+    }
+
+    this.outputTraces[segment.traceIndex] = {
+      ...trace,
+      tracePath: normalizePath(nextTracePath),
+    }
+
+    return true
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics = visualizeInputProblem(this.inputProblem, {
+      chipAlpha: 0.1,
+      connectionAlpha: 0.1,
+    })
+
+    for (const trace of this.outputTraces) {
+      graphics.lines!.push({
+        points: trace.tracePath,
+        strokeColor: "green",
+      })
+    }
+
+    return graphics
+  }
+}
+
+const areSegmentsCompatible = (
+  a: SegmentRef,
+  b: SegmentRef,
+  mergeDistance: number,
+): boolean => {
+  if (a.traceIndex === b.traceIndex) return false
+  if (a.orientation !== b.orientation) return false
+  if (Math.abs(a.axisCoord - b.axisCoord) > mergeDistance + EPS) return false
+
+  const overlap =
+    Math.min(a.rangeEnd, b.rangeEnd) - Math.max(a.rangeStart, b.rangeStart)
+  return overlap > EPS
+}
+
+const getSegmentKey = (segment: SegmentRef) =>
+  `${segment.traceIndex}:${segment.segmentIndex}:${segment.orientation}`
+
+const normalizePath = (path: Point[]): Point[] => {
+  const deduped: Point[] = []
+
+  for (const point of path) {
+    const previous = deduped[deduped.length - 1]
+    if (
+      previous &&
+      Math.abs(previous.x - point.x) < EPS &&
+      Math.abs(previous.y - point.y) < EPS
+    ) {
+      continue
+    }
+    deduped.push({ ...point })
+  }
+
+  if (deduped.length <= 2) return deduped
+
+  const simplified = simplifyPath(deduped)
+  const finalPath: Point[] = []
+
+  for (const point of simplified) {
+    const previous = finalPath[finalPath.length - 1]
+    if (
+      previous &&
+      Math.abs(previous.x - point.x) < EPS &&
+      Math.abs(previous.y - point.y) < EPS
+    ) {
+      continue
+    }
+    finalPath.push({ ...point })
+  }
+
+  return finalPath
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -20,6 +20,7 @@ import { expandChipsToFitPins } from "./expandChipsToFitPins"
 import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import { SameNetSegmentMergingSolver } from "../SameNetSegmentMergingSolver/SameNetSegmentMergingSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -69,6 +70,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetSegmentMergingSolver?: SameNetSegmentMergingSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -207,10 +209,23 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetSegmentMergingSolver",
+      SameNetSegmentMergingSolver,
+      (instance) => [
+        {
+          inputProblem: instance.inputProblem,
+          allTraces:
+            instance.traceCleanupSolver?.getOutput().traces ??
+            instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetSegmentMergingSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/solvers/SameNetSegmentMergingSolver/SameNetSegmentMergingSolver.test.ts
+++ b/tests/solvers/SameNetSegmentMergingSolver/SameNetSegmentMergingSolver.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test"
+import { SameNetSegmentMergingSolver } from "lib/solvers/SameNetSegmentMergingSolver/SameNetSegmentMergingSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const inputProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+const createTrace = (
+  id: string,
+  netId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath => ({
+  mspPairId: id,
+  dcConnNetId: netId,
+  globalConnNetId: netId,
+  pins: [
+    { pinId: `${id}-a`, chipId: "A", x: tracePath[0]!.x, y: tracePath[0]!.y },
+    {
+      pinId: `${id}-b`,
+      chipId: "B",
+      x: tracePath[tracePath.length - 1]!.x,
+      y: tracePath[tracePath.length - 1]!.y,
+    },
+  ],
+  tracePath,
+  mspConnectionPairIds: [id],
+  pinIds: [`${id}-a`, `${id}-b`],
+})
+
+test("SameNetSegmentMergingSolver snaps overlapping internal same-net segments together", () => {
+  const solver = new SameNetSegmentMergingSolver({
+    inputProblem,
+    allTraces: [
+      createTrace("t1", "net-1", [
+        { x: -3, y: 0 },
+        { x: -2, y: 0 },
+        { x: -2, y: 1 },
+        { x: 2, y: 1 },
+        { x: 2, y: 0 },
+        { x: 3, y: 0 },
+      ]),
+      createTrace("t2", "net-1", [
+        { x: -3, y: 0.2 },
+        { x: -1, y: 0.2 },
+        { x: -1, y: 1.12 },
+        { x: 1, y: 1.12 },
+        { x: 1, y: 0.2 },
+        { x: 3, y: 0.2 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traces = solver.getOutput().traces
+  expect(traces[0]!.tracePath[2]!.y).toBeCloseTo(1.04, 5)
+  expect(traces[0]!.tracePath[3]!.y).toBeCloseTo(1.04, 5)
+  expect(traces[1]!.tracePath[2]!.y).toBeCloseTo(1.04, 5)
+  expect(traces[1]!.tracePath[3]!.y).toBeCloseTo(1.04, 5)
+})
+
+test("SameNetSegmentMergingSolver preserves anchored endpoint segments and only snaps the movable trace", () => {
+  const solver = new SameNetSegmentMergingSolver({
+    inputProblem,
+    allTraces: [
+      createTrace("t1", "net-1", [
+        { x: -3, y: 1 },
+        { x: 3, y: 1 },
+        { x: 3, y: 0 },
+      ]),
+      createTrace("t2", "net-1", [
+        { x: -3, y: 0 },
+        { x: -2, y: 0 },
+        { x: -2, y: 1.1 },
+        { x: 2, y: 1.1 },
+        { x: 2, y: 0 },
+        { x: 3, y: 0 },
+      ]),
+      createTrace("t3", "net-2", [
+        { x: -3, y: 0 },
+        { x: -2, y: 0 },
+        { x: -2, y: 1.08 },
+        { x: 2, y: 1.08 },
+        { x: 2, y: 0 },
+        { x: 3, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traces = solver.getOutput().traces
+  expect(traces[0]!.tracePath[0]!.y).toBe(1)
+  expect(traces[0]!.tracePath[1]!.y).toBe(1)
+  expect(traces[1]!.tracePath[2]!.y).toBeCloseTo(1, 5)
+  expect(traces[1]!.tracePath[3]!.y).toBeCloseTo(1, 5)
+  expect(traces[2]!.tracePath[2]!.y).toBeCloseTo(1.08, 5)
+  expect(traces[2]!.tracePath[3]!.y).toBeCloseTo(1.08, 5)
+})


### PR DESCRIPTION
Hey @seveibar! Daniel (Dali) here. I've been following the solver's progress and decided to jump in on this trace-merging issue...

/claim #29

This PR adds a dedicated `SameNetSegmentMergingSolver` phase after `TraceCleanupSolver` and before the final `NetLabelPlacementSolver` pass.

What it does:
- groups solved traces by `globalConnNetId`
- scans horizontal and vertical segments separately so only truly parallel segments are considered
- treats endpoint segments as anchors, so pin-attached geometry stays fixed while nearby internal same-net segments can snap onto it
- clusters remaining movable same-net segments when they overlap along their run and are within a small merge threshold (`0.15`), then snaps them onto a shared weighted axis
- normalizes each updated path after every move so duplicate points and accidental collinear leftovers are removed before the next pass

I kept the phase intentionally tight: it only merges overlapping parallel spans on the same net, and it refuses to move endpoint segments. That gives the pipeline a post-cleanup consolidation step without rewriting routed connectivity or disturbing pin exits.

Validation:
- `npx bun test tests/solvers/SameNetSegmentMergingSolver/SameNetSegmentMergingSolver.test.ts tests/examples/example29.test.ts tests/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver_repro01.test.ts`
- `npx -p typescript@^5 tsc --noEmit`

Best,
Dali
