### PR TITLE
fix: remove duplicate points causing extra trace lines in post-processing

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,8 +4,23 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+/**
+ * Remove consecutive duplicate points (zero-length segments) from a path.
+ */
+export const removeDuplicatePoints = (path: Point[]): Point[] => {
+  if (path.length === 0) return path
+  const result: Point[] = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    const prev = result[result.length - 1]
+    if (prev.x !== path[i].x || prev.y !== path[i].y) {
+      result.push(path[i])
+    }
+  }
+  return result
+}
+
 export const simplifyPath = (path: Point[]): Point[] => {
-  if (path.length < 3) return path
+  if (path.length < 3) return removeDuplicatePoints(path)
   const newPath: Point[] = [path[0]]
   for (let i = 1; i < path.length - 1; i++) {
     const p1 = newPath[newPath.length - 1]
@@ -37,5 +52,5 @@ export const simplifyPath = (path: Point[]): Point[] => {
   }
   finalPath.push(newPath[newPath.length - 1])
 
-  return finalPath
+  return removeDuplicatePoints(finalPath)
 }

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -23,6 +23,7 @@ import { visualizeTightRectangle } from "../visualizeTightRectangle"
 import { visualizeCandidates } from "./visualizeCandidates"
 import { mergeGraphicsObjects } from "../mergeGraphicsObjects"
 import { visualizeCollision } from "./visualizeCollision"
+import { removeDuplicatePoints } from "../simplifyPath"
 
 /**
  * Defines the input structure for the UntangleTraceSubsolver.
@@ -258,11 +259,11 @@ export class UntangleTraceSubsolver extends BaseSolver {
           p.x === this.currentLShape!.p2.x && p.y === this.currentLShape!.p2.y,
       )
       if (p2Index !== -1) {
-        const newTracePath = [
+        const newTracePath = removeDuplicatePoints([
           ...originalTrace.tracePath.slice(0, p2Index),
           ...bestRoute,
           ...originalTrace.tracePath.slice(p2Index + 1),
-        ]
+        ])
         this.input.allTraces[traceIndex] = {
           ...originalTrace,
           tracePath: newTracePath,


### PR DESCRIPTION
## Summary
Fixes extra/overlapping trace lines caused by consecutive duplicate points (zero-length segments) in post-processing.

**Root cause:** 
1. `simplifyPath()` merged collinear segments but did not remove consecutive duplicate points
2. `_applyBestRoute()` in `UntangleTraceSubsolver` produced duplicate points when splicing rerouted segments

**Fix:**
- Added `removeDuplicatePoints()` in `simplifyPath.ts` to strip consecutive identical points
- Applied dedup at splice site in `UntangleTraceSubsolver._applyBestRoute()`

Closes #78

## Test plan
- [x] All 49 tests pass (0 failures)
- [x] No regressions in existing trace rendering