### PR TITLE
fix: merge close same-net parallel trace segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,6 +20,7 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { mergeCloseSameNetSegments } from "./mergeCloseSameNetSegments"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "merging_same_net_segments"
   | "untangling_traces"
 
 /**
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "merging_same_net_segments":
+        this._runMergeSameNetSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +113,17 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "merging_same_net_segments"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runMergeSameNetSegmentsStep() {
+    this.outputTraces = mergeCloseSameNetSegments(this.outputTraces)
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/mergeCloseSameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeCloseSameNetSegments.ts
@@ -23,7 +23,10 @@ const overlaps1D = (
   b1: number,
   b2: number,
   eps = EPS,
-) => Math.min(Math.max(a1, a2), Math.max(b1, b2)) - Math.max(Math.min(a1, a2), Math.min(b1, b2)) > eps
+) =>
+  Math.min(Math.max(a1, a2), Math.max(b1, b2)) -
+    Math.max(Math.min(a1, a2), Math.min(b1, b2)) >
+  eps
 
 const buildInternalSegmentRefs = (traces: SolvedTracePath[]): SegmentRef[] => {
   const refs: SegmentRef[] = []
@@ -112,8 +115,10 @@ export const mergeCloseSameNetSegments = (
           continue
         }
         if (a.orientation !== b.orientation) continue
-        if (a.pathIndex === b.pathIndex && a.segmentIndex === b.segmentIndex) continue
-        if (!overlaps1D(a.rangeStart, a.rangeEnd, b.rangeStart, b.rangeEnd)) continue
+        if (a.pathIndex === b.pathIndex && a.segmentIndex === b.segmentIndex)
+          continue
+        if (!overlaps1D(a.rangeStart, a.rangeEnd, b.rangeStart, b.rangeEnd))
+          continue
 
         const distance = Math.abs(a.coord - b.coord)
         if (distance < EPS || distance > mergeDistance) continue

--- a/lib/solvers/TraceCleanupSolver/mergeCloseSameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeCloseSameNetSegments.ts
@@ -1,0 +1,145 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+type SegmentRef = {
+  pathIndex: number
+  segmentIndex: number
+  orientation: "horizontal" | "vertical"
+  coord: number
+  rangeStart: number
+  rangeEnd: number
+}
+
+const EPS = 1e-6
+const DEFAULT_MERGE_DISTANCE = 0.12
+
+const isHorizontal = (a: Point, b: Point) => Math.abs(a.y - b.y) < EPS
+const isVertical = (a: Point, b: Point) => Math.abs(a.x - b.x) < EPS
+
+const overlaps1D = (
+  a1: number,
+  a2: number,
+  b1: number,
+  b2: number,
+  eps = EPS,
+) => Math.min(Math.max(a1, a2), Math.max(b1, b2)) - Math.max(Math.min(a1, a2), Math.min(b1, b2)) > eps
+
+const buildInternalSegmentRefs = (traces: SolvedTracePath[]): SegmentRef[] => {
+  const refs: SegmentRef[] = []
+
+  traces.forEach((trace, pathIndex) => {
+    const pts = trace.tracePath
+    for (let i = 1; i < pts.length - 2; i++) {
+      const p1 = pts[i]!
+      const p2 = pts[i + 1]!
+      if (isHorizontal(p1, p2)) {
+        refs.push({
+          pathIndex,
+          segmentIndex: i,
+          orientation: "horizontal",
+          coord: p1.y,
+          rangeStart: Math.min(p1.x, p2.x),
+          rangeEnd: Math.max(p1.x, p2.x),
+        })
+      } else if (isVertical(p1, p2)) {
+        refs.push({
+          pathIndex,
+          segmentIndex: i,
+          orientation: "vertical",
+          coord: p1.x,
+          rangeStart: Math.min(p1.y, p2.y),
+          rangeEnd: Math.max(p1.y, p2.y),
+        })
+      }
+    }
+  })
+
+  return refs
+}
+
+const shiftSegmentToCoord = (
+  trace: SolvedTracePath,
+  segmentIndex: number,
+  orientation: "horizontal" | "vertical",
+  targetCoord: number,
+): SolvedTracePath => {
+  const next = {
+    ...trace,
+    tracePath: trace.tracePath.map((p) => ({ ...p })),
+  }
+
+  const p1 = next.tracePath[segmentIndex]!
+  const p2 = next.tracePath[segmentIndex + 1]!
+
+  if (orientation === "horizontal") {
+    p1.y = targetCoord
+    p2.y = targetCoord
+  } else {
+    p1.x = targetCoord
+    p2.x = targetCoord
+  }
+
+  next.tracePath = simplifyPath(next.tracePath)
+  return next
+}
+
+export const mergeCloseSameNetSegments = (
+  traces: SolvedTracePath[],
+  opts?: { mergeDistance?: number; maxPasses?: number },
+): SolvedTracePath[] => {
+  const mergeDistance = opts?.mergeDistance ?? DEFAULT_MERGE_DISTANCE
+  const maxPasses = opts?.maxPasses ?? 3
+
+  let current = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((p) => ({ ...p })),
+  }))
+
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let changed = false
+    const refs = buildInternalSegmentRefs(current)
+
+    outer: for (let i = 0; i < refs.length; i++) {
+      for (let j = i + 1; j < refs.length; j++) {
+        const a = refs[i]!
+        const b = refs[j]!
+
+        if (
+          current[a.pathIndex]!.globalConnNetId !==
+          current[b.pathIndex]!.globalConnNetId
+        ) {
+          continue
+        }
+        if (a.orientation !== b.orientation) continue
+        if (a.pathIndex === b.pathIndex && a.segmentIndex === b.segmentIndex) continue
+        if (!overlaps1D(a.rangeStart, a.rangeEnd, b.rangeStart, b.rangeEnd)) continue
+
+        const distance = Math.abs(a.coord - b.coord)
+        if (distance < EPS || distance > mergeDistance) continue
+
+        const targetCoord = (a.coord + b.coord) / 2
+
+        current[a.pathIndex] = shiftSegmentToCoord(
+          current[a.pathIndex]!,
+          a.segmentIndex,
+          a.orientation,
+          targetCoord,
+        )
+        current[b.pathIndex] = shiftSegmentToCoord(
+          current[b.pathIndex]!,
+          b.segmentIndex,
+          b.orientation,
+          targetCoord,
+        )
+
+        changed = true
+        break outer
+      }
+    }
+
+    if (!changed) break
+  }
+
+  return current
+}

--- a/tests/solvers/TraceCleanupSolver/mergeCloseSameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeCloseSameNetSegments.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { mergeCloseSameNetSegments } from "lib/solvers/TraceCleanupSolver/mergeCloseSameNetSegments"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [] as any,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+  }) as unknown as SolvedTracePath
+
+describe("mergeCloseSameNetSegments", () => {
+  test("merges close horizontal internal segments on the same net", () => {
+    const traces = [
+      makeTrace("a", "N1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 0 },
+      ]),
+      makeTrace("b", "N1", [
+        { x: 0, y: 0.08 },
+        { x: 0, y: 1.08 },
+        { x: 4, y: 1.08 },
+        { x: 4, y: 0.08 },
+      ]),
+    ]
+
+    const result = mergeCloseSameNetSegments(traces)
+
+    expect(result[0]!.tracePath[1]!.y).toBeCloseTo(1.04, 6)
+    expect(result[0]!.tracePath[2]!.y).toBeCloseTo(1.04, 6)
+    expect(result[1]!.tracePath[1]!.y).toBeCloseTo(1.04, 6)
+    expect(result[1]!.tracePath[2]!.y).toBeCloseTo(1.04, 6)
+  })
+
+  test("merges close vertical internal segments on the same net", () => {
+    const traces = [
+      makeTrace("a", "N1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 4 },
+        { x: 0, y: 4 },
+      ]),
+      makeTrace("b", "N1", [
+        { x: 0.08, y: 0 },
+        { x: 1.08, y: 0 },
+        { x: 1.08, y: 4 },
+        { x: 0.08, y: 4 },
+      ]),
+    ]
+
+    const result = mergeCloseSameNetSegments(traces)
+
+    expect(result[0]!.tracePath[1]!.x).toBeCloseTo(1.04, 6)
+    expect(result[0]!.tracePath[2]!.x).toBeCloseTo(1.04, 6)
+    expect(result[1]!.tracePath[1]!.x).toBeCloseTo(1.04, 6)
+    expect(result[1]!.tracePath[2]!.x).toBeCloseTo(1.04, 6)
+  })
+
+  test("does not merge segments from different nets", () => {
+    const traces = [
+      makeTrace("a", "N1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 0 },
+      ]),
+      makeTrace("b", "N2", [
+        { x: 0, y: 0.08 },
+        { x: 0, y: 1.08 },
+        { x: 4, y: 1.08 },
+        { x: 4, y: 0.08 },
+      ]),
+    ]
+
+    const result = mergeCloseSameNetSegments(traces)
+
+    expect(result[0]!.tracePath[1]!.y).toBe(1)
+    expect(result[1]!.tracePath[1]!.y).toBe(1.08)
+  })
+
+  test("does not merge when distance exceeds threshold", () => {
+    const traces = [
+      makeTrace("a", "N1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 0 },
+      ]),
+      makeTrace("b", "N1", [
+        { x: 0, y: 0.4 },
+        { x: 0, y: 1.4 },
+        { x: 4, y: 1.4 },
+        { x: 4, y: 0.4 },
+      ]),
+    ]
+
+    const result = mergeCloseSameNetSegments(traces)
+
+    expect(result[0]!.tracePath[1]!.y).toBe(1)
+    expect(result[1]!.tracePath[1]!.y).toBe(1.4)
+  })
+
+  test("does not merge non-overlapping parallel segments", () => {
+    const traces = [
+      makeTrace("a", "N1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 2, y: 1 },
+        { x: 2, y: 0 },
+      ]),
+      makeTrace("b", "N1", [
+        { x: 3, y: 0.08 },
+        { x: 3, y: 1.08 },
+        { x: 5, y: 1.08 },
+        { x: 5, y: 0.08 },
+      ]),
+    ]
+
+    const result = mergeCloseSameNetSegments(traces)
+
+    expect(result[0]!.tracePath[1]!.y).toBe(1)
+    expect(result[1]!.tracePath[1]!.y).toBe(1.08)
+  })
+})


### PR DESCRIPTION
## Summary\n- add a final TraceCleanup pass that merges close, overlapping, parallel **internal** segments when they belong to the same net\n- keep the change low-risk by skipping terminal segments and requiring both 1D overlap and a small merge-distance threshold\n- add focused tests covering horizontal/vertical merge and the key non-merge cases\n\n## Why\nAfter , same-net traces can end up visually split onto nearby Y/X coordinates. This patch snaps those close internal segments back together without touching different nets or distant/non-overlapping segments.\n\n## Validation\n- \n- bun test v1.3.11 (af24e281)
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 1 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 2 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 2 sub-solvers.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 1 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 1 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 1 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 1 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 1 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 2 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 0 sub-solvers.
All sub-solvers finished.
Dispatch phase complete. Created 1 sub-solvers.
All sub-solvers finished.\n\n## Claim\n/claim #34