### PR TITLE
fix: remove duplicate consecutive points causing extra trace lines in post-processing

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,7 +4,31 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+/**
+ * Removes consecutive duplicate points (zero-length segments) from a path.
+ *
+ * These arise when rerouted segments are spliced together at the same
+ * coordinate — e.g. when _applyBestRoute concatenates path slices and the
+ * junction point appears twice. Zero-length segments render as tiny artifacts
+ * in the schematic output.
+ */
+export const removeDuplicateConsecutivePoints = (path: Point[]): Point[] => {
+  if (path.length === 0) return path
+  const result: Point[] = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    const prev = result[result.length - 1]
+    if (prev.x !== path[i].x || prev.y !== path[i].y) {
+      result.push(path[i])
+    }
+  }
+  return result
+}
+
 export const simplifyPath = (path: Point[]): Point[] => {
+  // Remove duplicate consecutive points (zero-length segments) first so the
+  // collinear-merge pass below doesn't see misleading direction changes.
+  path = removeDuplicateConsecutivePoints(path)
+
   if (path.length < 3) return path
   const newPath: Point[] = [path[0]]
   for (let i = 1; i < path.length - 1; i++) {

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -23,6 +23,7 @@ import { visualizeTightRectangle } from "../visualizeTightRectangle"
 import { visualizeCandidates } from "./visualizeCandidates"
 import { mergeGraphicsObjects } from "../mergeGraphicsObjects"
 import { visualizeCollision } from "./visualizeCollision"
+import { removeDuplicateConsecutivePoints } from "../simplifyPath"
 
 /**
  * Defines the input structure for the UntangleTraceSubsolver.
@@ -258,11 +259,14 @@ export class UntangleTraceSubsolver extends BaseSolver {
           p.x === this.currentLShape!.p2.x && p.y === this.currentLShape!.p2.y,
       )
       if (p2Index !== -1) {
-        const newTracePath = [
+        // Splice the rerouted segment into the trace path. The slice boundaries
+        // may share a coordinate with the first/last point of bestRoute, so we
+        // remove any duplicate consecutive points that arise at the junctions.
+        const newTracePath = removeDuplicateConsecutivePoints([
           ...originalTrace.tracePath.slice(0, p2Index),
           ...bestRoute,
           ...originalTrace.tracePath.slice(p2Index + 1),
-        ]
+        ])
         this.input.allTraces[traceIndex] = {
           ...originalTrace,
           tracePath: newTracePath,
@@ -280,18 +284,6 @@ export class UntangleTraceSubsolver extends BaseSolver {
   }
 
   override visualize(): GraphicsObject {
-    // console.log("VISUALIZE STATE:", {
-    //   step: this.lShapeProcessingStep,
-    //   vizMode: this.visualizationMode,
-    //   lShape: this.currentLShape?.traceId,
-    //   rectIdx: this.currentRectangleIndex,
-    //   rectCount: this.rectangleCandidates.length,
-    //   tightRect: this.tightRectangle,
-    //   pathIdx: this.currentCandidateIndex,
-    //   pathCount: this.candidates.length,
-    //   lastCollision: this.lastCollision?.isColliding,
-    // })
-
     switch (this.visualizationMode) {
       case "l_shapes":
         return visualizeLSapes(this.lShapesToProcess)
@@ -329,7 +321,7 @@ export class UntangleTraceSubsolver extends BaseSolver {
           for (let i = 0; i < trace.tracePath.length - 1; i++) {
             allTracesGraphics.lines!.push({
               points: [trace.tracePath[i], trace.tracePath[i + 1]],
-              strokeColor: "#ccc", // Light gray for other traces
+              strokeColor: "#ccc",
             })
           }
         }

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -284,6 +284,18 @@ export class UntangleTraceSubsolver extends BaseSolver {
   }
 
   override visualize(): GraphicsObject {
+    // console.log("VISUALIZE STATE:", {
+    //   step: this.lShapeProcessingStep,
+    //   vizMode: this.visualizationMode,
+    //   lShape: this.currentLShape?.traceId,
+    //   rectIdx: this.currentRectangleIndex,
+    //   rectCount: this.rectangleCandidates.length,
+    //   tightRect: this.tightRectangle,
+    //   pathIdx: this.currentCandidateIndex,
+    //   pathCount: this.candidates.length,
+    //   lastCollision: this.lastCollision?.isColliding,
+    // })
+
     switch (this.visualizationMode) {
       case "l_shapes":
         return visualizeLSapes(this.lShapesToProcess)
@@ -321,7 +333,7 @@ export class UntangleTraceSubsolver extends BaseSolver {
           for (let i = 0; i < trace.tracePath.length - 1; i++) {
             allTracesGraphics.lines!.push({
               points: [trace.tracePath[i], trace.tracePath[i + 1]],
-              strokeColor: "#ccc",
+              strokeColor: "#ccc", // Light gray for other traces
             })
           }
         }

--- a/tests/functions/simplifyPath.test.ts
+++ b/tests/functions/simplifyPath.test.ts
@@ -1,7 +1,7 @@
-import { describe, test, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import {
-  simplifyPath,
   removeDuplicateConsecutivePoints,
+  simplifyPath,
 } from "lib/solvers/TraceCleanupSolver/simplifyPath"
 
 describe("removeDuplicateConsecutivePoints", () => {
@@ -70,8 +70,9 @@ describe("simplifyPath", () => {
     ])
   })
 
-  test("removes duplicate consecutive points before collinear merge", () => {
-    // Duplicate junction from _applyBestRoute splice
+  test("removes duplicate junction point introduced by _applyBestRoute splice", () => {
+    // When _applyBestRoute splices a segment, the endpoint of the left slice
+    // can equal the first point of bestRoute, producing a zero-length segment.
     const path = [
       { x: 0, y: 0 },
       { x: 1, y: 0 },
@@ -80,10 +81,14 @@ describe("simplifyPath", () => {
       { x: 2, y: 1 },
     ]
     const result = simplifyPath(path)
-    // After dedup: [0,0]-[1,0]-[1,1]-[2,1] — an L-shape, no collinear removal
-    expect(result).not.toContainEqual({ x: 1, y: 0 })
-    // Final shape should be [0,0]-[1,0]-[1,1]-[2,1] or simplified
+    // Duplicate removed, path length should be smaller than input
     expect(result.length).toBeLessThan(path.length)
+    // No consecutive duplicates in the output
+    for (let i = 1; i < result.length; i++) {
+      expect(
+        result[i].x !== result[i - 1].x || result[i].y !== result[i - 1].y,
+      ).toBe(true)
+    }
   })
 
   test("path shorter than 3 points is returned as-is", () => {

--- a/tests/functions/simplifyPath.test.ts
+++ b/tests/functions/simplifyPath.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from "bun:test"
+import {
+  simplifyPath,
+  removeDuplicateConsecutivePoints,
+} from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+describe("removeDuplicateConsecutivePoints", () => {
+  test("removes consecutive duplicates", () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 0 }, // duplicate
+      { x: 2, y: 0 },
+    ]
+    const result = removeDuplicateConsecutivePoints(path)
+    expect(result).toEqual([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ])
+  })
+
+  test("keeps non-consecutive duplicates", () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 0 }, // same as first but not consecutive
+    ]
+    const result = removeDuplicateConsecutivePoints(path)
+    expect(result).toEqual(path)
+  })
+
+  test("handles empty path", () => {
+    expect(removeDuplicateConsecutivePoints([])).toEqual([])
+  })
+
+  test("handles single point", () => {
+    const path = [{ x: 1, y: 2 }]
+    expect(removeDuplicateConsecutivePoints(path)).toEqual(path)
+  })
+
+  test("removes multiple consecutive duplicates", () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ]
+    const result = removeDuplicateConsecutivePoints(path)
+    expect(result).toEqual([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ])
+  })
+})
+
+describe("simplifyPath", () => {
+  test("removes collinear points on horizontal segment", () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ]
+    const result = simplifyPath(path)
+    expect(result).toEqual([
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+    ])
+  })
+
+  test("removes duplicate consecutive points before collinear merge", () => {
+    // Duplicate junction from _applyBestRoute splice
+    const path = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 0 }, // duplicate at splice junction
+      { x: 1, y: 1 },
+      { x: 2, y: 1 },
+    ]
+    const result = simplifyPath(path)
+    // After dedup: [0,0]-[1,0]-[1,1]-[2,1] — an L-shape, no collinear removal
+    expect(result).not.toContainEqual({ x: 1, y: 0 })
+    // Final shape should be [0,0]-[1,0]-[1,1]-[2,1] or simplified
+    expect(result.length).toBeLessThan(path.length)
+  })
+
+  test("path shorter than 3 points is returned as-is", () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ]
+    expect(simplifyPath(path)).toEqual(path)
+  })
+})


### PR DESCRIPTION
## Problem\n\nExtra zero-length trace segments appear in the schematic output when `_applyBestRoute()` splices a rerouted segment into an existing trace path. The splice produces duplicate consecutive coordinates at the junction (the last point of the left slice equals the first point of `bestRoute`), which renders as a tiny extra line artifact.\n\n`simplifyPath()` also lacked protection: if duplicate consecutive points reached the collinear-merge pass, the direction test would see a zero-length segment and behave incorrectly.\n\n## Fix\n\nAdded `removeDuplicateConsecutivePoints()` to `simplifyPath.ts` (also exported for direct use):\n- **`simplifyPath`** now calls it as a pre-pass before the collinear-merge loops, so zero-length segments are stripped regardless of origin.\n- **`UntangleTraceSubsolver._applyBestRoute`** wraps the spliced path with `removeDuplicateConsecutivePoints` at the splice site, fixing the root cause.\n\n## Files\n\n| File | Change |\n|------|--------|\n| `lib/solvers/TraceCleanupSolver/simplifyPath.ts` | Added exported `removeDuplicateConsecutivePoints`; call it at start of `simplifyPath` |\n| `lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts` | Import and apply `removeDuplicateConsecutivePoints` in `_applyBestRoute` |\n| `tests/functions/simplifyPath.test.ts` | New unit tests for `removeDuplicateConsecutivePoints` and updated `simplifyPath` behaviour |\n\n/claim #78