### PR TITLE
fix: skip wire routing for net-label-only nets (issue #79)

### DIFF
--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -116,7 +116,27 @@ export class LongDistancePairSolver extends BaseSolver {
         }
       }
     }
-    this.queuedCandidatePairs = candidatePairs
+    // Filter out nets handled exclusively via net label orientations
+    // to avoid spurious extra trace lines (issue #79)
+    const directlyWiredPinIds = new Set<PinId>()
+    for (const dc of inputProblem.directConnections) {
+      for (const pid of dc.pinIds) {
+        directlyWiredPinIds.add(pid)
+      }
+    }
+    const netLabelOrientedNets = new Set<string>(
+      Object.keys(inputProblem.availableNetLabelOrientations ?? {}),
+    )
+    this.queuedCandidatePairs = candidatePairs.filter(([p1, p2]) => {
+      const netId1 = this.netConnMap.getNetConnectedToId(p1.pinId)
+      if (!netId1) return false
+      const connectedIds = this.netConnMap.getIdsConnectedToNet(netId1) as string[]
+      if (!connectedIds.some((id) => directlyWiredPinIds.has(id)) &&
+          connectedIds.some((id) => netLabelOrientedNets.has(id))) {
+        return false
+      }
+      return true
+    })
   }
 
   override getConstructorParams() {

--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -74,7 +74,23 @@ export class MspConnectionPairSolver extends BaseSolver {
       }
     }
 
-    this.queuedDcNetIds = Object.keys(netConnMap.netMap)
+    // Only queue nets that need wire traces.
+    // Nets handled exclusively via net label orientations get spurious extra
+    // trace lines - skip them so NetLabelPlacementSolver handles them instead (issue #79).
+    const directlyWiredPinIds = new Set<string>()
+    for (const dc of inputProblem.directConnections) {
+      for (const pid of dc.pinIds) {
+        directlyWiredPinIds.add(pid)
+      }
+    }
+    const netLabelOrientedNets = new Set<string>(
+      Object.keys(inputProblem.availableNetLabelOrientations ?? {}),
+    )
+    this.queuedDcNetIds = Object.keys(netConnMap.netMap).filter((netId) => {
+      const connectedIds = netConnMap.getIdsConnectedToNet(netId) as string[]
+      if (connectedIds.some((id) => directlyWiredPinIds.has(id))) return true
+      return !connectedIds.some((id) => netLabelOrientedNets.has(id))
+    })
   }
 
   override getConstructorParams(): ConstructorParameters<


### PR DESCRIPTION
## Fix for Issue #79: Fix extra net label in repro61, or remove trace

### Problem
Nets handled exclusively via net label connections (no direct wire connections) were getting spurious extra trace lines. The MSP and LongDistancePair solvers were routing wires for nets that should only have net labels.

### Solution
Filter nets from the routing queue if they have no direct wire connections AND have net label orientations configured. NetLabelPlacementSolver will place the net labels instead of routing wire traces.

### Changes
- `lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts`: Filter queuedDcNetIds
- `lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts`: Filter queuedCandidatePairs

### Testing
Validated against issue #79 test case.

Fixes #79

/claim #79