### PR TITLE
fix: remove extra trace lines in post-processing step (issue #78)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -19,6 +19,7 @@ interface TraceCleanupSolverInput {
 }
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
+import { removeNetSegmentDuplicates } from "./removeNetSegmentDuplicates"
 import { is4PointRectangle } from "./is4PointRectangle"
 
 /**
@@ -148,7 +149,7 @@ export class TraceCleanupSolver extends BaseSolver {
 
   getOutput() {
     return {
-      traces: this.outputTraces,
+      traces: removeNetSegmentDuplicates(this.outputTraces),
     }
   }
 

--- a/lib/solvers/TraceCleanupSolver/removeNetSegmentDuplicates.ts
+++ b/lib/solvers/TraceCleanupSolver/removeNetSegmentDuplicates.ts
@@ -1,0 +1,40 @@
+/**
+ * Removes duplicate trace segments from the same net.
+ * When multiple MSP pairs in the same net are routed independently,
+ * they can share physical segments near common pin endpoints,
+ * creating visible duplicate trace lines in the schematic (#78).
+ */
+import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+export const removeNetSegmentDuplicates = (
+  traces: SolvedTracePath[],
+): SolvedTracePath[] => {
+  const netGroups = new Map<string, SolvedTracePath[]>()
+  
+  for (const trace of traces) {
+    const netId = trace.dcConnNetId || trace.globalConnNetId
+    if (!netGroups.has(netId)) netGroups.set(netId, [])
+    netGroups.get(netId)!.push(trace)
+  }
+  
+  const result: SolvedTracePath[] = []
+  
+  for (const [, netTraces] of netGroups) {
+    if (netTraces.length === 1) {
+      result.push(...netTraces)
+      continue
+    }
+    
+    // For multiple traces in same net, keep only unique paths
+    const seen = new Set<string>()
+    for (const trace of netTraces) {
+      const key = trace.tracePath.map(p => `${p.x},${p.y}`).join('|')
+      if (!seen.has(key)) {
+        seen.add(key)
+        result.push(trace)
+      }
+    }
+  }
+  
+  return result
+}

--- a/lib/solvers/TraceCleanupSolver/removeNetSegmentDuplicates.ts
+++ b/lib/solvers/TraceCleanupSolver/removeNetSegmentDuplicates.ts
@@ -1,40 +1,103 @@
-/**
- * Removes duplicate trace segments from the same net.
- * When multiple MSP pairs in the same net are routed independently,
- * they can share physical segments near common pin endpoints,
- * creating visible duplicate trace lines in the schematic (#78).
- */
-import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { Point } from "graphics-debug"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 
-export const removeNetSegmentDuplicates = (
+/**
+ * Create a canonical key for a line segment between two points.
+ * Direction-independent (A→B == B→A).
+ */
+function segmentKey(a: Point, b: Point): string {
+  const ax = Math.round(a.x * 1000) / 1000
+  const ay = Math.round(a.y * 1000) / 1000
+  const bx = Math.round(b.x * 1000) / 1000
+  const by = Math.round(b.y * 1000) / 1000
+
+  if (ax < bx || (ax === bx && ay < by)) {
+    return `${ax},${ay}-${bx},${by}`
+  }
+  return `${bx},${by}-${ax},${ay}`
+}
+
+/**
+ * Remove duplicate trace segments within the same net.
+ *
+ * When multiple MSP pairs in the same net share a pin, they get routed
+ * independently and produce overlapping segments near the shared pin.
+ * This trims duplicate segments from the start and end of later traces
+ * (where shared pins produce overlap), preserving path connectivity.
+ */
+export function removeNetSegmentDuplicates(
   traces: SolvedTracePath[],
-): SolvedTracePath[] => {
+): SolvedTracePath[] {
+  // Group traces by net
   const netGroups = new Map<string, SolvedTracePath[]>()
-  
   for (const trace of traces) {
-    const netId = trace.dcConnNetId || trace.globalConnNetId
-    if (!netGroups.has(netId)) netGroups.set(netId, [])
+    const netId = trace.globalConnNetId
+    if (!netGroups.has(netId)) {
+      netGroups.set(netId, [])
+    }
     netGroups.get(netId)!.push(trace)
   }
-  
+
   const result: SolvedTracePath[] = []
-  
-  for (const [, netTraces] of netGroups) {
-    if (netTraces.length === 1) {
-      result.push(...netTraces)
+  for (const [_netId, group] of netGroups) {
+    if (group.length <= 1) {
+      result.push(...group)
       continue
     }
-    
-    // For multiple traces in same net, keep only unique paths
-    const seen = new Set<string>()
-    for (const trace of netTraces) {
-      const key = trace.tracePath.map(p => `${p.x},${p.y}`).join('|')
-      if (!seen.has(key)) {
-        seen.add(key)
+
+    // First trace claims all its segments
+    const claimedSegments = new Set<string>()
+    const firstTrace = group[0]
+    for (let i = 1; i < firstTrace.tracePath.length; i++) {
+      claimedSegments.add(
+        segmentKey(firstTrace.tracePath[i - 1], firstTrace.tracePath[i]),
+      )
+    }
+    result.push(firstTrace)
+
+    // For subsequent traces, trim duplicate segments from the start and end
+    for (let t = 1; t < group.length; t++) {
+      const trace = group[t]
+      const path = trace.tracePath
+      if (path.length < 2) {
         result.push(trace)
+        continue
       }
+
+      // Trim duplicate segments from the start of the path
+      let startIdx = 0
+      while (startIdx < path.length - 1) {
+        const key = segmentKey(path[startIdx], path[startIdx + 1])
+        if (claimedSegments.has(key)) {
+          startIdx++
+        } else {
+          break
+        }
+      }
+
+      // Trim duplicate segments from the end of the path
+      let endIdx = path.length - 1
+      while (endIdx > startIdx) {
+        const key = segmentKey(path[endIdx - 1], path[endIdx])
+        if (claimedSegments.has(key)) {
+          endIdx--
+        } else {
+          break
+        }
+      }
+
+      // Claim the remaining segments
+      const trimmedPath = path.slice(startIdx, endIdx + 1)
+      for (let i = 1; i < trimmedPath.length; i++) {
+        claimedSegments.add(segmentKey(trimmedPath[i - 1], trimmedPath[i]))
+      }
+
+      result.push({
+        ...trace,
+        tracePath: trimmedPath.length >= 2 ? trimmedPath : path,
+      })
     }
   }
-  
+
   return result
 }

--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -39,3 +39,25 @@ export const simplifyPath = (path: Point[]): Point[] => {
 
   return finalPath
 }
+
+
+/**
+ * Removes consecutive duplicate points from a trace path.
+ * When a route is spliced into an existing path, the concatenation can
+ * produce consecutive duplicate points (same x,y) which render as
+ * spurious extra trace lines (issue #78).
+ */
+export const removeDuplicateConsecutivePoints = (
+  path: Array<{ x: number; y: number }>,
+): Array<{ x: number; y: number }> => {
+  if (path.length <= 1) return path;
+  const result: Array<{ x: number; y: number }> = [path[0]];
+  for (let i = 1; i < path.length; i++) {
+    const prev = result[result.length - 1];
+    const curr = path[i];
+    if (prev.x !== curr.x || prev.y !== curr.y) {
+      result.push(curr);
+    }
+  }
+  return result;
+};

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -4,6 +4,8 @@ import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicT
 import type { NetLabelPlacement } from "../../NetLabelPlacementSolver/NetLabelPlacementSolver"
 
 import { findAllLShapedTurns, type LShape } from "./findAllLShapedTurns"
+import { removeDuplicateConsecutivePoints } from "../simplifyPath"
+import { removeDuplicateConsecutivePoints } from "../simplifyPath"
 import { getTraceObstacles } from "./getTraceObstacles"
 import { findIntersectionsWithObstacles } from "./findIntersectionsWithObstacles"
 import { generateLShapeRerouteCandidates } from "./generateLShapeRerouteCandidates"
@@ -258,11 +260,13 @@ export class UntangleTraceSubsolver extends BaseSolver {
           p.x === this.currentLShape!.p2.x && p.y === this.currentLShape!.p2.y,
       )
       if (p2Index !== -1) {
-        const newTracePath = [
+        // Remove consecutive duplicate points that appear when splicing
+        // the rerouted segment. These render as spurious extra trace lines (#78).
+        const newTracePath = removeDuplicateConsecutivePoints([
           ...originalTrace.tracePath.slice(0, p2Index),
           ...bestRoute,
           ...originalTrace.tracePath.slice(p2Index + 1),
-        ]
+        ])
         this.input.allTraces[traceIndex] = {
           ...originalTrace,
           tracePath: newTracePath,

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -5,7 +5,6 @@ import type { NetLabelPlacement } from "../../NetLabelPlacementSolver/NetLabelPl
 
 import { findAllLShapedTurns, type LShape } from "./findAllLShapedTurns"
 import { removeDuplicateConsecutivePoints } from "../simplifyPath"
-import { removeDuplicateConsecutivePoints } from "../simplifyPath"
 import { getTraceObstacles } from "./getTraceObstacles"
 import { findIntersectionsWithObstacles } from "./findIntersectionsWithObstacles"
 import { generateLShapeRerouteCandidates } from "./generateLShapeRerouteCandidates"


### PR DESCRIPTION
## Fix for Issue #78: Remove extra trace lines in post-processing step

### Problem
When multiple MSP pairs in the same net share a pin, they get routed independently and produce overlapping segments near the shared pin. Additionally, when a route is spliced into an existing path, consecutive duplicate points can appear, rendering as spurious extra trace lines.

### Solution
1. removeDuplicateConsecutivePoints - Removes consecutive duplicate points from trace paths. When a route is spliced, the concatenation can produce consecutive duplicate points (same x,y) which render as spurious extra trace lines.

2. removeNetSegmentDuplicates - Removes duplicate trace segments within the same net. When multiple traces in the same net share pins, trims duplicate segments from the start and end of later traces while preserving path connectivity.

### Files Changed
- lib/solvers/TraceCleanupSolver/simplifyPath.ts - Added removeDuplicateConsecutivePoints
- lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts - Apply deduplication when splicing routes
- lib/solvers/TraceCleanupSolver/removeNetSegmentDuplicates.ts - New file for cross-trace deduplication
- lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts - Apply removeNetSegmentDuplicates at output

/claim #78