### PR TITLE
Merge close same-net trace segments (Issue #29 & #34)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -2,6 +2,7 @@ import type { InputProblem } from "lib/types/InputProblem"
 import type { GraphicsObject, Line } from "graphics-debug"
 import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
 import { balanceZShapes } from "./balanceZShapes"
+import { mergeCloseSegmentsForSingleTrace } from "./mergeCloseSegments"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
@@ -28,6 +29,7 @@ type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
+  | "merging_close_segments"
 
 /**
  * The TraceCleanupSolver is responsible for improving the aesthetics and readability of schematic traces.
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "merging_close_segments":
+        this._runMergeCloseSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +113,39 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "merging_close_segments"
+      this.traceIdQueue = Array.from(
+        this.input.allTraces.map((e) => e.mspPairId),
+      )
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runMergeCloseSegmentsStep() {
+    if (this.traceIdQueue.length === 0) {
+      this.solved = true
+      return
+    }
+
+    const targetMspConnectionPairId = this.traceIdQueue.shift()!
+    this.activeTraceId = targetMspConnectionPairId
+    const originalTrace = this.tracesMap.get(targetMspConnectionPairId)!
+
+    if (is4PointRectangle(originalTrace.tracePath)) {
+      return
+    }
+
+    const allTraces = Array.from(this.tracesMap.values())
+
+    const updatedTrace = mergeCloseSegmentsForSingleTrace({
+      targetMspConnectionPairId,
+      traces: allTraces,
+    })
+
+    this.tracesMap.set(targetMspConnectionPairId, updatedTrace)
+    this.outputTraces = Array.from(this.tracesMap.values())
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/mergeCloseSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeCloseSegments.ts
@@ -1,0 +1,190 @@
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { Point } from "@tscircuit/math-utils"
+
+/**
+ * 合并同一网络中挨得很近的线段，将它们对齐到相同的 X 或 Y 坐标
+ *
+ * 算法思路：
+ * 1. 按网络 ID（same-net）分组所有 trace
+ * 2. 对每条 trace，提取水平和垂直线段
+ * 3. 检测挨得很近的线段（距离小于阈值）
+ * 4. 将这些线段对齐到平均 X 或 Y 坐标
+ * 5. 重新连接 trace 的路径点
+ */
+
+interface LineSegment {
+  traceId: string
+  segmentIndex: number
+  p1: Point
+  p2: Point
+  isHorizontal: boolean
+  isVertical: boolean
+  fixedCoord: number // 水平线的 Y，垂直线的 X
+  otherCoord1: number
+  otherCoord2: number
+}
+
+interface MergeCloseSegmentsInput {
+  traces: SolvedTracePath[]
+  distanceThreshold?: number // 默认 0.5mm，接近就合并
+}
+
+export function mergeCloseSegments({
+  traces,
+  distanceThreshold = 0.5,
+}: MergeCloseSegmentsInput): SolvedTracePath[] {
+  const resultTraces = traces.map((t) => ({
+    ...t,
+    tracePath: [...t.tracePath],
+  }))
+
+  // 1. 按网络 ID 分组
+  const tracesByNetId: Record<string, SolvedTracePath[]> = {}
+  for (const trace of resultTraces) {
+    const netId = trace.netId || trace.mspPairId.split("-")[0]
+    if (!tracesByNetId[netId]) {
+      tracesByNetId[netId] = []
+    }
+    tracesByNetId[netId].push(trace)
+  }
+
+  // 2. 对每个网络处理
+  for (const netId of Object.keys(tracesByNetId)) {
+    const netTraces = tracesByNetId[netId]
+    if (netTraces.length < 2) continue
+
+    processNetTraces(netTraces, distanceThreshold)
+  }
+
+  return resultTraces
+}
+
+function processNetTraces(
+  netTraces: SolvedTracePath[],
+  distanceThreshold: number,
+): void {
+  // 提取所有线段
+  const segments: LineSegment[] = []
+
+  for (const trace of netTraces) {
+    for (let i = 0; i < trace.tracePath.length - 1; i++) {
+      const p1 = trace.tracePath[i]
+      const p2 = trace.tracePath[i + 1]
+      const isHorizontal = Math.abs(p1.y - p2.y) < 0.001
+      const isVertical = Math.abs(p1.x - p2.x) < 0.001
+
+      if (isHorizontal || isVertical) {
+        segments.push({
+          traceId: trace.mspPairId,
+          segmentIndex: i,
+          p1,
+          p2,
+          isHorizontal,
+          isVertical,
+          fixedCoord: isHorizontal ? p1.y : p1.x,
+          otherCoord1: isHorizontal ? p1.x : p1.y,
+          otherCoord2: isHorizontal ? p2.x : p2.y,
+        })
+      }
+    }
+  }
+
+  // 分组水平线
+  const horizontalSegments = segments.filter((s) => s.isHorizontal)
+  alignSegments(horizontalSegments, distanceThreshold, true)
+
+  // 分组垂直线
+  const verticalSegments = segments.filter((s) => s.isVertical)
+  alignSegments(verticalSegments, distanceThreshold, false)
+}
+
+function alignSegments(
+  segments: LineSegment[],
+  threshold: number,
+  isHorizontal: boolean,
+): void {
+  if (segments.length < 2) return
+
+  // 按固定坐标排序
+  const sorted = [...segments].sort(
+    (a, b) => a.fixedCoord - b.fixedCoord,
+  )
+
+  // 找接近的组
+  const groups: LineSegment[][] = []
+  let currentGroup: LineSegment[] = [sorted[0]]
+
+  for (let i = 1; i < sorted.length; i++) {
+    const diff = Math.abs(
+      sorted[i].fixedCoord - currentGroup[currentGroup.length - 1].fixedCoord,
+    )
+    if (diff <= threshold) {
+      currentGroup.push(sorted[i])
+    } else {
+      if (currentGroup.length >= 2) {
+        groups.push(currentGroup)
+      }
+      currentGroup = [sorted[i]]
+    }
+  }
+  if (currentGroup.length >= 2) {
+    groups.push(currentGroup)
+  }
+
+  // 对齐每个组到平均坐标
+  for (const group of groups) {
+    const avgCoord =
+      group.reduce((sum, s) => sum + s.fixedCoord, 0) / group.length
+
+    for (const seg of group) {
+      const trace = seg.traceId
+        ? seg.traceId
+        : group[0].traceId
+      if (isHorizontal) {
+        seg.p1.y = avgCoord
+        seg.p2.y = avgCoord
+      } else {
+        seg.p1.x = avgCoord
+        seg.p2.x = avgCoord
+      }
+    }
+  }
+}
+
+/**
+ * 只处理单个 trace 的版本（用于 pipeline 阶段）
+ */
+export function mergeCloseSegmentsForSingleTrace({
+  targetMspConnectionPairId,
+  traces,
+}: {
+  targetMspConnectionPairId: string
+  traces: SolvedTracePath[]
+}): SolvedTracePath {
+  const targetTrace = traces.find(
+    (t) => t.mspPairId === targetMspConnectionPairId,
+  )!
+  const otherTraces = traces.filter(
+    (t) => t.mspPairId !== targetMspConnectionPairId,
+  )
+
+  // 找到同网络的其他 trace
+  const targetNetId = targetTrace.netId || targetTrace.mspPairId.split("-")[0]
+  const sameNetTraces = otherTraces.filter(
+    (t) => (t.netId || t.mspPairId.split("-")[0]) === targetNetId,
+  )
+
+  if (sameNetTraces.length === 0) {
+    return { ...targetTrace, tracePath: [...targetTrace.tracePath] }
+  }
+
+  // 合并处理
+  const allNetTraces = [targetTrace, ...sameNetTraces]
+  const merged = mergeCloseSegments({
+    traces: allNetTraces,
+    distanceThreshold: 0.5,
+  })
+
+  // 返回更新后的目标 trace
+  return merged.find((t) => t.mspPairId === targetMspConnectionPairId)!
+}


### PR DESCRIPTION
## Summary

Adds a new pipeline phase to TraceCleanupSolver that automatically aligns horizontal and vertical line segments from the same net when they are very close together.

This implements both:
- **Issue #29**: New Phase To combine same-net trace segments that are close together
- **Issue #34**: Merge same-net trace lines that are close together (make at the same Y or same X)

## Changes

### New File: lib/solvers/TraceCleanupSolver/mergeCloseSegments.ts
- Core algorithm for detecting and merging close segments
- Groups traces by net ID
- Extracts horizontal/vertical line segments
- Finds segments within a distance threshold (default: 0.5mm)
- Aligns all segments in each group to their average coordinate

### Modified: lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
- Adds new 'merging_close_segments' pipeline phase
- Runs after 'balancing_l_shapes' phase
- Processes each trace sequentially

## How It Works

1. **Segment Extraction**: Identify horizontal and vertical segments from all traces
2. **Net Grouping**: Only consider segments from the same net
3. **Proximity Detection**: Find segments with fixed coords within threshold
4. **Alignment**: Move segments to their average coordinate
5. **Preserves Connectivity**: All trace path points are updated together

---

*This bounty implementation is worth $100 per issue. Looking forward to your review!* 😊
