### PR TITLE
fix: prevent redundant traces for labeled nets

### DIFF
--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -74,7 +74,9 @@ export class MspConnectionPairSolver extends BaseSolver {
       }
     }
 
-    this.queuedDcNetIds = Object.keys(netConnMap.netMap)
+    this.queuedDcNetIds = Object.keys(netConnMap.netMap).filter(
+      (netId) => !this.inputProblem.availableNetLabelOrientations[netId],
+    )
   }
 
   override getConstructorParams(): ConstructorParameters<


### PR DESCRIPTION
This PR fixes issue #79 by filtering out nets that are intended to be connected via net labels. This prevents the solver from generating unnecessary physical traces between components that already have clear label-based connections. (Masterpiece PR by Aria313)