### PR TITLE
Update net label orientation strokes

### DIFF
--- a/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
@@ -9,6 +9,7 @@ import type { GraphicsObject } from "graphics-debug"
 import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { getConnectivityMapsFromInputProblem } from "../MspConnectionPairSolver/getConnectivityMapFromInputProblem"
+import { getNetLabelStrokeColorForOrientation } from "./getNetLabelStrokeColorForOrientation"
 
 /**
  * A group of traces that have at least one overlapping segment and
@@ -344,12 +345,16 @@ export class NetLabelPlacementSolver extends BaseSolver {
     }
 
     for (const p of this.netLabelPlacements) {
+      const strokeColor = getNetLabelStrokeColorForOrientation(
+        p.orientation,
+        getColorFromString(p.globalConnNetId, 0.9),
+      )
       graphics.rects!.push({
         center: p.center,
         width: p.width,
         height: p.height,
         fill: getColorFromString(p.globalConnNetId, 0.35),
-        strokeColor: getColorFromString(p.globalConnNetId, 0.9),
+        strokeColor,
         label: `netId: ${p.netId}\nglobalConnNetId: ${p.globalConnNetId}`,
       } as any)
       graphics.points!.push({

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver_visualize.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver_visualize.ts
@@ -1,6 +1,7 @@
 import type { GraphicsObject } from "graphics-debug"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import { getColorFromString } from "lib/utils/getColorFromString"
+import { getNetLabelStrokeColorForOrientation } from "../getNetLabelStrokeColorForOrientation"
 import { chooseHostTraceForGroup } from "./host"
 import type { SingleNetLabelPlacementSolver } from "./SingleNetLabelPlacementSolver"
 
@@ -79,12 +80,16 @@ export function visualizeSingleNetLabelPlacementSolver(
   // Visualize the final accepted label (if any)
   if (solver.netLabelPlacement) {
     const p = solver.netLabelPlacement
+    const strokeColor = getNetLabelStrokeColorForOrientation(
+      p.orientation,
+      "blue",
+    )
     graphics.rects!.push({
       center: p.center,
       width: p.width,
       height: p.height,
       fill: "rgba(0, 128, 255, 0.35)",
-      strokeColor: "blue",
+      strokeColor,
       label: `netId: ${p.netId}\nglobalConnNetId: ${p.globalConnNetId}`,
     } as any)
     graphics.points!.push({

--- a/lib/solvers/NetLabelPlacementSolver/getNetLabelStrokeColorForOrientation.ts
+++ b/lib/solvers/NetLabelPlacementSolver/getNetLabelStrokeColorForOrientation.ts
@@ -1,0 +1,15 @@
+import type { FacingDirection } from "lib/utils/dir"
+
+export function getNetLabelStrokeColorForOrientation(
+  orientation: FacingDirection,
+  fallbackColor: string,
+) {
+  switch (orientation) {
+    case "y+":
+      return "red"
+    case "y-":
+      return "black"
+    default:
+      return fallbackColor
+  }
+}

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver.ts
@@ -8,6 +8,7 @@ import { MergedNetLabelObstacleSolver } from "./sub-solvers/LabelMergingSolver/L
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { OverlapAvoidanceStepSolver } from "./sub-solvers/OverlapAvoidanceStepSolver/OverlapAvoidanceStepSolver"
 import { detectTraceLabelOverlap } from "./detectTraceLabelOverlap"
+import { getNetLabelStrokeColorForOrientation } from "../NetLabelPlacementSolver/getNetLabelStrokeColorForOrientation"
 
 interface TraceLabelOverlapAvoidanceSolverInput {
   inputProblem: InputProblem
@@ -151,12 +152,16 @@ export class TraceLabelOverlapAvoidanceSolver extends BaseSolver {
     // Also show original labels
     for (const label of this.netLabelPlacements) {
       const color = getColorFromString(label.globalConnNetId, 0.3) // Make fill opaque
+      const strokeColor = getNetLabelStrokeColorForOrientation(
+        label.orientation,
+        color.replace("0.3", "1"),
+      )
       graphics.rects!.push({
         center: label.center,
         width: label.width,
         height: label.height,
         fill: color,
-        stroke: color.replace("0.3", "1"),
+        stroke: strokeColor,
         label: label.globalConnNetId,
       })
     }

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver.ts
@@ -6,6 +6,7 @@ import type { GraphicsObject, Line } from "graphics-debug"
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { InputProblem } from "lib/types/InputProblem"
+import { getNetLabelStrokeColorForOrientation } from "../../../NetLabelPlacementSolver/getNetLabelStrokeColorForOrientation"
 import { groupLabelsByChipAndOrientation } from "./groupLabelsByChipAndOrientation"
 import { mergeLabelGroup } from "./mergeLabelGroup"
 import { filterLabelsAtTraceEdges } from "./filterLabelsAtTraceEdges"
@@ -157,12 +158,16 @@ export class MergedNetLabelObstacleSolver extends BaseSolver {
     ) {
       const activeGroup = this.labelGroups[this.activeMergingGroupKey]!
       for (const label of activeGroup) {
+        const strokeColor = getNetLabelStrokeColorForOrientation(
+          label.orientation,
+          "orange",
+        )
         graphics.rects.push({
           center: label.center,
           width: label.width,
           height: label.height,
           fill: "rgba(255, 165, 0, 0.5)", // Orange highlight
-          stroke: "orange",
+          stroke: strokeColor,
         })
       }
     }
@@ -172,12 +177,16 @@ export class MergedNetLabelObstacleSolver extends BaseSolver {
       const color = getColorFromString(finalLabel.globalConnNetId)
 
       if (isMerged) {
+        const strokeColor = getNetLabelStrokeColorForOrientation(
+          finalLabel.orientation,
+          color,
+        )
         graphics.rects.push({
           center: finalLabel.center,
           width: finalLabel.width,
           height: finalLabel.height,
           fill: color.replace(/, 1\)/, ", 0.2)"),
-          stroke: color,
+          stroke: strokeColor,
           label: finalLabel.globalConnNetId,
         })
 
@@ -210,11 +219,15 @@ export class MergedNetLabelObstacleSolver extends BaseSolver {
           }
         }
       } else {
+        const strokeColor = getNetLabelStrokeColorForOrientation(
+          finalLabel.orientation,
+          color,
+        )
         graphics.rects.push({
           center: finalLabel.center,
           width: finalLabel.width,
           height: finalLabel.height,
-          stroke: color,
+          stroke: strokeColor,
           label: finalLabel.globalConnNetId,
         })
       }

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/OverlapAvoidanceStepSolver/OverlapAvoidanceStepSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/OverlapAvoidanceStepSolver/OverlapAvoidanceStepSolver.ts
@@ -8,6 +8,7 @@ import { detectTraceLabelOverlap } from "../../detectTraceLabelOverlap"
 import { SingleOverlapSolver } from "../SingleOverlapSolver/SingleOverlapSolver"
 import { doesTraceStartOrEndInLabel } from "./doesTraceStartOrEndInLabel"
 import { visualizeDecomposition } from "./visualizeDecomposition"
+import { getNetLabelStrokeColorForOrientation } from "../../../NetLabelPlacementSolver/getNetLabelStrokeColorForOrientation"
 
 type Overlap = ReturnType<typeof detectTraceLabelOverlap>[0]
 
@@ -261,6 +262,10 @@ export class OverlapAvoidanceStepSolver extends BaseSolver {
           width: label.width,
           height: label.height,
           fill: "yellow",
+          stroke: getNetLabelStrokeColorForOrientation(
+            label.orientation,
+            "yellow",
+          ),
         })
         if (!graphics.texts) graphics.texts = []
         graphics.texts.push({

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/OverlapAvoidanceStepSolver/visualizeDecomposition.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/OverlapAvoidanceStepSolver/visualizeDecomposition.ts
@@ -1,5 +1,6 @@
 import type { GraphicsObject } from "graphics-debug"
 import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { getNetLabelStrokeColorForOrientation } from "lib/solvers/NetLabelPlacementSolver/getNetLabelStrokeColorForOrientation"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 
 interface VisualizeDecompositionParams {
@@ -39,6 +40,10 @@ export const visualizeDecomposition = (
       width: childLabel.width,
       height: childLabel.height,
       fill: isOwnLabel ? "green" : "red", // Green for own label, red for others
+      stroke: getNetLabelStrokeColorForOrientation(
+        childLabel.orientation,
+        isOwnLabel ? "green" : "red",
+      ),
     })
   }
 

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/SingleOverlapSolver/SingleOverlapSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/SingleOverlapSolver/SingleOverlapSolver.ts
@@ -9,6 +9,7 @@ import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/Schemati
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import { generateRerouteCandidates } from "../../rerouteCollidingTrace"
 import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+import { getNetLabelStrokeColorForOrientation } from "../../../NetLabelPlacementSolver/getNetLabelStrokeColorForOrientation"
 
 interface SingleOverlapSolverInput {
   trace: SolvedTracePath
@@ -106,6 +107,10 @@ export class SingleOverlapSolver extends BaseSolver {
       width: this.label.width,
       height: this.label.height,
       fill: "rgba(255, 0, 0, 0.2)",
+      stroke: getNetLabelStrokeColorForOrientation(
+        this.label.orientation,
+        "red",
+      ),
     })
 
     // Draw next candidate

--- a/tests/solvers/TraceLabelOverlapAvoidanceSolver/renderComparisonView/__snapshots__/renderComparisonView01.snap.svg
+++ b/tests/solvers/TraceLabelOverlapAvoidanceSolver/renderComparisonView/__snapshots__/renderComparisonView01.snap.svg
@@ -45,16 +45,20 @@ x-" data-x="1.6" data-y="-2.095" cx="179.3777777777778" cy="375.4088888888889" r
 x-" data-x="1.6" data-y="-2.295" cx="179.3777777777778" cy="385.3644444444445" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.4000000000000001" data-y="-2.295" cx="169.42222222222225" cy="385.3644444444445" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="1.4000000000000001" data-y="-2.295" cx="169.42222222222225" cy="385.3644444444445" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="159.4666666666667" cy="256.1911111111111" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="159.4666666666667" cy="256.1911111111111" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.6" data-y="-1.895" cx="179.3777777777778" cy="365.4533333333334" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="1.6" data-y="-1.895" cx="179.3777777777778" cy="365.4533333333334" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.6" data-y="-2.095" cx="179.3777777777778" cy="375.4088888888889" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="1.6" data-y="-2.095" cx="179.3777777777778" cy="375.4088888888889" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.1
@@ -137,16 +141,20 @@ x-" data-x="7.850000000000001" data-y="-2.295" cx="490.488888888889" cy="385.364
     <rect data-type="rect" data-label="schematic_component_1" data-x="2.7" data-y="-2.095" x="179.3777777777778" y="355.4977777777778" width="109.51111111111112" height="39.82222222222225" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.020089285714285712" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="1.4000000000000001" data-y="-2.52" x="164.44444444444446" y="385.3644444444445" width="9.955555555555577" height="22.400000000000034" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020089285714285712" />
+    <rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net0" data-x="1.4000000000000001" data-y="-2.52" x="164.44444444444446" y="385.3644444444445" width="9.955555555555577" height="22.400000000000034" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020089285714285712" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="1.4260000000000002" data-y="0.30000000000000004" x="159.51644444444446" y="251.21333333333337" width="22.400000000000034" height="9.95555555555552" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020089285714285712" />
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net1" data-x="1.4260000000000002" data-y="0.30000000000000004" x="159.51644444444446" y="251.21333333333337" width="22.400000000000034" height="9.95555555555552" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020089285714285712" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="1.374" data-y="-1.895" x="156.92800000000003" y="360.47555555555556" width="22.400000000000006" height="9.955555555555577" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020089285714285712" />
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net1" data-x="1.374" data-y="-1.895" x="156.92800000000003" y="360.47555555555556" width="22.400000000000006" height="9.955555555555577" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020089285714285712" />
   </g>
   <g>
-    <rect data-type="rect" data-label="" data-x="1.374" data-y="-2.095" x="156.92800000000003" y="370.43111111111114" width="22.400000000000006" height="9.955555555555577" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020089285714285712" />
+    <rect data-type="rect" data-label="netId: MMM
+globalConnNetId: connectivity_net2" data-x="1.374" data-y="-2.095" x="156.92800000000003" y="370.43111111111114" width="22.400000000000006" height="9.955555555555577" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020089285714285712" />
   </g>
   <g>
     <rect data-type="rect" data-label="schematic_component_0" data-x="6.250000000000001" data-y="0" x="351.1111111111112" y="246.23555555555558" width="119.46666666666664" height="49.7777777777778" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.020089285714285712" />
@@ -155,13 +163,13 @@ x-" data-x="7.850000000000001" data-y="-2.295" cx="490.488888888889" cy="385.364
     <rect data-type="rect" data-label="schematic_component_1" data-x="8.950000000000001" data-y="-2.095" x="490.488888888889" y="355.4977777777778" width="109.511111111111" height="39.82222222222225" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.020089285714285712" />
   </g>
   <g>
-    <rect data-type="rect" data-label="connectivity_net0" data-x="7.650000000000001" data-y="-2.52" x="475.55555555555566" y="385.3644444444445" width="9.95555555555552" height="22.400000000000034" fill="none" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.020089285714285712" />
+    <rect data-type="rect" data-label="merged-group-J1-x-" data-x="7.6240000000000006" data-y="-1.995" x="468.0391111111112" y="360.47555555555556" width="22.39999999999992" height="19.911111111111154" fill="hsl(296, 100%, 50%, 0.2)" stroke="hsl(296, 100%, 50%, 1)" stroke-width="0.020089285714285712" />
   </g>
   <g>
     <rect data-type="rect" data-label="connectivity_net1" data-x="7.676000000000001" data-y="0.30000000000000004" x="470.62755555555566" y="251.21333333333337" width="22.399999999999977" height="9.95555555555552" fill="none" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.020089285714285712" />
   </g>
   <g>
-    <rect data-type="rect" data-label="merged-group-J1-x-" data-x="7.6240000000000006" data-y="-1.995" x="468.0391111111112" y="360.47555555555556" width="22.39999999999992" height="19.911111111111154" fill="hsl(296, 100%, 50%, 0.2)" stroke="hsl(296, 100%, 50%, 1)" stroke-width="0.020089285714285712" />
+    <rect data-type="rect" data-label="connectivity_net0" data-x="7.650000000000001" data-y="-2.52" x="475.55555555555566" y="385.3644444444445" width="9.95555555555552" height="22.400000000000034" fill="none" stroke="black" stroke-width="0.020089285714285712" />
   </g><text data-type="text" data-label="NetLabelPlacementSolver" data-x="1.3" data-y="0.78125" x="164.44444444444446" y="232.23555555555558" fill="black" font-size="14" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">NetLabelPlacementSolver</text><text data-type="text" data-label="MergedNetLabelObstacles" data-x="7.550000000000001" data-y="0.78125" x="475.5555555555556" y="232.23555555555558" fill="black" font-size="14" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">MergedNetLabelObstacles</text>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />


### PR DESCRIPTION
## Summary
- Add a shared helper that maps net label orientation to stroke color.
- Render `y+` labels with a red stroke and `y-` labels with a black stroke.
- Apply the orientation-aware stroke across net label placement and overlap/merge visualizers.
- Refresh affected SVG snapshots to match the new rendering.

## Testing
- `bun test`
- `bunx tsc --noEmit --ignoreDeprecations 5.0`