### PR TITLE
enhance: improve simplifyPath with removeDuplicateConsecutivePoints (issue #110)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,13 +4,39 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+/**
+ * Removes duplicate consecutive points (zero-length segments) from a path.
+ * This is useful when UntangleTraceSubsolver introduces redundant points
+ * at path-concatenation junctions.
+ */
+export const removeDuplicateConsecutivePoints = (path: Point[]): Point[] => {
+  if (path.length < 2) return path
+
+  const result: Point[] = [path[0]!]
+  for (let i = 1; i < path.length; i++) {
+    const last = result[result.length - 1]!
+    const curr = path[i]!
+    // Check if points are effectively the same
+    const dx = Math.abs(curr.x - last.x)
+    const dy = Math.abs(curr.y - last.y)
+    if (dx > 0.0001 || dy > 0.0001) {
+      result.push(curr)
+    }
+  }
+  return result
+}
+
 export const simplifyPath = (path: Point[]): Point[] => {
-  if (path.length < 3) return path
-  const newPath: Point[] = [path[0]]
-  for (let i = 1; i < path.length - 1; i++) {
+  // First remove any duplicate consecutive points
+  let processedPath = removeDuplicateConsecutivePoints(path)
+
+  if (processedPath.length < 3) return processedPath
+
+  const newPath: Point[] = [processedPath[0]]
+  for (let i = 1; i < processedPath.length - 1; i++) {
     const p1 = newPath[newPath.length - 1]
-    const p2 = path[i]
-    const p3 = path[i + 1]
+    const p2 = processedPath[i]
+    const p3 = processedPath[i + 1]
     if (
       (isVertical(p1, p2) && isVertical(p2, p3)) ||
       (isHorizontal(p1, p2) && isHorizontal(p2, p3))
@@ -19,9 +45,10 @@ export const simplifyPath = (path: Point[]): Point[] => {
     }
     newPath.push(p2)
   }
-  newPath.push(path[path.length - 1])
+  newPath.push(processedPath[processedPath.length - 1])
 
   if (newPath.length < 3) return newPath
+
   const finalPath: Point[] = [newPath[0]]
   for (let i = 1; i < newPath.length - 1; i++) {
     const p1 = finalPath[finalPath.length - 1]


### PR DESCRIPTION
Enhances TraceCleanupSolver path simplification by adding removeDuplicateConsecutivePoints helper.

All 55 tests pass. Closes #110