### PR TITLE
feat: add same-net trace merging to TraceCleanupSolver (closes #29, #34)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -6,6 +6,8 @@ import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { mergeSameNetCollinearTraces } from "./mergeSameNetCollinearTraces"
+import { mergeSameNetCloseTraces } from "./mergeSameNetCloseTraces"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -28,6 +30,8 @@ type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
+  | "merging_collinear_traces"
+  | "merging_close_traces"
 
 /**
  * The TraceCleanupSolver is responsible for improving the aesthetics and readability of schematic traces.
@@ -84,6 +88,12 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "merging_collinear_traces":
+        this._runMergeCollinearTracesStep()
+        break
+      case "merging_close_traces":
+        this._runMergeCloseTracesStep()
+        break
     }
   }
 
@@ -108,11 +118,29 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "merging_collinear_traces"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runMergeCollinearTracesStep() {
+    this.outputTraces = mergeSameNetCollinearTraces(
+      this.outputTraces,
+      this.input.inputProblem,
+    )
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.pipelineStep = "merging_close_traces"
+  }
+
+  private _runMergeCloseTracesStep() {
+    this.outputTraces = mergeSameNetCloseTraces(
+      this.outputTraces,
+      this.input.inputProblem,
+    )
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.ts
@@ -1,0 +1,178 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
+import { hasCollisions } from "./hasCollisions"
+import { simplifyPath } from "./simplifyPath"
+
+const EPS = 1e-6
+
+type ParallelSegment = {
+  traceIndex: number
+  segmentIndex: number
+  orientation: "horizontal" | "vertical"
+  /** The shared coordinate (Y for horizontal, X for vertical) */
+  sharedCoord: number
+  /** The range on the other axis [min, max] */
+  rangeMin: number
+  rangeMax: number
+  /** Whether this is the first or last segment in the trace */
+  isEndpoint: boolean
+}
+
+function extractParallelSegments(
+  trace: SolvedTracePath,
+  traceIndex: number,
+): ParallelSegment[] {
+  const segments: ParallelSegment[] = []
+  const path = trace.tracePath
+  const lastSegIdx = path.length - 2
+
+  for (let i = 0; i < path.length - 1; i++) {
+    const p1 = path[i]!
+    const p2 = path[i + 1]!
+    const dx = Math.abs(p1.x - p2.x)
+    const dy = Math.abs(p1.y - p2.y)
+
+    if (dy < EPS && dx > EPS) {
+      segments.push({
+        traceIndex,
+        segmentIndex: i,
+        orientation: "horizontal",
+        sharedCoord: p1.y,
+        rangeMin: Math.min(p1.x, p2.x),
+        rangeMax: Math.max(p1.x, p2.x),
+        isEndpoint: i === 0 || i === lastSegIdx,
+      })
+    } else if (dx < EPS && dy > EPS) {
+      segments.push({
+        traceIndex,
+        segmentIndex: i,
+        orientation: "vertical",
+        sharedCoord: p1.x,
+        rangeMin: Math.min(p1.y, p2.y),
+        rangeMax: Math.max(p1.y, p2.y),
+        isEndpoint: i === 0 || i === lastSegIdx,
+      })
+    }
+  }
+  return segments
+}
+
+function rangesOverlap(
+  aMin: number,
+  aMax: number,
+  bMin: number,
+  bMax: number,
+): boolean {
+  return aMin < bMax - EPS && bMin < aMax - EPS
+}
+
+/**
+ * Merges same-net trace segments that are parallel and close together
+ * (within a distance threshold) by snapping them to their midpoint coordinate.
+ *
+ * Implements issue #34: "Merge same-net trace lines that are close together
+ * (make at the same Y or same X)".
+ *
+ * Only merges internal (non-endpoint) segments to avoid breaking pin connectivity.
+ */
+export function mergeSameNetCloseTraces(
+  allTraces: SolvedTracePath[],
+  inputProblem: InputProblem,
+  threshold = 0.15,
+): SolvedTracePath[] {
+  const updatedPaths: Point[][] = allTraces.map((t) => [...t.tracePath])
+  const chipObstacles = getObstacleRects(inputProblem)
+
+  // Group traces by globalConnNetId
+  const netGroups = new Map<string, number[]>()
+  for (let i = 0; i < allTraces.length; i++) {
+    const netId = allTraces[i]!.globalConnNetId
+    if (!netGroups.has(netId)) netGroups.set(netId, [])
+    netGroups.get(netId)!.push(i)
+  }
+
+  for (const [, traceIndices] of netGroups) {
+    if (traceIndices.length < 2) continue
+
+    // Collect all internal segments from this net group
+    const allSegments: ParallelSegment[] = []
+    for (const ti of traceIndices) {
+      const segs = extractParallelSegments(
+        { ...allTraces[ti]!, tracePath: updatedPaths[ti]! },
+        ti,
+      )
+      // Only consider non-endpoint (internal) segments for close-merge
+      allSegments.push(...segs.filter((s) => !s.isEndpoint))
+    }
+
+    // Find pairs that are parallel, within threshold distance, and overlapping
+    for (let a = 0; a < allSegments.length; a++) {
+      for (let b = a + 1; b < allSegments.length; b++) {
+        const segA = allSegments[a]!
+        const segB = allSegments[b]!
+
+        if (segA.traceIndex === segB.traceIndex) continue
+        if (segA.orientation !== segB.orientation) continue
+
+        const dist = Math.abs(segA.sharedCoord - segB.sharedCoord)
+        // Skip if identical (those are handled by collinear merge) or too far
+        if (dist < EPS || dist > threshold) continue
+
+        if (
+          !rangesOverlap(
+            segA.rangeMin,
+            segA.rangeMax,
+            segB.rangeMin,
+            segB.rangeMax,
+          )
+        )
+          continue
+
+        const midCoord = (segA.sharedCoord + segB.sharedCoord) / 2
+
+        // Apply the snap to copies of both traces' paths
+        const pathA = [...updatedPaths[segA.traceIndex]!]
+        const pathB = [...updatedPaths[segB.traceIndex]!]
+        const piA = segA.segmentIndex
+        const piB = segB.segmentIndex
+
+        if (segA.orientation === "horizontal") {
+          pathA[piA] = { x: pathA[piA]!.x, y: midCoord }
+          pathA[piA + 1] = { x: pathA[piA + 1]!.x, y: midCoord }
+          pathB[piB] = { x: pathB[piB]!.x, y: midCoord }
+          pathB[piB + 1] = { x: pathB[piB + 1]!.x, y: midCoord }
+        } else {
+          pathA[piA] = { x: midCoord, y: pathA[piA]!.y }
+          pathA[piA + 1] = { x: midCoord, y: pathA[piA + 1]!.y }
+          pathB[piB] = { x: midCoord, y: pathB[piB]!.y }
+          pathB[piB + 1] = { x: midCoord, y: pathB[piB + 1]!.y }
+        }
+
+        const simplA = simplifyPath(pathA)
+        const simplB = simplifyPath(pathB)
+
+        // Revert if the snapped path collides with chips
+        if (
+          hasCollisions(simplA, chipObstacles) ||
+          hasCollisions(simplB, chipObstacles)
+        ) {
+          continue
+        }
+
+        updatedPaths[segA.traceIndex] = simplA
+        updatedPaths[segB.traceIndex] = simplB
+
+        // Update segment coords so later iterations use the updated position
+        segA.sharedCoord = midCoord
+        segB.sharedCoord = midCoord
+      }
+    }
+  }
+
+  return allTraces.map((trace, i) => ({
+    ...trace,
+    tracePath: updatedPaths[i]!,
+  }))
+}

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetCollinearTraces.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetCollinearTraces.ts
@@ -1,0 +1,223 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
+import { hasCollisions } from "./hasCollisions"
+import { simplifyPath } from "./simplifyPath"
+
+const EPS = 1e-6
+
+/**
+ * Returns true if two numeric ranges [aMin, aMax] and [bMin, bMax] are
+ * contiguous or overlapping (gap <= gapTolerance).
+ */
+function rangesContiguous(
+  aMin: number,
+  aMax: number,
+  bMin: number,
+  bMax: number,
+  gapTolerance = 0.1,
+): boolean {
+  // gap between ranges = max(0, max(mins) - min(maxes))
+  const gap = Math.max(0, Math.max(aMin, bMin) - Math.min(aMax, bMax))
+  return gap <= gapTolerance
+}
+
+type CollinearSegment = {
+  traceIndex: number
+  segmentIndex: number // index of first point of the segment in tracePath
+  orientation: "horizontal" | "vertical"
+  /** shared coordinate: Y for horizontal, X for vertical */
+  sharedCoord: number
+  rangeMin: number
+  rangeMax: number
+}
+
+function extractCollinearSegments(
+  path: Point[],
+  traceIndex: number,
+): CollinearSegment[] {
+  const segments: CollinearSegment[] = []
+  for (let i = 0; i < path.length - 1; i++) {
+    const p1 = path[i]!
+    const p2 = path[i + 1]!
+    const dx = Math.abs(p1.x - p2.x)
+    const dy = Math.abs(p1.y - p2.y)
+
+    if (dy < EPS && dx > EPS) {
+      segments.push({
+        traceIndex,
+        segmentIndex: i,
+        orientation: "horizontal",
+        sharedCoord: (p1.y + p2.y) / 2,
+        rangeMin: Math.min(p1.x, p2.x),
+        rangeMax: Math.max(p1.x, p2.x),
+      })
+    } else if (dx < EPS && dy > EPS) {
+      segments.push({
+        traceIndex,
+        segmentIndex: i,
+        orientation: "vertical",
+        sharedCoord: (p1.x + p2.x) / 2,
+        rangeMin: Math.min(p1.y, p2.y),
+        rangeMax: Math.max(p1.y, p2.y),
+      })
+    }
+  }
+  return segments
+}
+
+/**
+ * Merges segments from two different traces in the same net that are collinear
+ * (same axis, same shared coordinate within EPS) and contiguous/overlapping.
+ *
+ * Both traces are extended to cover the union of their ranges.
+ * If the merged path would collide with chip obstacles, the merge is skipped.
+ *
+ * Implements issue #29: "3 pins in a row connected by one net result in 2 segments;
+ * this should be merged to 1."
+ */
+export function mergeSameNetCollinearTraces(
+  allTraces: SolvedTracePath[],
+  inputProblem: InputProblem,
+  gapTolerance = 0.1,
+): SolvedTracePath[] {
+  const updatedPaths: Point[][] = allTraces.map((t) => [...t.tracePath])
+  const chipObstacles = getObstacleRects(inputProblem)
+
+  // Group trace indices by globalConnNetId
+  const netGroups = new Map<string, number[]>()
+  for (let i = 0; i < allTraces.length; i++) {
+    const netId = allTraces[i]!.globalConnNetId
+    if (!netGroups.has(netId)) netGroups.set(netId, [])
+    netGroups.get(netId)!.push(i)
+  }
+
+  for (const [, traceIndices] of netGroups) {
+    if (traceIndices.length < 2) continue
+
+    // Use a set to track which (traceA, traceB) pairs we've already merged
+    // to avoid infinite loops from re-detecting the same pair
+    const mergedPairs = new Set<string>()
+
+    let changed = true
+    let safetyIter = 0
+    const maxIter = allTraces.length * allTraces.length * 10
+
+    while (changed && safetyIter < maxIter) {
+      changed = false
+      safetyIter++
+
+      // Extract all segments from all traces in this net group (using current paths)
+      const allSegments: CollinearSegment[] = []
+      for (const ti of traceIndices) {
+        const segs = extractCollinearSegments(updatedPaths[ti]!, ti)
+        allSegments.push(...segs)
+      }
+
+      // Find collinear contiguous pairs across different traces
+      for (let a = 0; a < allSegments.length && !changed; a++) {
+        for (let b = a + 1; b < allSegments.length && !changed; b++) {
+          const segA = allSegments[a]!
+          const segB = allSegments[b]!
+
+          if (segA.traceIndex === segB.traceIndex) continue
+          if (segA.orientation !== segB.orientation) continue
+
+          // Must be on the same axis
+          if (Math.abs(segA.sharedCoord - segB.sharedCoord) > EPS) continue
+
+          // Must be contiguous or overlapping
+          if (
+            !rangesContiguous(
+              segA.rangeMin,
+              segA.rangeMax,
+              segB.rangeMin,
+              segB.rangeMax,
+              gapTolerance,
+            )
+          )
+            continue
+
+          // Skip if already identical ranges (fully merged)
+          if (
+            Math.abs(segA.rangeMin - segB.rangeMin) < EPS &&
+            Math.abs(segA.rangeMax - segB.rangeMax) < EPS
+          )
+            continue
+
+          const pairKey = `${Math.min(segA.traceIndex, segB.traceIndex)}-${Math.max(segA.traceIndex, segB.traceIndex)}-${segA.orientation}-${segA.sharedCoord.toFixed(6)}`
+          if (mergedPairs.has(pairKey)) continue
+
+          // Attempt to merge: extend both paths to cover the union range
+          const mergedMin = Math.min(segA.rangeMin, segB.rangeMin)
+          const mergedMax = Math.max(segA.rangeMax, segB.rangeMax)
+
+          const pathA = [...updatedPaths[segA.traceIndex]!]
+          const pathB = [...updatedPaths[segB.traceIndex]!]
+          const piA = segA.segmentIndex
+          const piB = segB.segmentIndex
+
+          if (segA.orientation === "horizontal") {
+            const yA = pathA[piA]!.y
+            if (pathA[piA]!.x <= pathA[piA + 1]!.x) {
+              pathA[piA] = { x: mergedMin, y: yA }
+              pathA[piA + 1] = { x: mergedMax, y: yA }
+            } else {
+              pathA[piA] = { x: mergedMax, y: yA }
+              pathA[piA + 1] = { x: mergedMin, y: yA }
+            }
+            const yB = pathB[piB]!.y
+            if (pathB[piB]!.x <= pathB[piB + 1]!.x) {
+              pathB[piB] = { x: mergedMin, y: yB }
+              pathB[piB + 1] = { x: mergedMax, y: yB }
+            } else {
+              pathB[piB] = { x: mergedMax, y: yB }
+              pathB[piB + 1] = { x: mergedMin, y: yB }
+            }
+          } else {
+            // Vertical
+            const xA = pathA[piA]!.x
+            if (pathA[piA]!.y <= pathA[piA + 1]!.y) {
+              pathA[piA] = { x: xA, y: mergedMin }
+              pathA[piA + 1] = { x: xA, y: mergedMax }
+            } else {
+              pathA[piA] = { x: xA, y: mergedMax }
+              pathA[piA + 1] = { x: xA, y: mergedMin }
+            }
+            const xB = pathB[piB]!.x
+            if (pathB[piB]!.y <= pathB[piB + 1]!.y) {
+              pathB[piB] = { x: xB, y: mergedMin }
+              pathB[piB + 1] = { x: xB, y: mergedMax }
+            } else {
+              pathB[piB] = { x: xB, y: mergedMax }
+              pathB[piB + 1] = { x: xB, y: mergedMin }
+            }
+          }
+
+          const simplA = simplifyPath(pathA)
+          const simplB = simplifyPath(pathB)
+
+          // Check for collisions
+          if (
+            hasCollisions(simplA, chipObstacles) ||
+            hasCollisions(simplB, chipObstacles)
+          ) {
+            mergedPairs.add(pairKey)
+            continue
+          }
+
+          updatedPaths[segA.traceIndex] = simplA
+          updatedPaths[segB.traceIndex] = simplB
+          mergedPairs.add(pairKey)
+          changed = true
+        }
+      }
+    }
+  }
+
+  return allTraces.map((trace, i) => ({
+    ...trace,
+    tracePath: updatedPaths[i]!,
+  }))
+}

--- a/tests/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.test.ts
@@ -1,0 +1,234 @@
+import { test, expect } from "bun:test"
+import { mergeSameNetCloseTraces } from "lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const emptyInputProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+function makePath(points: Array<[number, number]>) {
+  return points.map(([x, y]) => ({ x, y }))
+}
+
+function makeTrace(
+  id: string,
+  netId: string,
+  points: Array<[number, number]>,
+): SolvedTracePath {
+  return {
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [] as any,
+    mspConnectionPairIds: [id],
+    pinIds: [],
+    tracePath: makePath(points),
+  }
+}
+
+test("horizontal merge - same net, close Y (within threshold), overlapping X", () => {
+  // Two internal horizontal segments: A at y=0.0, B at y=0.1
+  // Both have internal segments (paths have 4+ points, not endpoints at the matching segs)
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 2],
+      [0, 0.0],
+      [3, 0.0],
+      [3, 2],
+    ]),
+    makeTrace("B", "net1", [
+      [0, -2],
+      [0, 0.1],
+      [3, 0.1],
+      [3, -2],
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, emptyInputProblem, 0.15)
+
+  // Both internal segments should be snapped to midpoint y=0.05
+  const midY = 0.05
+  const pathA = result[0]!.tracePath
+  const pathB = result[1]!.tracePath
+
+  // Find the y coords of internal points (not first/last)
+  const internalYA = pathA.slice(1, -1).map((p) => p.y)
+  const internalYB = pathB.slice(1, -1).map((p) => p.y)
+
+  expect(internalYA.some((y) => Math.abs(y - midY) < 0.001)).toBe(true)
+  expect(internalYB.some((y) => Math.abs(y - midY) < 0.001)).toBe(true)
+})
+
+test("vertical merge - same net, close X (within threshold), overlapping Y", () => {
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [-2, 0],
+      [0.0, 0],
+      [0.0, 3],
+      [-2, 3],
+    ]),
+    makeTrace("B", "net1", [
+      [2, 0],
+      [0.1, 0],
+      [0.1, 3],
+      [2, 3],
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, emptyInputProblem, 0.15)
+
+  const midX = 0.05
+  const pathA = result[0]!.tracePath
+  const pathB = result[1]!.tracePath
+
+  const internalXA = pathA.slice(1, -1).map((p) => p.x)
+  const internalXB = pathB.slice(1, -1).map((p) => p.x)
+
+  expect(internalXA.some((x) => Math.abs(x - midX) < 0.001)).toBe(true)
+  expect(internalXB.some((x) => Math.abs(x - midX) < 0.001)).toBe(true)
+})
+
+test("different net - no merge even if close and overlapping", () => {
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 2],
+      [0, 0.0],
+      [3, 0.0],
+      [3, 2],
+    ]),
+    makeTrace("B", "net2", [
+      [0, -2],
+      [0, 0.1],
+      [3, 0.1],
+      [3, -2],
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, emptyInputProblem, 0.15)
+
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(result[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})
+
+test("over threshold - no merge when distance exceeds threshold", () => {
+  // Distance is 0.5, threshold is 0.15 - should not merge
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 2],
+      [0, 0.0],
+      [3, 0.0],
+      [3, 2],
+    ]),
+    makeTrace("B", "net1", [
+      [0, -2],
+      [0, 0.5],
+      [3, 0.5],
+      [3, -2],
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, emptyInputProblem, 0.15)
+
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(result[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})
+
+test("non-overlapping X ranges - no merge when intervals don't overlap", () => {
+  // Both at y=0.1 apart but X ranges [0,1] and [2,3] don't overlap
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 2],
+      [0, 0.0],
+      [1, 0.0],
+      [1, 2],
+    ]),
+    makeTrace("B", "net1", [
+      [2, -2],
+      [2, 0.1],
+      [3, 0.1],
+      [3, -2],
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, emptyInputProblem, 0.15)
+
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(result[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})
+
+test("endpoint segments are skipped - 2-point traces have no internal segments", () => {
+  // Traces with only 2 points: the single segment is an endpoint segment, should not merge
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 0.0],
+      [3, 0.0],
+    ]),
+    makeTrace("B", "net1", [
+      [0, 0.1],
+      [3, 0.1],
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, emptyInputProblem, 0.15)
+
+  // With only 2 points both segments are endpoints, so no merge
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(result[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})
+
+test("collision revert - merge reverted if it causes chip collision", () => {
+  const problemWithChip: InputProblem = {
+    ...emptyInputProblem,
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 1.5, y: 0.05 },
+        width: 3,
+        height: 0.5,
+        pins: [
+          { pinId: "U1.1", x: 0, y: 0.3 },
+          { pinId: "U1.2", x: 3, y: 0.3 },
+        ],
+      },
+    ],
+  }
+
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 2],
+      [0, 0.0],
+      [3, 0.0],
+      [3, 2],
+    ]),
+    makeTrace("B", "net1", [
+      [0, -2],
+      [0, 0.1],
+      [3, 0.1],
+      [3, -2],
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, problemWithChip, 0.15)
+
+  // Merge should be reverted as midpoint y=0.05 goes through chip
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(result[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})
+
+test("single trace per net - no merge needed", () => {
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 2],
+      [0, 0],
+      [3, 0],
+      [3, 2],
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, emptyInputProblem)
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+})

--- a/tests/solvers/TraceCleanupSolver/mergeSameNetCollinearTraces.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeSameNetCollinearTraces.test.ts
@@ -1,0 +1,225 @@
+import { test, expect } from "bun:test"
+import { mergeSameNetCollinearTraces } from "lib/solvers/TraceCleanupSolver/mergeSameNetCollinearTraces"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const emptyInputProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+function makePath(points: Array<[number, number]>) {
+  return points.map(([x, y]) => ({ x, y }))
+}
+
+function makeTrace(
+  id: string,
+  netId: string,
+  points: Array<[number, number]>,
+): SolvedTracePath {
+  return {
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [] as any,
+    mspConnectionPairIds: [id],
+    pinIds: [],
+    tracePath: makePath(points),
+  }
+}
+
+test("collinear horizontal segments - same Y, contiguous: merge extends both traces", () => {
+  // Two traces on the same net: trace A covers x=[0,2] at y=0, trace B covers x=[2,4] at y=0
+  // After merge both should cover x=[0,4] at y=0
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 1],
+      [0, 0],
+      [2, 0],
+      [2, 1],
+    ]),
+    makeTrace("B", "net1", [
+      [4, 1],
+      [4, 0],
+      [2, 0],
+      [2, 1],
+    ]),
+  ]
+
+  const result = mergeSameNetCollinearTraces(traces, emptyInputProblem)
+
+  // Both traces should have a segment spanning x=0 to x=4 at y=0
+  const pathA = result[0]!.tracePath
+  const pathB = result[1]!.tracePath
+
+  // Each merged trace horizontal segment should now span [0, 4]
+  const xCoordsA = pathA.map((p) => p.x)
+  const xCoordsB = pathB.map((p) => p.x)
+
+  expect(xCoordsA).toContain(0)
+  expect(xCoordsA).toContain(4)
+  expect(xCoordsB).toContain(0)
+  expect(xCoordsB).toContain(4)
+})
+
+test("collinear vertical segments - same X, contiguous: merge extends both traces", () => {
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [1, 0],
+      [0, 0],
+      [0, 2],
+      [1, 2],
+    ]),
+    makeTrace("B", "net1", [
+      [1, 4],
+      [0, 4],
+      [0, 2],
+      [1, 2],
+    ]),
+  ]
+
+  const result = mergeSameNetCollinearTraces(traces, emptyInputProblem)
+
+  const pathA = result[0]!.tracePath
+  const pathB = result[1]!.tracePath
+
+  const yCoordsA = pathA.map((p) => p.y)
+  const yCoordsB = pathB.map((p) => p.y)
+
+  expect(yCoordsA).toContain(0)
+  expect(yCoordsA).toContain(4)
+  expect(yCoordsB).toContain(0)
+  expect(yCoordsB).toContain(4)
+})
+
+test("different nets - no merge even if collinear and contiguous", () => {
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 1],
+      [0, 0],
+      [2, 0],
+      [2, 1],
+    ]),
+    makeTrace("B", "net2", [
+      [4, 1],
+      [4, 0],
+      [2, 0],
+      [2, 1],
+    ]),
+  ]
+
+  const result = mergeSameNetCollinearTraces(traces, emptyInputProblem)
+
+  // Paths should be unchanged since nets are different
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(result[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})
+
+test("same net, collinear but gap too large - no merge", () => {
+  // Traces are on same Y but have a gap of 2 (well above default 0.1 tolerance)
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 1],
+      [0, 0],
+      [1, 0],
+      [1, 1],
+    ]),
+    makeTrace("B", "net1", [
+      [5, 1],
+      [5, 0],
+      [3, 0],
+      [3, 1],
+    ]),
+  ]
+
+  const result = mergeSameNetCollinearTraces(traces, emptyInputProblem)
+
+  // Gap is 2 (x=1 to x=3), above default tolerance 0.1, so no merge
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(result[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})
+
+test("same net, collinear overlapping - traces are extended to union", () => {
+  // Overlapping horizontal segments: A=[0,3], B=[2,5] on same Y
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 1],
+      [0, 0],
+      [3, 0],
+      [3, 1],
+    ]),
+    makeTrace("B", "net1", [
+      [5, 1],
+      [5, 0],
+      [2, 0],
+      [2, 1],
+    ]),
+  ]
+
+  const result = mergeSameNetCollinearTraces(traces, emptyInputProblem)
+
+  const xCoordsA = result[0]!.tracePath.map((p) => p.x)
+  const xCoordsB = result[1]!.tracePath.map((p) => p.x)
+
+  // Both should cover [0, 5]
+  expect(xCoordsA).toContain(0)
+  expect(xCoordsA).toContain(5)
+  expect(xCoordsB).toContain(0)
+  expect(xCoordsB).toContain(5)
+})
+
+test("chip obstacle collision - merge reverted", () => {
+  const problemWithChip: InputProblem = {
+    ...emptyInputProblem,
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 2.5, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [
+          { pinId: "U1.1", x: 2, y: -0.5 },
+          { pinId: "U1.2", x: 3, y: -0.5 },
+        ],
+      },
+    ],
+  }
+
+  // The merged segment would pass through the chip at x=2.5
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 1],
+      [0, 0],
+      [2, 0],
+      [2, 1],
+    ]),
+    makeTrace("B", "net1", [
+      [5, 1],
+      [5, 0],
+      [3, 0],
+      [3, 1],
+    ]),
+  ]
+
+  const result = mergeSameNetCollinearTraces(traces, problemWithChip)
+
+  // Merge should be skipped due to chip collision
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(result[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})
+
+test("single trace per net - no merge attempted", () => {
+  const traces: SolvedTracePath[] = [
+    makeTrace("A", "net1", [
+      [0, 1],
+      [0, 0],
+      [2, 0],
+      [2, 1],
+    ]),
+  ]
+
+  const result = mergeSameNetCollinearTraces(traces, emptyInputProblem)
+  expect(result[0]!.tracePath).toEqual(traces[0]!.tracePath)
+})

--- a/tests/solvers/TraceCleanupSolver/sameNetMerge_integration.test.ts
+++ b/tests/solvers/TraceCleanupSolver/sameNetMerge_integration.test.ts
@@ -1,0 +1,143 @@
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/index"
+import type { InputProblem } from "lib/types/InputProblem"
+
+/**
+ * Integration test: 3 pins in a row on same net should produce traces that share
+ * the same collinear segment (merged into one continuous segment).
+ *
+ * This tests issue #29: merge collinear same-net trace segments.
+ */
+test("issue #29: 3 inline pins on same GND net - collinear segments merged", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 0, y: 0 },
+        width: 1.6,
+        height: 1.0,
+        pins: [
+          { pinId: "U1.1", x: -0.8, y: 0.2 },
+          { pinId: "U1.2", x: -0.8, y: -0.2 },
+          { pinId: "U1.3", x: 0.8, y: 0.2 },
+          { pinId: "U1.4", x: 0.8, y: -0.2 },
+        ],
+      },
+      {
+        chipId: "C1",
+        center: { x: -3, y: 0 },
+        width: 0.5,
+        height: 0.8,
+        pins: [
+          { pinId: "C1.1", x: -3, y: 0.4 },
+          { pinId: "C1.2", x: -3, y: -0.4 },
+        ],
+      },
+      {
+        chipId: "C2",
+        center: { x: -6, y: 0 },
+        width: 0.5,
+        height: 0.8,
+        pins: [
+          { pinId: "C2.1", x: -6, y: 0.4 },
+          { pinId: "C2.2", x: -6, y: -0.4 },
+        ],
+      },
+    ],
+    directConnections: [],
+    netConnections: [
+      {
+        netId: "GND",
+        pinIds: ["U1.2", "C1.2", "C2.2"],
+      },
+      {
+        netId: "VCC",
+        pinIds: ["U1.1", "C1.1", "C2.1"],
+      },
+    ],
+    availableNetLabelOrientations: {
+      GND: ["y-"],
+      VCC: ["y+"],
+    },
+    maxMspPairDistance: 5,
+  }
+
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+
+  // Should produce trace cleanup output
+  const cleanupOutput = solver.traceCleanupSolver?.getOutput()
+  expect(cleanupOutput).toBeDefined()
+  expect(cleanupOutput!.traces.length).toBeGreaterThan(0)
+})
+
+/**
+ * Integration test for issue #34: parallel same-net traces that are close
+ * together should be snapped to a shared coordinate.
+ */
+test("issue #34: parallel same-net traces close together - solver completes without error", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U3",
+        center: { x: 0, y: 0 },
+        width: 2,
+        height: 2,
+        pins: [
+          { pinId: "U3.1", x: -1, y: 0.5 },
+          { pinId: "U3.2", x: -1, y: -0.5 },
+          { pinId: "U3.3", x: 1, y: 0.5 },
+          { pinId: "U3.4", x: 1, y: -0.5 },
+        ],
+      },
+      {
+        chipId: "C20",
+        center: { x: -3, y: 0 },
+        width: 0.5,
+        height: 0.8,
+        pins: [
+          { pinId: "C20.1", x: -3, y: 0.4 },
+          { pinId: "C20.2", x: -3, y: -0.4 },
+        ],
+      },
+      {
+        chipId: "R11",
+        center: { x: 3, y: 0 },
+        width: 0.5,
+        height: 0.8,
+        pins: [
+          { pinId: "R11.1", x: 3, y: 0.4 },
+          { pinId: "R11.2", x: 3, y: -0.4 },
+        ],
+      },
+    ],
+    directConnections: [],
+    netConnections: [
+      {
+        netId: "V3_3",
+        pinIds: ["U3.1", "C20.1", "R11.1"],
+      },
+      {
+        netId: "GND",
+        pinIds: ["U3.2", "C20.2", "R11.2"],
+      },
+    ],
+    availableNetLabelOrientations: {
+      V3_3: ["y+"],
+      GND: ["y-"],
+    },
+    maxMspPairDistance: 5,
+  }
+
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBeFalsy()
+
+  const cleanupOutput = solver.traceCleanupSolver?.getOutput()
+  expect(cleanupOutput).toBeDefined()
+  expect(cleanupOutput!.traces.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary

Adds two new merge phases at the end of the `TraceCleanupSolver` pipeline to address issues #29 and #34.

### mergeSameNetCollinearTraces (issue #29)

Merges trace segments from the same net that are **collinear** (same Y for horizontal, same X for vertical) and contiguous or overlapping. When 3 pins are in a row connected by one net, the two adjacent segments are extended to cover the union of their ranges — effectively making 2 segments into 1.

- Groups traces by `globalConnNetId`
- Detects collinear segments (within floating-point tolerance `EPS=1e-6`)
- Checks for contiguous/overlapping ranges with configurable gap tolerance (default 0.1)
- Extends both traces to the merged union range
- Skips merges that would cause chip obstacle collisions
- Uses a `mergedPairs` set to prevent re-processing the same pair

### mergeSameNetCloseTraces (issue #34)

Snaps parallel same-net segments that are **close but not collinear** (within distance threshold, default 0.15) to their midpoint coordinate.

- Only applies to internal (non-endpoint) segments to preserve pin connectivity
- Groups traces by `globalConnNetId`
- Finds parallel pairs with overlapping ranges and distance within threshold
- Snaps both segments to the midpoint coordinate
- Reverts snaps that cause chip obstacle collisions

### Tests

- 7 unit tests for `mergeSameNetCollinearTraces`
- 8 unit tests for `mergeSameNetCloseTraces` 
- 2 integration tests via `SchematicTracePipelineSolver`
- All 51 existing tests continue to pass

## Test Results

```
 68 pass
 4 skip
 0 fail
Ran 72 tests across 55 files.
```

Closes #29
Closes #34

/claim #29
/claim #34