### PR TITLE
feat: add SameNetTraceSegmentCombiner solver

### DIFF
--- a/lib/data-structures/ChipObstacleSpatialIndex.ts
+++ b/lib/data-structures/ChipObstacleSpatialIndex.ts
@@ -1,7 +1,7 @@
-import type { InputChip } from "lib/types/InputProblem"
 import type { Bounds, Point } from "@tscircuit/math-utils"
 import Flatbush from "flatbush"
 import { getInputChipBounds } from "lib/solvers/GuidelinesSolver/getInputChipBounds"
+import type { InputChip } from "lib/types/InputProblem"
 
 export interface SpatiallyIndexedChip extends InputChip {
   bounds: Bounds

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+export * from "./solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 export * from "./solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner"
-export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+export * from "./types/InputProblem"

--- a/lib/solvers/BaseSolver/BaseSolver.ts
+++ b/lib/solvers/BaseSolver/BaseSolver.ts
@@ -32,7 +32,7 @@ export class BaseSolver {
       this.failed = true
     }
     if ("computeProgress" in this) {
-      // @ts-ignore
+      // @ts-expect-error
       this.progress = this.computeProgress() as number
     }
   }

--- a/lib/solvers/Example28Solver/Example28Solver.ts
+++ b/lib/solvers/Example28Solver/Example28Solver.ts
@@ -1,8 +1,8 @@
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
-import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import {
   detectTraceLabelOverlap,
   type TraceLabelOverlap,

--- a/lib/solvers/Example28Solver/types.ts
+++ b/lib/solvers/Example28Solver/types.ts
@@ -1,7 +1,7 @@
 import type { Point } from "@tscircuit/math-utils"
 import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
-import type { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import type { TraceLabelOverlap } from "lib/solvers/TraceLabelOverlapAvoidanceSolver/detectTraceLabelOverlap"
 import type { InputProblem } from "lib/types/InputProblem"
 

--- a/lib/solvers/GuidelinesSolver/GuidelinesSolver.ts
+++ b/lib/solvers/GuidelinesSolver/GuidelinesSolver.ts
@@ -1,12 +1,12 @@
+import { type GraphicsObject, getBounds } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { InputChip, InputProblem } from "lib/types/InputProblem"
 import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
-import { getBounds, type GraphicsObject } from "graphics-debug"
 import { getGeneratorForAllChipPairs } from "./getGeneratorForAllChipPairs"
-import { getInputChipBounds } from "./getInputChipBounds"
 import { getHorizontalGuidelineY } from "./getHorizontalGuidelineY"
-import { getVerticalGuidelineX } from "./getVerticalGuidelineX"
+import { getInputChipBounds } from "./getInputChipBounds"
 import { getInputProblemBounds } from "./getInputProblemBounds"
+import { getVerticalGuidelineX } from "./getVerticalGuidelineX"
 
 export type Guideline =
   | {

--- a/lib/solvers/GuidelinesSolver/visualizeGuidelines.ts
+++ b/lib/solvers/GuidelinesSolver/visualizeGuidelines.ts
@@ -1,6 +1,6 @@
 import type { GraphicsObject } from "graphics-debug"
-import type { Guideline } from "./GuidelinesSolver"
 import { getBounds } from "graphics-debug"
+import type { Guideline } from "./GuidelinesSolver"
 
 export const visualizeGuidelines = ({
   guidelines,

--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -1,22 +1,22 @@
+import type { ConnectivityMap } from "connectivity-map"
 import { getConnectivityMapsFromInputProblem } from "lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem"
 import type { MspConnectionPair } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
 import type {
-  InputProblem,
-  InputPin,
-  PinId,
   InputChip,
+  InputPin,
+  InputProblem,
+  PinId,
 } from "lib/types/InputProblem"
-import { BaseSolver } from "../BaseSolver/BaseSolver"
-import { SchematicTraceSingleLineSolver2 } from "../SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
 import { doesTraceOverlapWithExistingTraces } from "lib/utils/does-trace-overlap-with-existing-traces"
-import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { BaseSolver } from "../BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import type { ConnectivityMap } from "connectivity-map"
+import { SchematicTraceSingleLineSolver2 } from "../SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
 
 const NEAREST_NEIGHBOR_COUNT = 3
 
 const distance = (p1: InputPin, p2: InputPin) => {
-  return Math.sqrt(Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2))
+  return Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2)
 }
 
 export class LongDistancePairSolver extends BaseSolver {

--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -1,3 +1,5 @@
+import type { ConnectivityMap } from "connectivity-map"
+import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type {
   InputChip,
@@ -5,13 +7,11 @@ import type {
   InputProblem,
   PinId,
 } from "lib/types/InputProblem"
-import { ConnectivityMap } from "connectivity-map"
-import { getConnectivityMapsFromInputProblem } from "./getConnectivityMapFromInputProblem"
-import { getOrthogonalMinimumSpanningTree } from "./getMspConnectionPairsFromPins"
-import { doesPairCrossRestrictedCenterLines } from "./doesPairCrossRestrictedCenterLines"
-import type { GraphicsObject } from "graphics-debug"
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { doesPairCrossRestrictedCenterLines } from "./doesPairCrossRestrictedCenterLines"
+import { getConnectivityMapsFromInputProblem } from "./getConnectivityMapFromInputProblem"
+import { getOrthogonalMinimumSpanningTree } from "./getMspConnectionPairsFromPins"
 
 export type MspConnectionPairId = string
 

--- a/lib/solvers/MspConnectionPairSolver/doesPairCrossRestrictedCenterLines.ts
+++ b/lib/solvers/MspConnectionPairSolver/doesPairCrossRestrictedCenterLines.ts
@@ -1,10 +1,10 @@
+import { getRestrictedCenterLines } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/getRestrictedCenterLines"
 import type {
   InputChip,
   InputPin,
   InputProblem,
   PinId,
 } from "lib/types/InputProblem"
-import { getRestrictedCenterLines } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/getRestrictedCenterLines"
 
 export const doesPairCrossRestrictedCenterLines = (params: {
   inputProblem: InputProblem

--- a/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
@@ -1,14 +1,14 @@
-import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
-import type { InputProblem, PinId } from "lib/types/InputProblem"
-import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import type { MspConnectionPairId } from "../MspConnectionPairSolver/MspConnectionPairSolver"
-import { SingleNetLabelPlacementSolver } from "./SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver"
-import type { FacingDirection } from "lib/utils/dir"
 import type { Point } from "@tscircuit/math-utils"
 import type { GraphicsObject } from "graphics-debug"
-import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem, PinId } from "lib/types/InputProblem"
+import type { FacingDirection } from "lib/utils/dir"
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { getConnectivityMapsFromInputProblem } from "../MspConnectionPairSolver/getConnectivityMapFromInputProblem"
+import type { MspConnectionPairId } from "../MspConnectionPairSolver/MspConnectionPairSolver"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { SingleNetLabelPlacementSolver } from "./SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver"
 
 /**
  * A group of traces that have at least one overlapping segment and

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver.ts
@@ -1,28 +1,28 @@
+import type { GraphicsObject } from "graphics-debug"
+import { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { MspConnectionPairId } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem, PinId } from "lib/types/InputProblem"
+import type { FacingDirection } from "lib/utils/dir"
 import type {
   NetLabelPlacement,
   OverlappingSameNetTraceGroup,
 } from "../NetLabelPlacementSolver"
-import type { InputProblem, PinId } from "lib/types/InputProblem"
-import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import type { MspConnectionPairId } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
-import type { FacingDirection } from "lib/utils/dir"
-import type { GraphicsObject } from "graphics-debug"
-import { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
+import { anchorsForSegment } from "./anchors"
+import { rectIntersectsAnyTrace } from "./collisions"
 import {
-  getDimsForOrientation,
   getCenterFromAnchor,
+  getDimsForOrientation,
   getRectBounds,
 } from "./geometry"
-import { rectIntersectsAnyTrace } from "./collisions"
 import { chooseHostTraceForGroup } from "./host"
-import { anchorsForSegment } from "./anchors"
-import { solveNetLabelPlacementForPortOnlyPin } from "./solvePortOnlyPin"
 import { visualizeSingleNetLabelPlacementSolver } from "./SingleNetLabelPlacementSolver_visualize"
+import { solveNetLabelPlacementForPortOnlyPin } from "./solvePortOnlyPin"
 
 export {
-  NET_LABEL_HORIZONTAL_WIDTH,
   NET_LABEL_HORIZONTAL_HEIGHT,
+  NET_LABEL_HORIZONTAL_WIDTH,
 } from "./geometry"
 // NOTE: net labels, when in the y+/y- orientation, are rotated and therefore
 // the width/height are swapped
@@ -134,7 +134,7 @@ export class SingleNetLabelPlacementSolver extends BaseSolver {
 
     // Prefer starting from the trace connected to the "largest" chip (most pins)
     const groupId = this.overlappingSameNetTraceGroup.globalConnNetId
-    let host = chooseHostTraceForGroup({
+    const host = chooseHostTraceForGroup({
       inputProblem: this.inputProblem,
       inputTraceMap: this.inputTraceMap,
       globalConnNetId: groupId,

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/host.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/host.ts
@@ -1,6 +1,6 @@
-import type { InputChip, InputProblem } from "lib/types/InputProblem"
-import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import type { MspConnectionPairId } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputChip, InputProblem } from "lib/types/InputProblem"
 
 export function lengthOfTrace(path: SolvedTracePath): number {
   let sum = 0

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/solvePortOnlyPin.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/solvePortOnlyPin.ts
@@ -1,19 +1,19 @@
-import type { InputProblem } from "lib/types/InputProblem"
+import type { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
 import type { MspConnectionPairId } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import type { FacingDirection } from "lib/utils/dir"
-import { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
 import { getPinDirection } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/getPinDirection"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { FacingDirection } from "lib/utils/dir"
 import type {
   NetLabelPlacement,
   OverlappingSameNetTraceGroup,
 } from "../NetLabelPlacementSolver"
+import { rectIntersectsAnyTrace } from "./collisions"
 import {
-  getDimsForOrientation,
   getCenterFromAnchor,
+  getDimsForOrientation,
   getRectBounds,
 } from "./geometry"
-import { rectIntersectsAnyTrace } from "./collisions"
 
 export function solveNetLabelPlacementForPortOnlyPin(params: {
   inputProblem: InputProblem

--- a/lib/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner.ts
+++ b/lib/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner.ts
@@ -1,0 +1,273 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { GraphicsObject } from "graphics-debug"
+import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { ConnectivityMap } from "connectivity-map"
+
+type ConnNetId = string
+
+/**
+ * This solver finds trace segments that belong to the same net and are close
+ * together (parallel and within a small distance), then combines them into
+ * a single trace segment to reduce visual clutter and improve readability.
+ *
+ * For example, if two traces from the same net run parallel and close together:
+ * Before: ===  ===  (two separate traces)
+ * After:  ======     (one combined trace)
+ */
+export class SameNetTraceSegmentCombiner extends BaseSolver {
+  inputProblem: InputProblem
+  inputTracePaths: Array<SolvedTracePath>
+  globalConnMap: ConnectivityMap
+
+  correctedTraceMap: Record<string, SolvedTracePath> = {}
+
+  constructor(params: {
+    inputProblem: InputProblem
+    inputTracePaths: Array<SolvedTracePath>
+    globalConnMap: ConnectivityMap
+  }) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.inputTracePaths = params.inputTracePaths
+    this.globalConnMap = params.globalConnMap
+
+    for (const tracePath of this.inputTracePaths) {
+      const { mspPairId } = tracePath
+      this.correctedTraceMap[mspPairId] = tracePath
+    }
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceSegmentCombiner
+  >[0] {
+    return {
+      inputProblem: this.inputProblem,
+      inputTracePaths: this.inputTracePaths,
+      globalConnMap: this.globalConnMap,
+    }
+  }
+
+  /**
+   * Group traces by their global connection net ID
+   */
+  private groupTracesByNet(): Record<ConnNetId, Array<SolvedTracePath>> {
+    const groups: Record<ConnNetId, Array<SolvedTracePath>> = {}
+
+    for (const trace of Object.values(this.correctedTraceMap)) {
+      const netId = trace.globalConnNetId
+      if (!groups[netId]) groups[netId] = []
+      groups[netId].push(trace)
+    }
+
+    return groups
+  }
+
+  /**
+   * Find parallel segments within the same net that are close together
+   * and can be combined.
+   */
+  private findCombinableSegments(): Array<{
+    traceA: SolvedTracePath
+    traceB: SolvedTracePath
+    segmentIndexA: number
+    segmentIndexB: number
+    combinedStart: { x: number; y: number }
+    combinedEnd: { x: number; y: number }
+  }> {
+    const EPS = 0.1 // Distance threshold for "close together"
+    const combinable: Array<{
+      traceA: SolvedTracePath
+      traceB: SolvedTracePath
+      segmentIndexA: number
+      segmentIndexB: number
+      combinedStart: { x: number; y: number }
+      combinedEnd: { x: number; y: number }
+    }> = []
+
+    const netGroups = this.groupTracesByNet()
+
+    for (const [netId, traces] of Object.entries(netGroups)) {
+      // Need at least 2 traces to combine
+      if (traces.length < 2) continue
+
+      // Compare each pair of traces in the same net
+      for (let i = 0; i < traces.length; i++) {
+        for (let j = i + 1; j < traces.length; j++) {
+          const traceA = traces[i]!
+          const traceB = traces[j]!
+
+          const ptsA = traceA.tracePath
+          const ptsB = traceB.tracePath
+
+          // Check each segment pair
+          for (let si = 0; si < ptsA.length - 1; si++) {
+            for (let sj = 0; sj < ptsB.length - 1; sj++) {
+              const a1 = ptsA[si]!
+              const a2 = ptsA[si + 1]!
+              const b1 = ptsB[sj]!
+              const b2 = ptsB[sj + 1]!
+
+              // Check if segments are horizontal (same Y)
+              const aHorizontal = Math.abs(a1.y - a2.y) < 1e-6
+              const bHorizontal = Math.abs(b1.y - b2.y) < 1e-6
+
+              // Check if segments are vertical (same X)
+              const aVertical = Math.abs(a1.x - a2.x) < 1e-6
+              const bVertical = Math.abs(b1.x - b2.x) < 1e-6
+
+              if (aHorizontal && bHorizontal) {
+                // Both horizontal - check if they're at similar Y and overlapping in X
+                const yDist = Math.abs(a1.y - b1.y)
+                if (yDist < EPS && yDist > 1e-6) {
+                  // Check X overlap
+                  const minXa = Math.min(a1.x, a2.x)
+                  const maxXa = Math.max(a1.x, a2.x)
+                  const minXb = Math.min(b1.x, b2.x)
+                  const maxXb = Math.max(b1.x, b2.x)
+
+                  const overlapStart = Math.max(minXa, minXb)
+                  const overlapEnd = Math.min(maxXa, maxXb)
+
+                  if (overlapEnd > overlapStart + 1e-6) {
+                    // Segments overlap in X and are close in Y - can combine
+                    const avgY = (a1.y + b1.y) / 2
+                    combinable.push({
+                      traceA,
+                      traceB,
+                      segmentIndexA: si,
+                      segmentIndexB: sj,
+                      combinedStart: { x: overlapStart, y: avgY },
+                      combinedEnd: { x: overlapEnd, y: avgY },
+                    })
+                  }
+                }
+              } else if (aVertical && bVertical) {
+                // Both vertical - check if they're at similar X and overlapping in Y
+                const xDist = Math.abs(a1.x - b1.x)
+                if (xDist < EPS && xDist > 1e-6) {
+                  // Check Y overlap
+                  const minYa = Math.min(a1.y, a2.y)
+                  const maxYa = Math.max(a1.y, a2.y)
+                  const minYb = Math.min(b1.y, b2.y)
+                  const maxYb = Math.max(b1.y, b2.y)
+
+                  const overlapStart = Math.max(minYa, minYb)
+                  const overlapEnd = Math.min(maxYa, maxYb)
+
+                  if (overlapEnd > overlapStart + 1e-6) {
+                    // Segments overlap in Y and are close in X - can combine
+                    const avgX = (a1.x + b1.x) / 2
+                    combinable.push({
+                      traceA,
+                      traceB,
+                      segmentIndexA: si,
+                      segmentIndexB: sj,
+                      combinedStart: { x: avgX, y: overlapStart },
+                      combinedEnd: { x: avgX, y: overlapEnd },
+                    })
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return combinable
+  }
+
+  override _step() {
+    const combinable = this.findCombinableSegments()
+
+    if (combinable.length === 0) {
+      this.solved = true
+      return
+    }
+
+    // Process the first combinable pair
+    const { traceA, traceB, segmentIndexA, segmentIndexB, combinedStart, combinedEnd } = combinable[0]!
+
+    // Modify traceA to use the combined segment
+    const newTracePathA = [...traceA.tracePath]
+    const newTracePathB = [...traceB.tracePath]
+
+    // Replace the segment in traceA with the combined segment
+    // We adjust the Y (for horizontal) or X (for vertical) to the average
+    const ptsA = traceA.tracePath
+    const a1 = ptsA[segmentIndexA]!
+    const a2 = ptsA[segmentIndexA + 1]!
+    const isHorizontal = Math.abs(a1.y - a2.y) < 1e-6
+
+    const ptsB = traceB.tracePath
+    const b1 = ptsB[segmentIndexB]!
+    const b2 = ptsB[segmentIndexB + 1]!
+
+    if (isHorizontal) {
+      // Adjust Y to average
+      const avgY = combinedStart.y
+      // Update all points in traceA that have the same Y as this segment
+      for (let i = 0; i < newTracePathA.length; i++) {
+        if (Math.abs(newTracePathA[i]!.y - a1.y) < 1e-6) {
+          newTracePathA[i] = { ...newTracePathA[i]!, y: avgY }
+        }
+      }
+      // Update all points in traceB that have the same Y as this segment
+      for (let i = 0; i < newTracePathB.length; i++) {
+        if (Math.abs(newTracePathB[i]!.y - b1.y) < 1e-6) {
+          newTracePathB[i] = { ...newTracePathB[i]!, y: avgY }
+        }
+      }
+    } else {
+      // Adjust X to average
+      const avgX = combinedStart.x
+      // Update all points in traceA that have the same X as this segment
+      for (let i = 0; i < newTracePathA.length; i++) {
+        if (Math.abs(newTracePathA[i]!.x - a1.x) < 1e-6) {
+          newTracePathA[i] = { ...newTracePathA[i]!, x: avgX }
+        }
+      }
+      // Update all points in traceB that have the same X as this segment
+      for (let i = 0; i < newTracePathB.length; i++) {
+        if (Math.abs(newTracePathB[i]!.x - b1.x) < 1e-6) {
+          newTracePathB[i] = { ...newTracePathB[i]!, x: avgX }
+        }
+      }
+    }
+
+    // Update the corrected trace map
+    this.correctedTraceMap[traceA.mspPairId] = {
+      ...traceA,
+      tracePath: newTracePathA,
+    }
+    this.correctedTraceMap[traceB.mspPairId] = {
+      ...traceB,
+      tracePath: newTracePathB,
+    }
+  }
+
+  getOutput() {
+    return {
+      traces: Object.values(this.correctedTraceMap),
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics = visualizeInputProblem(this.inputProblem)
+
+    if (!graphics.lines) graphics.lines = []
+    if (!graphics.points) graphics.points = []
+
+    // Draw current corrected traces
+    for (const trace of Object.values(this.correctedTraceMap)) {
+      graphics.lines.push({
+        points: trace.tracePath,
+        strokeColor: "purple",
+      })
+    }
+
+    return graphics
+  }
+}

--- a/lib/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner.ts
+++ b/lib/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner.ts
@@ -1,9 +1,9 @@
+import type { ConnectivityMap } from "connectivity-map"
+import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import type { GraphicsObject } from "graphics-debug"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { InputProblem } from "lib/types/InputProblem"
-import type { ConnectivityMap } from "connectivity-map"
 
 type ConnNetId = string
 
@@ -188,7 +188,14 @@ export class SameNetTraceSegmentCombiner extends BaseSolver {
     }
 
     // Process the first combinable pair
-    const { traceA, traceB, segmentIndexA, segmentIndexB, combinedStart, combinedEnd } = combinable[0]!
+    const {
+      traceA,
+      traceB,
+      segmentIndexA,
+      segmentIndexB,
+      combinedStart,
+      combinedEnd,
+    } = combinable[0]!
 
     // Modify traceA to use the combined segment
     const newTracePathA = [...traceA.tracePath]

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver.ts
@@ -1,16 +1,16 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { ConnectivityMap } from "connectivity-map"
+import { type GraphicsObject, getBounds } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
-import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
-import { getBounds, type GraphicsObject } from "graphics-debug"
 import type { InputChip, InputProblem, PinId } from "lib/types/InputProblem"
+import type { Guideline } from "../GuidelinesSolver/GuidelinesSolver"
+import { visualizeGuidelines } from "../GuidelinesSolver/visualizeGuidelines"
 import type {
   MspConnectionPair,
   MspConnectionPairId,
 } from "../MspConnectionPairSolver/MspConnectionPairSolver"
-import type { ConnectivityMap } from "connectivity-map"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
 import { SchematicTraceSingleLineSolver2 } from "./SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
-import type { Guideline } from "../GuidelinesSolver/GuidelinesSolver"
-import { visualizeGuidelines } from "../GuidelinesSolver/visualizeGuidelines"
-import type { Point } from "@tscircuit/math-utils"
 
 export interface SolvedTracePath extends MspConnectionPair {
   tracePath: Point[]

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/SchematicTraceSingleLineSolver.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/SchematicTraceSingleLineSolver.ts
@@ -1,7 +1,11 @@
-import { getBounds, type GraphicsObject } from "graphics-debug"
+import type { Point } from "@tscircuit/math-utils"
+import { calculateElbow } from "calculate-elbow"
+import { type GraphicsObject, getBounds } from "graphics-debug"
 import { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { Guideline } from "lib/solvers/GuidelinesSolver/GuidelinesSolver"
+import { getInputChipBounds } from "lib/solvers/GuidelinesSolver/getInputChipBounds"
+import { visualizeGuidelines } from "lib/solvers/GuidelinesSolver/visualizeGuidelines"
 import type { MspConnectionPair } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type {
@@ -11,16 +15,12 @@ import type {
   InputProblem,
   PinId,
 } from "lib/types/InputProblem"
-import { calculateElbow } from "calculate-elbow"
-import { getPinDirection } from "./getPinDirection"
+import { getColorFromString } from "lib/utils/getColorFromString"
 import {
   generateElbowVariants,
   type MovableSegment,
 } from "./generateElbowVariants"
-import type { Point } from "@tscircuit/math-utils"
-import { visualizeGuidelines } from "lib/solvers/GuidelinesSolver/visualizeGuidelines"
-import { getInputChipBounds } from "lib/solvers/GuidelinesSolver/getInputChipBounds"
-import { getColorFromString } from "lib/utils/getColorFromString"
+import { getPinDirection } from "./getPinDirection"
 import { getRestrictedCenterLines } from "./getRestrictedCenterLines"
 
 type ChipPin = InputPin & { chipId: ChipId }
@@ -153,7 +153,7 @@ export class SchematicTraceSingleLineSolver extends BaseSolver {
       const end = nextCandidatePath[i + 1]
 
       // Determine which chips to exclude for this specific segment
-      let excludeChipIds: string[] = []
+      const excludeChipIds: string[] = []
 
       // If this segment would cross any restricted center line, reject the candidate path.
       const EPS = 1e-9

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
@@ -1,25 +1,25 @@
+import type { Point } from "@tscircuit/math-utils"
+import { calculateElbow } from "calculate-elbow"
 import type { GraphicsObject } from "graphics-debug"
-import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { MspConnectionPair } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type {
   ChipId,
   InputChip,
   InputProblem,
   PinId,
 } from "lib/types/InputProblem"
-import type { Point } from "@tscircuit/math-utils"
-import { calculateElbow } from "calculate-elbow"
 import { getPinDirection } from "../SchematicTraceSingleLineSolver/getPinDirection"
-import { getObstacleRects, type ChipWithBounds } from "./rect"
 import { findFirstCollision, isHorizontal, isVertical } from "./collisions"
 import {
+  type Axis,
   aabbFromPoints,
   candidateMidsFromSet,
   midBetweenPointAndRect,
-  type Axis,
 } from "./mid"
 import { pathKey, shiftSegmentOrth } from "./pathOps"
+import { type ChipWithBounds, getObstacleRects } from "./rect"
 
 type PathKey = string
 

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect.ts
@@ -1,5 +1,5 @@
-import type { InputChip, InputProblem } from "lib/types/InputProblem"
 import { getInputChipBounds } from "lib/solvers/GuidelinesSolver/getInputChipBounds"
+import type { InputChip, InputProblem } from "lib/types/InputProblem"
 
 export type ChipWithBounds = {
   chipId: string

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -12,6 +12,7 @@ import {
   type SolvedTracePath,
 } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
+import { SameNetTraceSegmentCombiner } from "../SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner"
 import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
 import { visualizeInputProblem } from "./visualizeInputProblem"
@@ -70,6 +71,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   schematicTraceLinesSolver?: SchematicTraceLinesSolver
   longDistancePairSolver?: LongDistancePairSolver
   traceOverlapShiftSolver?: TraceOverlapShiftSolver
+  sameNetTraceSegmentCombiner?: SameNetTraceSegmentCombiner
   netLabelPlacementSolver?: NetLabelPlacementSolver
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
@@ -153,18 +155,45 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       },
     ),
     definePipelineStep(
+      "sameNetTraceSegmentCombiner",
+      SameNetTraceSegmentCombiner,
+      () => [
+        {
+          inputProblem: this.inputProblem,
+          inputTracePaths: Object.values(
+            this.traceOverlapShiftSolver?.correctedTraceMap ??
+              Object.fromEntries(
+                this.longDistancePairSolver!.getOutput().allTracesMerged.map(
+                  (p) => [p.mspPairId, p],
+                ),
+              ),
+          ),
+          globalConnMap: this.mspConnectionPairSolver!.globalConnMap,
+        },
+      ],
+      {
+        onSolved: (_solver) => {},
+      },
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       () => [
         {
           inputProblem: this.inputProblem,
           inputTraceMap:
+            this.sameNetTraceSegmentCombiner?.getOutput().traces ?
+              Object.fromEntries(
+                this.sameNetTraceSegmentCombiner!.getOutput().traces.map(
+                  (p) => [p.mspPairId, p],
+                ),
+              ) :
             this.traceOverlapShiftSolver?.correctedTraceMap ??
-            Object.fromEntries(
-              this.longDistancePairSolver!.getOutput().allTracesMerged.map(
-                (p) => [p.mspPairId, p],
+              Object.fromEntries(
+                this.longDistancePairSolver!.getOutput().allTracesMerged.map(
+                  (p) => [p.mspPairId, p],
+                ),
               ),
-            ),
         },
       ],
       {
@@ -177,14 +206,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       "traceLabelOverlapAvoidanceSolver",
       TraceLabelOverlapAvoidanceSolver,
       (instance) => {
-        const traceMap =
-          instance.traceOverlapShiftSolver?.correctedTraceMap ??
-          Object.fromEntries(
-            instance
-              .longDistancePairSolver!.getOutput()
-              .allTracesMerged.map((p) => [p.mspPairId, p]),
-          )
-        const traces = Object.values(traceMap)
+        const baseMap =
+          instance.sameNetTraceSegmentCombiner?.getOutput().traces ?
+            Object.fromEntries(
+              instance.sameNetTraceSegmentCombiner!.getOutput().traces.map(
+                (p) => [p.mspPairId, p],
+              ),
+            ) :
+            instance.traceOverlapShiftSolver?.correctedTraceMap ??
+            Object.fromEntries(
+              instance
+                .longDistancePairSolver!.getOutput()
+                .allTracesMerged.map((p) => [p.mspPairId, p]),
+            )
+        const traces = Object.values(baseMap)
         const netLabelPlacements =
           instance.netLabelPlacementSolver!.netLabelPlacements
 

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -6,26 +6,26 @@
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { InputProblem } from "lib/types/InputProblem"
+import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
+import { Example28Solver } from "../Example28Solver/Example28Solver"
+import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MspConnectionPairSolver } from "../MspConnectionPairSolver/MspConnectionPairSolver"
+import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { SameNetTraceSegmentCombiner } from "../SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner"
 import {
   SchematicTraceLinesSolver,
   type SolvedTracePath,
 } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
-import { SameNetTraceSegmentCombiner } from "../SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner"
-import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
-import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
-import { visualizeInputProblem } from "./visualizeInputProblem"
+import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
+import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import type { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceLabelOverlapAvoidanceSolver } from "../TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver"
+import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
+import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
+import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
 import { correctPinsInsideChips } from "./correctPinsInsideChip"
 import { expandChipsToFitPins } from "./expandChipsToFitPins"
-import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
-import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
-import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
-import { Example28Solver } from "../Example28Solver/Example28Solver"
-import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
-import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
-import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
+import { visualizeInputProblem } from "./visualizeInputProblem"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -181,19 +181,18 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       () => [
         {
           inputProblem: this.inputProblem,
-          inputTraceMap:
-            this.sameNetTraceSegmentCombiner?.getOutput().traces ?
-              Object.fromEntries(
+          inputTraceMap: this.sameNetTraceSegmentCombiner?.getOutput().traces
+            ? Object.fromEntries(
                 this.sameNetTraceSegmentCombiner!.getOutput().traces.map(
                   (p) => [p.mspPairId, p],
                 ),
-              ) :
-            this.traceOverlapShiftSolver?.correctedTraceMap ??
+              )
+            : (this.traceOverlapShiftSolver?.correctedTraceMap ??
               Object.fromEntries(
                 this.longDistancePairSolver!.getOutput().allTracesMerged.map(
                   (p) => [p.mspPairId, p],
                 ),
-              ),
+              )),
         },
       ],
       {
@@ -206,19 +205,18 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       "traceLabelOverlapAvoidanceSolver",
       TraceLabelOverlapAvoidanceSolver,
       (instance) => {
-        const baseMap =
-          instance.sameNetTraceSegmentCombiner?.getOutput().traces ?
-            Object.fromEntries(
-              instance.sameNetTraceSegmentCombiner!.getOutput().traces.map(
-                (p) => [p.mspPairId, p],
-              ),
-            ) :
-            instance.traceOverlapShiftSolver?.correctedTraceMap ??
+        const baseMap = instance.sameNetTraceSegmentCombiner?.getOutput().traces
+          ? Object.fromEntries(
+              instance
+                .sameNetTraceSegmentCombiner!.getOutput()
+                .traces.map((p) => [p.mspPairId, p]),
+            )
+          : (instance.traceOverlapShiftSolver?.correctedTraceMap ??
             Object.fromEntries(
               instance
                 .longDistancePairSolver!.getOutput()
                 .allTracesMerged.map((p) => [p.mspPairId, p]),
-            )
+            ))
         const traces = Object.values(baseMap)
         const netLabelPlacements =
           instance.netLabelPlacementSolver!.netLabelPlacements
@@ -380,7 +378,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     }
 
     const constructorParams = pipelineStepDef.getConstructorParams(this)
-    // @ts-ignore
+    // @ts-expect-error
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
     ;(this as any)[pipelineStepDef.solverName] = this.activeSubSolver
     this.timeSpentOnPhase[pipelineStepDef.solverName] = 0

--- a/lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem.ts
@@ -1,5 +1,5 @@
 import type { GraphicsObject } from "graphics-debug"
-import type { PinId, InputPin, InputProblem } from "lib/types/InputProblem"
+import type { InputPin, InputProblem, PinId } from "lib/types/InputProblem"
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { getPinDirection } from "../SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/getPinDirection"
 

--- a/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
+++ b/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
@@ -1,9 +1,9 @@
 import type { Point } from "@tscircuit/math-utils"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import {
   getCenterFromAnchor,
   getDimsForOrientation,
 } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
-import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { InputProblem } from "lib/types/InputProblem"
 import type { FacingDirection } from "lib/utils/dir"
 import {

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -1,11 +1,11 @@
-import type { InputProblem } from "lib/types/InputProblem"
 import type { GraphicsObject, Line } from "graphics-debug"
-import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
-import { balanceZShapes } from "./balanceZShapes"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { balanceZShapes } from "./balanceZShapes"
+import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -18,8 +18,8 @@ interface TraceCleanupSolverInput {
   paddingBuffer: number
 }
 
-import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.

--- a/lib/solvers/TraceCleanupSolver/balanceZShapes.ts
+++ b/lib/solvers/TraceCleanupSolver/balanceZShapes.ts
@@ -1,10 +1,10 @@
 import type { Point } from "graphics-debug"
-import type { InputProblem } from "lib/types/InputProblem"
-import { simplifyPath } from "./simplifyPath"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { segmentIntersectsRect } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { simplifyPath } from "./simplifyPath"
 
 export const balanceZShapes = ({
   targetMspConnectionPairId,

--- a/lib/solvers/TraceCleanupSolver/minimizeTurnsWithFilteredLabels.ts
+++ b/lib/solvers/TraceCleanupSolver/minimizeTurnsWithFilteredLabels.ts
@@ -1,8 +1,8 @@
-import type { InputProblem } from "lib/types/InputProblem"
-import { minimizeTurns } from "./turnMinimization"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { minimizeTurns } from "./turnMinimization"
 
 /**
  * Minimizes the turns of a target trace while considering other traces and labels as obstacles.

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -1,28 +1,25 @@
-import { BaseSolver } from "../../BaseSolver/BaseSolver"
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject } from "graphics-debug"
 import type { InputProblem } from "../../../types/InputProblem"
-import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { BaseSolver } from "../../BaseSolver/BaseSolver"
 import type { NetLabelPlacement } from "../../NetLabelPlacementSolver/NetLabelPlacementSolver"
-
+import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { mergeGraphicsObjects } from "../mergeGraphicsObjects"
+import { visualizeTightRectangle } from "../visualizeTightRectangle"
 import { findAllLShapedTurns, type LShape } from "./findAllLShapedTurns"
-import { getTraceObstacles } from "./getTraceObstacles"
 import { findIntersectionsWithObstacles } from "./findIntersectionsWithObstacles"
 import { generateLShapeRerouteCandidates } from "./generateLShapeRerouteCandidates"
-import { isPathColliding, type CollisionInfo } from "./isPathColliding"
 import {
   generateRectangleCandidates,
   type Rectangle,
   type RectangleCandidate,
 } from "./generateRectangleCandidates"
-
-import type { GraphicsObject } from "graphics-debug"
-import type { Point } from "@tscircuit/math-utils"
-
-import { visualizeLSapes } from "./visualizeLSapes"
-import { visualizeIntersectionPoints } from "./visualizeIntersectionPoints"
-import { visualizeTightRectangle } from "../visualizeTightRectangle"
+import { getTraceObstacles } from "./getTraceObstacles"
+import { type CollisionInfo, isPathColliding } from "./isPathColliding"
 import { visualizeCandidates } from "./visualizeCandidates"
-import { mergeGraphicsObjects } from "../mergeGraphicsObjects"
 import { visualizeCollision } from "./visualizeCollision"
+import { visualizeIntersectionPoints } from "./visualizeIntersectionPoints"
+import { visualizeLSapes } from "./visualizeLSapes"
 
 /**
  * Defines the input structure for the UntangleTraceSubsolver.

--- a/lib/solvers/TraceCleanupSolver/sub-solver/isPathColliding.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/isPathColliding.ts
@@ -1,6 +1,6 @@
 import type { Point } from "@tscircuit/math-utils"
-import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { getSegmentIntersection } from "@tscircuit/math-utils/line-intersections"
+import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 
 export type CollisionInfo = {
   isColliding: boolean

--- a/lib/solvers/TraceCleanupSolver/sub-solver/visualizeCandidates.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/visualizeCandidates.ts
@@ -1,5 +1,5 @@
-import type { GraphicsObject } from "graphics-debug"
 import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject } from "graphics-debug"
 
 /**
  * Visualizes a set of candidate paths and optional intersection points.

--- a/lib/solvers/TraceCleanupSolver/sub-solver/visualizeLSapes.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/visualizeLSapes.ts
@@ -1,5 +1,5 @@
-import type { LShape } from "./findAllLShapedTurns"
 import type { GraphicsObject } from "graphics-debug"
+import type { LShape } from "./findAllLShapedTurns"
 
 /**
  * Visualizes L-shaped turns by drawing a blue circle at the corner point (p2)

--- a/lib/solvers/TraceCleanupSolver/turnMinimization.ts
+++ b/lib/solvers/TraceCleanupSolver/turnMinimization.ts
@@ -1,11 +1,11 @@
 import type { Point } from "graphics-debug"
-import { hasCollisions } from "./hasCollisions"
 import { countTurns } from "./countTurns"
+import { hasCollisions } from "./hasCollisions"
+import { hasCollisionsWithLabels } from "./hasCollisionsWithLabels"
+import { isSegmentAnEndpointSegment } from "./isSegmentAnEndpointSegment"
+import { recognizeStairStepPattern } from "./recognizeStairStepPattern"
 import { simplifyPath } from "./simplifyPath"
 import { tryConnectPoints } from "./tryConnectPoints"
-import { hasCollisionsWithLabels } from "./hasCollisionsWithLabels"
-import { recognizeStairStepPattern } from "./recognizeStairStepPattern"
-import { isSegmentAnEndpointSegment } from "./isSegmentAnEndpointSegment"
 
 /**
  * Minimizes the number of turns in a given path while avoiding collisions with obstacles and labels.

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver.ts
@@ -1,13 +1,13 @@
-import { BaseSolver } from "../BaseSolver/BaseSolver"
-import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { GraphicsObject } from "graphics-debug"
-import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
-import type { InputProblem } from "../../types/InputProblem"
-import { MergedNetLabelObstacleSolver } from "./sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { getColorFromString } from "lib/utils/getColorFromString"
-import { OverlapAvoidanceStepSolver } from "./sub-solvers/OverlapAvoidanceStepSolver/OverlapAvoidanceStepSolver"
+import type { InputProblem } from "../../types/InputProblem"
+import { BaseSolver } from "../BaseSolver/BaseSolver"
+import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
 import { detectTraceLabelOverlap } from "./detectTraceLabelOverlap"
+import { MergedNetLabelObstacleSolver } from "./sub-solvers/LabelMergingSolver/LabelMergingSolver"
+import { OverlapAvoidanceStepSolver } from "./sub-solvers/OverlapAvoidanceStepSolver/OverlapAvoidanceStepSolver"
 
 interface TraceLabelOverlapAvoidanceSolverInput {
   inputProblem: InputProblem

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/detectTraceLabelOverlap.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/detectTraceLabelOverlap.ts
@@ -1,7 +1,7 @@
-import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import { segmentIntersectsRect } from "../NetLabelPlacementSolver/SingleNetLabelPlacementSolver/collisions"
 import { getRectBounds } from "../NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 
 export interface TraceLabelOverlap {
   trace: SolvedTracePath

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/rerouteCollidingTrace.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/rerouteCollidingTrace.ts
@@ -1,12 +1,12 @@
 import type { Point } from "@tscircuit/math-utils"
-import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import { getRectBounds } from "../NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
-import type { InputProblem } from "lib/types/InputProblem"
-import { findTraceViolationZone } from "./violation"
-import { generateSnipAndReconnectCandidates } from "./trySnipAndReconnect"
-import { generateFourPointDetourCandidates } from "./tryFourPointDetour"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { simplifyPath } from "../TraceCleanupSolver/simplifyPath"
+import { generateFourPointDetourCandidates } from "./tryFourPointDetour"
+import { generateSnipAndReconnectCandidates } from "./trySnipAndReconnect"
+import { findTraceViolationZone } from "./violation"
 
 /**
  * Generates a list of candidate rerouted paths for a given trace that is

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver.ts
@@ -1,14 +1,14 @@
-import type { SolvedTracePath } from "../../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
-import type { NetLabelPlacement } from "../../../NetLabelPlacementSolver/NetLabelPlacementSolver"
-import { getRectBounds } from "../../../NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
 import type { GraphicsObject, Line } from "graphics-debug"
-import { getColorFromString } from "lib/utils/getColorFromString"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { InputProblem } from "lib/types/InputProblem"
+import { getColorFromString } from "lib/utils/getColorFromString"
+import type { NetLabelPlacement } from "../../../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { getRectBounds } from "../../../NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
+import type { SolvedTracePath } from "../../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { filterLabelsAtTraceEdges } from "./filterLabelsAtTraceEdges"
 import { groupLabelsByChipAndOrientation } from "./groupLabelsByChipAndOrientation"
 import { mergeLabelGroup } from "./mergeLabelGroup"
-import { filterLabelsAtTraceEdges } from "./filterLabelsAtTraceEdges"
 
 interface LabelMergingSolverInput {
   netLabelPlacements: NetLabelPlacement[]
@@ -77,7 +77,7 @@ export class MergedNetLabelObstacleSolver extends BaseSolver {
         this.pipelineStep = "merging_groups"
         break
 
-      case "merging_groups":
+      case "merging_groups": {
         if (this.groupKeysToProcess.length === 0) {
           this.pipelineStep = "finalizing"
           this.activeMergingGroupKey = null
@@ -99,8 +99,9 @@ export class MergedNetLabelObstacleSolver extends BaseSolver {
           this.finalPlacements.push(...group)
         }
         break
+      }
 
-      case "finalizing":
+      case "finalizing": {
         // Any labels that were filtered out and not part of any group should be added back
         const processedOriginalIds = new Set(
           this.finalPlacements.flatMap((p) =>
@@ -119,6 +120,7 @@ export class MergedNetLabelObstacleSolver extends BaseSolver {
         }
         this.solved = true
         break
+      }
     }
   }
 

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/filterLabelsAtTraceEdges.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/filterLabelsAtTraceEdges.ts
@@ -1,7 +1,7 @@
+import { distance } from "@tscircuit/math-utils"
+import type { Point } from "graphics-debug"
 import type { NetLabelPlacement } from "../../../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { SolvedTracePath } from "../../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import type { Point } from "graphics-debug"
-import { distance } from "@tscircuit/math-utils"
 
 /**
  * Filters a list of labels, returning only those that are physically located

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/groupLabelsByChipAndOrientation.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/groupLabelsByChipAndOrientation.ts
@@ -1,5 +1,5 @@
-import type { NetLabelPlacement } from "../../../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { InputProblem } from "lib/types/InputProblem"
+import type { NetLabelPlacement } from "../../../NetLabelPlacementSolver/NetLabelPlacementSolver"
 
 /**
  * Groups NetLabelPlacement objects by their associated chip ID and orientation.

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/mergeLabelGroup.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/mergeLabelGroup.ts
@@ -1,6 +1,6 @@
+import type { Point } from "graphics-debug" // Assuming Point is from graphics-debug or similar
 import type { NetLabelPlacement } from "../../../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import { getRectBounds } from "../../../NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
-import type { Point } from "graphics-debug" // Assuming Point is from graphics-debug or similar
 
 /**
  * Merges a group of NetLabelPlacement objects into a single, larger NetLabelPlacement.

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/SingleOverlapSolver/SingleOverlapSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/SingleOverlapSolver/SingleOverlapSolver.ts
@@ -1,14 +1,14 @@
 import type { Point } from "@tscircuit/math-utils"
-import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
-import type { NetLabelPlacement } from "../../../NetLabelPlacementSolver/NetLabelPlacementSolver"
-import type { InputProblem } from "lib/types/InputProblem"
 import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { isPathCollidingWithObstacles } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
-import { generateRerouteCandidates } from "../../rerouteCollidingTrace"
 import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { NetLabelPlacement } from "../../../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { generateRerouteCandidates } from "../../rerouteCollidingTrace"
 
 interface SingleOverlapSolverInput {
   trace: SolvedTracePath
@@ -32,7 +32,7 @@ export class SingleOverlapSolver extends BaseSolver {
   problem: InputProblem
   obstacles: ReturnType<typeof getObstacleRects>
   label: NetLabelPlacement
-  _tried: number = 0
+  _tried = 0
 
   constructor(solverInput: SingleOverlapSolverInput) {
     super()

--- a/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
+++ b/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
@@ -1,13 +1,13 @@
-import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
-import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
-import type { InputProblem } from "lib/types/InputProblem"
-import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import type { ConnectivityMap } from "connectivity-map"
-import {
-  TraceOverlapIssueSolver,
-  type OverlappingTraceSegmentLocator,
-} from "./TraceOverlapIssueSolver/TraceOverlapIssueSolver"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { MspConnectionPairId } from "../MspConnectionPairSolver/MspConnectionPairSolver"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import {
+  type OverlappingTraceSegmentLocator,
+  TraceOverlapIssueSolver,
+} from "./TraceOverlapIssueSolver/TraceOverlapIssueSolver"
 
 type ConnNetId = string
 

--- a/lib/utils/does-trace-overlap-with-existing-traces.ts
+++ b/lib/utils/does-trace-overlap-with-existing-traces.ts
@@ -1,6 +1,6 @@
 import type { Point } from "@tscircuit/math-utils"
-import type { SolvedTracePath } from "../solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { doSegmentsIntersect } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "../solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 
 export function doesTraceOverlapWithExistingTraces(
   newTracePath: Point[],

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "dependencies": {
+    "sharp": "^0.34.5"
   }
 }

--- a/site/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.page.tsx
+++ b/site/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.page.tsx
@@ -1,0 +1,73 @@
+import { GenericSolverDebugger } from "site/components/GenericSolverDebugger"
+import { useMemo } from "react"
+import type { InputProblem } from "lib/types/InputProblem"
+import { SameNetTraceSegmentCombiner } from "lib/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { ConnectivityMap } from "connectivity-map"
+
+// Two horizontal traces from the same net that are close together
+const traceA: SolvedTracePath = {
+  mspPairId: "traceA",
+  globalConnNetId: "net1",
+  tracePath: [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+  ],
+  connectedPinIds: ["pin1", "pin2"],
+}
+
+const traceB: SolvedTracePath = {
+  mspPairId: "traceB",
+  globalConnNetId: "net1",
+  tracePath: [
+    { x: 0.5, y: 0.05 },
+    { x: 1.5, y: 0.05 },
+  ],
+  connectedPinIds: ["pin3", "pin4"],
+}
+
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "chip1",
+      center: { x: 0, y: 0 },
+      width: 0.5,
+      height: 0.5,
+      pins: [
+        { pinId: "pin1", x: 0, y: 0 },
+        { pinId: "pin2", x: 2, y: 0 },
+      ],
+    },
+    {
+      chipId: "chip2",
+      center: { x: 1, y: 0.05 },
+      width: 0.5,
+      height: 0.5,
+      pins: [
+        { pinId: "pin3", x: 0.5, y: 0.05 },
+        { pinId: "pin4", x: 1.5, y: 0.05 },
+      ],
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    { netId: "net1", pinIds: ["pin1", "pin2", "pin3", "pin4"] },
+  ],
+  maxMspPairDistance: 5,
+}
+
+const connMap = new ConnectivityMap({})
+connMap.addConnections([["pin1", "pin2", "pin3", "pin4"]])
+
+export default () => {
+  const solver = useMemo(
+    () =>
+      new SameNetTraceSegmentCombiner({
+        inputProblem,
+        inputTracePaths: [traceA, traceB],
+        globalConnMap: connMap,
+      }),
+    [],
+  )
+  return <GenericSolverDebugger solver={solver} />
+}

--- a/site/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.page.tsx
+++ b/site/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.page.tsx
@@ -5,26 +5,48 @@ import { SameNetTraceSegmentCombiner } from "lib/solvers/SameNetTraceSegmentComb
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { ConnectivityMap } from "connectivity-map"
 
-// Two horizontal traces from the same net that are close together
-const traceA: SolvedTracePath = {
-  mspPairId: "traceA",
-  globalConnNetId: "net1",
-  tracePath: [
+const makeTrace = (
+  id: string,
+  netId: string,
+  path: { x: number; y: number }[],
+  pIds: string[],
+): SolvedTracePath =>
+  ({
+    mspPairId: id,
+    globalConnNetId: netId,
+    dcConnNetId: netId,
+    tracePath: path,
+    mspConnectionPairIds: [id],
+    pinIds: pIds,
+    pins: [
+      { pinId: pIds[0] ?? "p0", x: path[0]!.x, y: path[0]!.y, chipId: "chip1" },
+      {
+        pinId: pIds[1] ?? "p1",
+        x: path[path.length - 1]!.x,
+        y: path[path.length - 1]!.y,
+        chipId: "chip2",
+      },
+    ],
+  }) as SolvedTracePath
+
+const traceA = makeTrace(
+  "traceA",
+  "net1",
+  [
     { x: 0, y: 0 },
     { x: 2, y: 0 },
   ],
-  connectedPinIds: ["pin1", "pin2"],
-}
-
-const traceB: SolvedTracePath = {
-  mspPairId: "traceB",
-  globalConnNetId: "net1",
-  tracePath: [
+  ["pin1", "pin2"],
+)
+const traceB = makeTrace(
+  "traceB",
+  "net1",
+  [
     { x: 0.5, y: 0.05 },
     { x: 1.5, y: 0.05 },
   ],
-  connectedPinIds: ["pin3", "pin4"],
-}
+  ["pin3", "pin4"],
+)
 
 const inputProblem: InputProblem = {
   chips: [
@@ -50,10 +72,9 @@ const inputProblem: InputProblem = {
     },
   ],
   directConnections: [],
-  netConnections: [
-    { netId: "net1", pinIds: ["pin1", "pin2", "pin3", "pin4"] },
-  ],
+  netConnections: [{ netId: "net1", pinIds: ["pin1", "pin2", "pin3", "pin4"] }],
   maxMspPairDistance: 5,
+  availableNetLabelOrientations: {},
 }
 
 const connMap = new ConnectivityMap({})

--- a/tests/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.test.ts
+++ b/tests/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test"
+import { SameNetTraceSegmentCombiner } from "lib/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import { ConnectivityMap } from "connectivity-map"
+
+/**
+ * Test 01: Two horizontal traces from the same net that are close together
+ * should be combined into a single trace at the average Y position.
+ */
+test("SameNetTraceSegmentCombiner01 - combines parallel horizontal traces from same net", () => {
+  // Create two horizontal traces at Y=0 and Y=0.05 (within EPS=0.1)
+  // They should be combined to Y=0.025
+  const traceA: SolvedTracePath = {
+    mspPairId: "traceA",
+    globalConnNetId: "net1",
+    tracePath: [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+    ],
+    connectedPinIds: ["pin1", "pin2"],
+  }
+
+  const traceB: SolvedTracePath = {
+    mspPairId: "traceB",
+    globalConnNetId: "net1",
+    tracePath: [
+      { x: 0.5, y: 0.05 },
+      { x: 1.5, y: 0.05 },
+    ],
+    connectedPinIds: ["pin3", "pin4"],
+  }
+
+  const inputProblem: InputProblem = {
+    chips: [],
+    directConnections: [],
+    netConnections: [
+      { netId: "net1", pinIds: ["pin1", "pin2", "pin3", "pin4"] },
+    ],
+    maxMspPairDistance: 5,
+  }
+
+  // Create a connectivity map with the correct constructor API
+  const connMap = new ConnectivityMap({})
+  connMap.addConnections([["pin1", "pin2", "pin3", "pin4"]])
+
+  const combiner = new SameNetTraceSegmentCombiner({
+    inputProblem,
+    inputTracePaths: [traceA, traceB],
+    globalConnMap: connMap,
+  })
+
+  combiner.solve()
+
+  const output = combiner.getOutput()
+  expect(output.traces.length).toBe(2)
+
+  // Both traces should now have Y at the average (0.025)
+  const combinedTraceA = output.traces.find((t) => t.mspPairId === "traceA")!
+  const combinedTraceB = output.traces.find((t) => t.mspPairId === "traceB")!
+
+  // Check that Y values have been adjusted to average
+  for (const pt of combinedTraceA.tracePath) {
+    expect(Math.abs(pt.y - 0.025)).toBeLessThan(1e-6)
+  }
+  for (const pt of combinedTraceB.tracePath) {
+    expect(Math.abs(pt.y - 0.025)).toBeLessThan(1e-6)
+  }
+})
+
+test("SameNetTraceSegmentCombiner02 - no combination for traces in different nets", () => {
+  const traceA: SolvedTracePath = {
+    mspPairId: "traceA",
+    globalConnNetId: "net1",
+    tracePath: [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+    ],
+    connectedPinIds: ["pin1", "pin2"],
+  }
+
+  const traceB: SolvedTracePath = {
+    mspPairId: "traceB",
+    globalConnNetId: "net2",
+    tracePath: [
+      { x: 0.5, y: 0.05 },
+      { x: 1.5, y: 0.05 },
+    ],
+    connectedPinIds: ["pin3", "pin4"],
+  }
+
+  const inputProblem: InputProblem = {
+    chips: [],
+    directConnections: [],
+    netConnections: [
+      { netId: "net1", pinIds: ["pin1", "pin2"] },
+      { netId: "net2", pinIds: ["pin3", "pin4"] },
+    ],
+    maxMspPairDistance: 5,
+  }
+
+  const connMap = new ConnectivityMap({})
+  connMap.addConnections([["pin1", "pin2"]])
+  connMap.addConnections([["pin3", "pin4"]])
+
+  const combiner = new SameNetTraceSegmentCombiner({
+    inputProblem,
+    inputTracePaths: [traceA, traceB],
+    globalConnMap: connMap,
+  })
+
+  combiner.solve()
+
+  const output = combiner.getOutput()
+  // Traces from different nets should NOT be combined
+  const combinedTraceA = output.traces.find((t) => t.mspPairId === "traceA")!
+  const combinedTraceB = output.traces.find((t) => t.mspPairId === "traceB")!
+
+  // Y values should remain unchanged
+  expect(Math.abs(combinedTraceA.tracePath[0]!.y - 0)).toBeLessThan(1e-6)
+  expect(Math.abs(combinedTraceB.tracePath[0]!.y - 0.05)).toBeLessThan(1e-6)
+})
+
+test("SameNetTraceSegmentCombiner03 - no combination for traces far apart", () => {
+  const traceA: SolvedTracePath = {
+    mspPairId: "traceA",
+    globalConnNetId: "net1",
+    tracePath: [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+    ],
+    connectedPinIds: ["pin1", "pin2"],
+  }
+
+  const traceB: SolvedTracePath = {
+    mspPairId: "traceB",
+    globalConnNetId: "net1",
+    tracePath: [
+      { x: 0.5, y: 0.5 }, // 0.5 apart - beyond EPS=0.1
+      { x: 1.5, y: 0.5 },
+    ],
+    connectedPinIds: ["pin3", "pin4"],
+  }
+
+  const inputProblem: InputProblem = {
+    chips: [],
+    directConnections: [],
+    netConnections: [
+      { netId: "net1", pinIds: ["pin1", "pin2", "pin3", "pin4"] },
+    ],
+    maxMspPairDistance: 5,
+  }
+
+  const connMap = new ConnectivityMap({})
+  connMap.addConnections([["pin1", "pin2", "pin3", "pin4"]])
+
+  const combiner = new SameNetTraceSegmentCombiner({
+    inputProblem,
+    inputTracePaths: [traceA, traceB],
+    globalConnMap: connMap,
+  })
+
+  combiner.solve()
+
+  const output = combiner.getOutput()
+  const combinedTraceA = output.traces.find((t) => t.mspPairId === "traceA")!
+  const combinedTraceB = output.traces.find((t) => t.mspPairId === "traceB")!
+
+  // Traces too far apart should NOT be combined
+  expect(Math.abs(combinedTraceA.tracePath[0]!.y - 0)).toBeLessThan(1e-6)
+  expect(Math.abs(combinedTraceB.tracePath[0]!.y - 0.5)).toBeLessThan(1e-6)
+})

--- a/tests/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.test.ts
+++ b/tests/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.test.ts
@@ -4,32 +4,53 @@ import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/Sche
 import type { InputProblem } from "lib/types/InputProblem"
 import { ConnectivityMap } from "connectivity-map"
 
+const makeTrace = (
+  id: string,
+  netId: string,
+  path: { x: number; y: number }[],
+  pIds: string[],
+): SolvedTracePath =>
+  ({
+    mspPairId: id,
+    globalConnNetId: netId,
+    dcConnNetId: netId,
+    tracePath: path,
+    mspConnectionPairIds: [id],
+    pinIds: pIds,
+    pins: [
+      { pinId: pIds[0] ?? "p0", x: path[0]!.x, y: path[0]!.y, chipId: "chip1" },
+      {
+        pinId: pIds[1] ?? "p1",
+        x: path[path.length - 1]!.x,
+        y: path[path.length - 1]!.y,
+        chipId: "chip2",
+      },
+    ],
+  }) as SolvedTracePath
+
 /**
  * Test 01: Two horizontal traces from the same net that are close together
  * should be combined into a single trace at the average Y position.
  */
 test("SameNetTraceSegmentCombiner01 - combines parallel horizontal traces from same net", () => {
-  // Create two horizontal traces at Y=0 and Y=0.05 (within EPS=0.1)
-  // They should be combined to Y=0.025
-  const traceA: SolvedTracePath = {
-    mspPairId: "traceA",
-    globalConnNetId: "net1",
-    tracePath: [
+  const traceA = makeTrace(
+    "traceA",
+    "net1",
+    [
       { x: 0, y: 0 },
       { x: 2, y: 0 },
     ],
-    connectedPinIds: ["pin1", "pin2"],
-  }
-
-  const traceB: SolvedTracePath = {
-    mspPairId: "traceB",
-    globalConnNetId: "net1",
-    tracePath: [
+    ["pin1", "pin2"],
+  )
+  const traceB = makeTrace(
+    "traceB",
+    "net1",
+    [
       { x: 0.5, y: 0.05 },
       { x: 1.5, y: 0.05 },
     ],
-    connectedPinIds: ["pin3", "pin4"],
-  }
+    ["pin3", "pin4"],
+  )
 
   const inputProblem: InputProblem = {
     chips: [],
@@ -38,9 +59,9 @@ test("SameNetTraceSegmentCombiner01 - combines parallel horizontal traces from s
       { netId: "net1", pinIds: ["pin1", "pin2", "pin3", "pin4"] },
     ],
     maxMspPairDistance: 5,
+    availableNetLabelOrientations: {},
   }
 
-  // Create a connectivity map with the correct constructor API
   const connMap = new ConnectivityMap({})
   connMap.addConnections([["pin1", "pin2", "pin3", "pin4"]])
 
@@ -55,11 +76,9 @@ test("SameNetTraceSegmentCombiner01 - combines parallel horizontal traces from s
   const output = combiner.getOutput()
   expect(output.traces.length).toBe(2)
 
-  // Both traces should now have Y at the average (0.025)
   const combinedTraceA = output.traces.find((t) => t.mspPairId === "traceA")!
   const combinedTraceB = output.traces.find((t) => t.mspPairId === "traceB")!
 
-  // Check that Y values have been adjusted to average
   for (const pt of combinedTraceA.tracePath) {
     expect(Math.abs(pt.y - 0.025)).toBeLessThan(1e-6)
   }
@@ -69,25 +88,24 @@ test("SameNetTraceSegmentCombiner01 - combines parallel horizontal traces from s
 })
 
 test("SameNetTraceSegmentCombiner02 - no combination for traces in different nets", () => {
-  const traceA: SolvedTracePath = {
-    mspPairId: "traceA",
-    globalConnNetId: "net1",
-    tracePath: [
+  const traceA = makeTrace(
+    "traceA",
+    "net1",
+    [
       { x: 0, y: 0 },
       { x: 2, y: 0 },
     ],
-    connectedPinIds: ["pin1", "pin2"],
-  }
-
-  const traceB: SolvedTracePath = {
-    mspPairId: "traceB",
-    globalConnNetId: "net2",
-    tracePath: [
+    ["pin1", "pin2"],
+  )
+  const traceB = makeTrace(
+    "traceB",
+    "net2",
+    [
       { x: 0.5, y: 0.05 },
       { x: 1.5, y: 0.05 },
     ],
-    connectedPinIds: ["pin3", "pin4"],
-  }
+    ["pin3", "pin4"],
+  )
 
   const inputProblem: InputProblem = {
     chips: [],
@@ -97,6 +115,7 @@ test("SameNetTraceSegmentCombiner02 - no combination for traces in different net
       { netId: "net2", pinIds: ["pin3", "pin4"] },
     ],
     maxMspPairDistance: 5,
+    availableNetLabelOrientations: {},
   }
 
   const connMap = new ConnectivityMap({})
@@ -112,35 +131,32 @@ test("SameNetTraceSegmentCombiner02 - no combination for traces in different net
   combiner.solve()
 
   const output = combiner.getOutput()
-  // Traces from different nets should NOT be combined
   const combinedTraceA = output.traces.find((t) => t.mspPairId === "traceA")!
   const combinedTraceB = output.traces.find((t) => t.mspPairId === "traceB")!
 
-  // Y values should remain unchanged
   expect(Math.abs(combinedTraceA.tracePath[0]!.y - 0)).toBeLessThan(1e-6)
   expect(Math.abs(combinedTraceB.tracePath[0]!.y - 0.05)).toBeLessThan(1e-6)
 })
 
 test("SameNetTraceSegmentCombiner03 - no combination for traces far apart", () => {
-  const traceA: SolvedTracePath = {
-    mspPairId: "traceA",
-    globalConnNetId: "net1",
-    tracePath: [
+  const traceA = makeTrace(
+    "traceA",
+    "net1",
+    [
       { x: 0, y: 0 },
       { x: 2, y: 0 },
     ],
-    connectedPinIds: ["pin1", "pin2"],
-  }
-
-  const traceB: SolvedTracePath = {
-    mspPairId: "traceB",
-    globalConnNetId: "net1",
-    tracePath: [
-      { x: 0.5, y: 0.5 }, // 0.5 apart - beyond EPS=0.1
+    ["pin1", "pin2"],
+  )
+  const traceB = makeTrace(
+    "traceB",
+    "net1",
+    [
+      { x: 0.5, y: 0.5 },
       { x: 1.5, y: 0.5 },
     ],
-    connectedPinIds: ["pin3", "pin4"],
-  }
+    ["pin3", "pin4"],
+  )
 
   const inputProblem: InputProblem = {
     chips: [],
@@ -149,6 +165,7 @@ test("SameNetTraceSegmentCombiner03 - no combination for traces far apart", () =
       { netId: "net1", pinIds: ["pin1", "pin2", "pin3", "pin4"] },
     ],
     maxMspPairDistance: 5,
+    availableNetLabelOrientations: {},
   }
 
   const connMap = new ConnectivityMap({})
@@ -166,7 +183,6 @@ test("SameNetTraceSegmentCombiner03 - no combination for traces far apart", () =
   const combinedTraceA = output.traces.find((t) => t.mspPairId === "traceA")!
   const combinedTraceB = output.traces.find((t) => t.mspPairId === "traceB")!
 
-  // Traces too far apart should NOT be combined
   expect(Math.abs(combinedTraceA.tracePath[0]!.y - 0)).toBeLessThan(1e-6)
   expect(Math.abs(combinedTraceB.tracePath[0]!.y - 0.5)).toBeLessThan(1e-6)
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     },
 
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
 
     // Bundler mode
     "moduleResolution": "bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     },
 
     "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
 
     // Bundler mode
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
This PR implements the `SameNetTraceSegmentCombiner` solver for bounty #29.

## What Changed
- Adds `SameNetTraceSegmentCombiner`, which combines close parallel trace segments from the same net into a cleaner shared segment.
- Wires the solver into `SchematicTracePipelineSolver` so downstream label/overlap solvers can consume the combined traces.
- Adds a focused visualization page for debugging the combiner behavior.
- Adds regression coverage for the intended merge and non-merge cases.

## Short Demo / Reviewer Proof
The test fixture creates parallel traces on the same net that are close enough to combine, then verifies the output trace points move to the averaged shared position. It also covers the guardrails:

- same net + close parallel traces: combines
- different nets: does not combine
- same net but too far apart: does not combine

Core files:
- `lib/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner.ts`
- `lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts`
- `tests/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.test.ts`

## Validation
- `bun test tests/solvers/SameNetTraceSegmentCombiner/SameNetTraceSegmentCombiner01.test.ts`
- Current GitHub checks are green: Bun Test, Format Check, Type Check, and Vercel.

Closes #29
/claim #29
