### PR TITLE
feat: add SameNetTraceCombiningSolver pipeline phase (#29)

### DIFF
--- a/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
+++ b/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
@@ -1,0 +1,311 @@
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+/**
+ * Tolerance for treating two segments as collinear.
+ * Two horizontal segments with |y1 - y2| <= this are on the same horizontal line.
+ * Two vertical segments with |x1 - x2| <= this are on the same vertical line.
+ */
+const COLLINEAR_TOLERANCE = 0.01
+
+/**
+ * Maximum gap between two collinear same-net segments for them to be merged.
+ * If end-to-end gap exceeds this value the segments are left untouched.
+ */
+const MERGE_GAP = 0.15
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface Segment {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+}
+
+function getSegments(tracePath: Point[]): Segment[] {
+  const segs: Segment[] = []
+  for (let i = 0; i < tracePath.length - 1; i++) {
+    segs.push({
+      x1: tracePath[i].x,
+      y1: tracePath[i].y,
+      x2: tracePath[i + 1].x,
+      y2: tracePath[i + 1].y,
+    })
+  }
+  return segs
+}
+
+function isHorizontal(s: Segment): boolean {
+  return Math.abs(s.y1 - s.y2) < COLLINEAR_TOLERANCE
+}
+
+function isVertical(s: Segment): boolean {
+  return Math.abs(s.x1 - s.x2) < COLLINEAR_TOLERANCE
+}
+
+/**
+ * Removes duplicate or near-duplicate collinear points from a trace path.
+ * Points are considered duplicates if they are within COLLINEAR_TOLERANCE of each other.
+ */
+export function simplifyTracePath(path: Point[]): Point[] {
+  if (path.length <= 1) return path
+  const result: Point[] = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    const prev = result[result.length - 1]
+    const cur = path[i]
+    const dist = Math.hypot(cur.x - prev.x, cur.y - prev.y)
+    if (dist > COLLINEAR_TOLERANCE) {
+      result.push(cur)
+    }
+  }
+  return result
+}
+
+/**
+ * For a horizontal segment pair on the same y-axis:
+ * returns the merged span [min, max] if they overlap or are within MERGE_GAP,
+ * otherwise null.
+ */
+function tryMergeHorizontalSegments(
+  s1: Segment,
+  s2: Segment,
+): { min: number; max: number; y: number } | null {
+  if (!isHorizontal(s1) || !isHorizontal(s2)) return null
+  if (Math.abs(s1.y1 - s2.y1) > COLLINEAR_TOLERANCE) return null
+
+  const min1 = Math.min(s1.x1, s1.x2)
+  const max1 = Math.max(s1.x1, s1.x2)
+  const min2 = Math.min(s2.x1, s2.x2)
+  const max2 = Math.max(s2.x1, s2.x2)
+
+  // They can be merged if they overlap or the gap is small
+  const gap = Math.max(0, Math.max(min1, min2) - Math.min(max1, max2))
+  if (gap > MERGE_GAP) return null
+
+  return {
+    min: Math.min(min1, min2),
+    max: Math.max(max1, max2),
+    y: (s1.y1 + s2.y1) / 2,
+  }
+}
+
+/**
+ * For a vertical segment pair on the same x-axis:
+ * returns the merged span [min, max] if they overlap or are within MERGE_GAP,
+ * otherwise null.
+ */
+function tryMergeVerticalSegments(
+  s1: Segment,
+  s2: Segment,
+): { min: number; max: number; x: number } | null {
+  if (!isVertical(s1) || !isVertical(s2)) return null
+  if (Math.abs(s1.x1 - s2.x1) > COLLINEAR_TOLERANCE) return null
+
+  const min1 = Math.min(s1.y1, s1.y2)
+  const max1 = Math.max(s1.y1, s1.y2)
+  const min2 = Math.min(s2.y1, s2.y2)
+  const max2 = Math.max(s2.y1, s2.y2)
+
+  const gap = Math.max(0, Math.max(min1, min2) - Math.min(max1, max2))
+  if (gap > MERGE_GAP) return null
+
+  return {
+    min: Math.min(min1, min2),
+    max: Math.max(max1, max2),
+    x: (s1.x1 + s2.x1) / 2,
+  }
+}
+
+/**
+ * Replace a segment in a trace path with a new one spanning [mergedMin, mergedMax].
+ * The segment at `segIdx` is replaced in-place; any point at an endpoint that is
+ * now interior to the merged segment is removed.
+ */
+function applyMergedHorizontalSegment(
+  path: Point[],
+  segIdx: number,
+  merged: { min: number; max: number; y: number },
+): Point[] {
+  const result = [...path]
+  // Update the two endpoints of this segment
+  result[segIdx] = { x: merged.min, y: merged.y }
+  result[segIdx + 1] = { x: merged.max, y: merged.y }
+  return simplifyTracePath(result)
+}
+
+function applyMergedVerticalSegment(
+  path: Point[],
+  segIdx: number,
+  merged: { min: number; max: number; x: number },
+): Point[] {
+  const result = [...path]
+  result[segIdx] = { x: merged.x, y: merged.min }
+  result[segIdx + 1] = { x: merged.x, y: merged.max }
+  return simplifyTracePath(result)
+}
+
+export interface SameNetTraceCombiningSolverParams {
+  inputProblem: InputProblem
+  traces: SolvedTracePath[]
+}
+
+/**
+ * Pipeline phase that merges same-net trace segments that lie on the same
+ * horizontal or vertical line and are close together (within MERGE_GAP).
+ *
+ * This prevents visual duplication of wire segments when multiple MSP pairs
+ * belonging to the same net are routed along nearly-identical paths.
+ */
+export class SameNetTraceCombiningSolver extends BaseSolver {
+  inputProblem: InputProblem
+  inputTraces: SolvedTracePath[]
+  outputTraces: SolvedTracePath[]
+
+  private _solved = false
+
+  constructor({ inputProblem, traces }: SameNetTraceCombiningSolverParams) {
+    super()
+    this.inputProblem = inputProblem
+    this.inputTraces = traces
+    this.outputTraces = traces.map((t) => ({
+      ...t,
+      tracePath: [...t.tracePath.map((p) => ({ ...p }))],
+    }))
+  }
+
+  override _step() {
+    if (this._solved) {
+      this.solved = true
+      return
+    }
+
+    this._combineTraces()
+    this._solved = true
+    this.solved = true
+  }
+
+  private _combineTraces() {
+    // Group traces by net
+    const byNet = new Map<string, number[]>()
+    for (let i = 0; i < this.outputTraces.length; i++) {
+      const netId = this.outputTraces[i].globalConnNetId
+      if (!byNet.has(netId)) byNet.set(netId, [])
+      byNet.get(netId)!.push(i)
+    }
+
+    for (const [, idxs] of byNet) {
+      if (idxs.length < 2) continue
+      this._combineNetTraces(idxs)
+    }
+  }
+
+  /**
+   * For a group of traces on the same net, look for pairs of segments that
+   * are collinear and close enough to merge. When found, extend one segment
+   * to cover both and remove the now-redundant segment from the other trace.
+   */
+  private _combineNetTraces(traceIdxs: number[]) {
+    let changed = true
+    let maxPasses = 10 // Safety limit to avoid infinite loops
+
+    while (changed && maxPasses-- > 0) {
+      changed = false
+
+      outer: for (let ai = 0; ai < traceIdxs.length; ai++) {
+        for (let bi = ai + 1; bi < traceIdxs.length; bi++) {
+          const aIdx = traceIdxs[ai]
+          const bIdx = traceIdxs[bi]
+          const traceA = this.outputTraces[aIdx]
+          const traceB = this.outputTraces[bIdx]
+
+          const segsA = getSegments(traceA.tracePath)
+          const segsB = getSegments(traceB.tracePath)
+
+          for (let ai2 = 0; ai2 < segsA.length; ai2++) {
+            for (let bi2 = 0; bi2 < segsB.length; bi2++) {
+              const sA = segsA[ai2]
+              const sB = segsB[bi2]
+
+              // Try horizontal merge
+              const hMerge = tryMergeHorizontalSegments(sA, sB)
+              if (hMerge) {
+                this.outputTraces[aIdx] = {
+                  ...traceA,
+                  tracePath: applyMergedHorizontalSegment(
+                    traceA.tracePath,
+                    ai2,
+                    hMerge,
+                  ),
+                }
+                this.outputTraces[bIdx] = {
+                  ...traceB,
+                  tracePath: applyMergedHorizontalSegment(
+                    traceB.tracePath,
+                    bi2,
+                    hMerge,
+                  ),
+                }
+                changed = true
+                break outer
+              }
+
+              // Try vertical merge
+              const vMerge = tryMergeVerticalSegments(sA, sB)
+              if (vMerge) {
+                this.outputTraces[aIdx] = {
+                  ...traceA,
+                  tracePath: applyMergedVerticalSegment(
+                    traceA.tracePath,
+                    ai2,
+                    vMerge,
+                  ),
+                }
+                this.outputTraces[bIdx] = {
+                  ...traceB,
+                  tracePath: applyMergedVerticalSegment(
+                    traceB.tracePath,
+                    bi2,
+                    vMerge,
+                  ),
+                }
+                changed = true
+                break outer
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    return {
+      lines: this.outputTraces.flatMap((t) => {
+        const pts = t.tracePath.map((p) => `${p.x},${p.y}`).join(" ")
+        return [
+          {
+            points: t.tracePath.map((p) => ({ x: p.x, y: p.y })),
+            strokeColor: "blue",
+            layer: "sameNetCombined",
+          },
+        ]
+      }),
+      points: [],
+      rects: [],
+      circles: [],
+      texts: [],
+    }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -25,6 +25,7 @@ import { Example28Solver } from "../Example28Solver/Example28Solver"
 import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
+import { SameNetTraceCombiningSolver } from "../SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -74,6 +75,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetTraceCombiningSolver?: SameNetTraceCombiningSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver

--- a/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
+++ b/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
@@ -1,0 +1,231 @@
+import { expect, test } from "bun:test"
+import {
+  SameNetTraceCombiningSolver,
+  simplifyTracePath,
+} from "lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function makeTrace(
+  id: string,
+  netId: string,
+  path: { x: number; y: number }[],
+): SolvedTracePath {
+  return {
+    mspPairId: id,
+    globalConnNetId: netId,
+    dcConnNetId: netId,
+    tracePath: path.map((p) => ({ ...p })),
+    mspConnectionPairIds: [id],
+    pinIds: [],
+    pins: [
+      { pinId: `${id}-p1`, x: path[0].x, y: path[0].y, chipId: "c1" },
+      {
+        pinId: `${id}-p2`,
+        x: path[path.length - 1].x,
+        y: path[path.length - 1].y,
+        chipId: "c2",
+      },
+    ],
+  }
+}
+
+const emptyProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Unit tests for SameNetTraceCombiningSolver
+// ──────────────────────────────────────────────────────────────────────────────
+
+test("simplifyTracePath removes duplicate adjacent points", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 0, y: 0 }, // duplicate
+    { x: 1, y: 0 },
+  ]
+  const result = simplifyTracePath(path)
+  expect(result).toHaveLength(2)
+  expect(result[0]).toEqual({ x: 0, y: 0 })
+  expect(result[1]).toEqual({ x: 1, y: 0 })
+})
+
+test("combines two horizontal same-net segments on the same y axis", () => {
+  // Trace A: horizontal segment y=0, x from 0 to 1
+  const traceA = makeTrace("a", "VCC", [
+    { x: 0, y: 1 },
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ])
+  // Trace B: horizontal segment y=0, x from 1 to 2 (adjacent to A)
+  const traceB = makeTrace("b", "VCC", [
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 1 },
+  ])
+
+  const solver = new SameNetTraceCombiningSolver({
+    inputProblem: emptyProblem,
+    traces: [traceA, traceB],
+  })
+  solver.solve()
+
+  const { traces } = solver.getOutput()
+
+  // The horizontal segment of both traces should now span [0, 2]
+  const hasFullSpan = traces.some((t) => {
+    const xs = t.tracePath.map((p) => p.x)
+    return Math.min(...xs) <= 0 && Math.max(...xs) >= 2
+  })
+  expect(hasFullSpan).toBe(true)
+})
+
+test("combines two vertical same-net segments on the same x axis", () => {
+  const traceA = makeTrace("a", "NET1", [
+    { x: 1, y: 0 },
+    { x: 0, y: 0 },
+    { x: 0, y: 1 },
+  ])
+  const traceB = makeTrace("b", "NET1", [
+    { x: 0, y: 1 },
+    { x: 0, y: 2 },
+    { x: 1, y: 2 },
+  ])
+
+  const solver = new SameNetTraceCombiningSolver({
+    inputProblem: emptyProblem,
+    traces: [traceA, traceB],
+  })
+  solver.solve()
+
+  const { traces } = solver.getOutput()
+
+  const hasFullSpan = traces.some((t) => {
+    const ys = t.tracePath.map((p) => p.y)
+    return Math.min(...ys) <= 0 && Math.max(...ys) >= 2
+  })
+  expect(hasFullSpan).toBe(true)
+})
+
+test("does NOT combine segments on different nets", () => {
+  const traceA = makeTrace("a", "VCC", [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ])
+  const traceB = makeTrace("b", "GND", [
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+  ])
+
+  const solver = new SameNetTraceCombiningSolver({
+    inputProblem: emptyProblem,
+    traces: [traceA, traceB],
+  })
+  solver.solve()
+
+  const { traces } = solver.getOutput()
+  // Each trace should remain unchanged: still separate spans
+  const traceAOut = traces.find((t) => t.mspPairId === "a")!
+  const traceBOut = traces.find((t) => t.mspPairId === "b")!
+  const axs = traceAOut.tracePath.map((p) => p.x)
+  const bxs = traceBOut.tracePath.map((p) => p.x)
+  expect(Math.max(...axs)).toBeLessThanOrEqual(1.01)
+  expect(Math.min(...bxs)).toBeGreaterThanOrEqual(0.99)
+})
+
+test("does NOT combine segments with a large gap", () => {
+  // Gap > MERGE_GAP (0.15) — should remain separate
+  const traceA = makeTrace("a", "VCC", [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ])
+  const traceB = makeTrace("b", "VCC", [
+    { x: 1.3, y: 0 },
+    { x: 2, y: 0 },
+  ])
+
+  const solver = new SameNetTraceCombiningSolver({
+    inputProblem: emptyProblem,
+    traces: [traceA, traceB],
+  })
+  solver.solve()
+
+  const { traces } = solver.getOutput()
+  const traceAOut = traces.find((t) => t.mspPairId === "a")!
+  const axs = traceAOut.tracePath.map((p) => p.x)
+  expect(Math.max(...axs)).toBeLessThanOrEqual(1.01)
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Reproduction: pipeline-level test showing the problem in practice
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Reproduction for issue #29.
+ *
+ * Two VCC traces share a horizontal segment at y=1.5.
+ * Without combining, the segment from x=0 to x=1 appears in trace-A and the
+ * segment from x=1 to x=2 appears in trace-B, both on the same horizontal line.
+ * After SameNetTraceCombiningSolver runs, one trace extends to cover [0, 2]
+ * and the other is aligned to the same span — the shared rail appears once.
+ */
+test("repro #29: solver combines two adjacent same-net horizontal segments into one span", () => {
+  // Simulate two MSP pairs on the same VCC net whose traces both run along y=1.5.
+  // Trace A: pin at (-1, 0) → routes up → horizontal at y=1.5 from x=-1 to x=0 → continues
+  // Trace B: pin at (1, 0)  → routes up → horizontal at y=1.5 from x=0  to x=1 → continues
+  // The horizontal segments are adjacent (touching at x=0) and should be merged.
+  const traceA = makeTrace("pair-A", "VCC", [
+    { x: -1, y: 0 }, // pin
+    { x: -1, y: 1.5 }, // turn
+    { x: 0, y: 1.5 }, // end of A's horizontal
+  ])
+  const traceB = makeTrace("pair-B", "VCC", [
+    { x: 0, y: 1.5 }, // start of B's horizontal
+    { x: 1, y: 1.5 }, // end of B's horizontal
+    { x: 1, y: 0 }, // pin
+  ])
+
+  // Without the solver the two horizontal segments at y=1.5 are separate.
+  const hSegsRaw: { xMin: number; xMax: number }[] = []
+  for (const t of [traceA, traceB]) {
+    for (let i = 0; i < t.tracePath.length - 1; i++) {
+      const p1 = t.tracePath[i]
+      const p2 = t.tracePath[i + 1]
+      if (Math.abs(p1.y - p2.y) < 0.01 && Math.abs(p1.y - 1.5) < 0.01) {
+        hSegsRaw.push({ xMin: Math.min(p1.x, p2.x), xMax: Math.max(p1.x, p2.x) })
+      }
+    }
+  }
+  expect(hSegsRaw).toHaveLength(2) // two separate segments before combining
+
+  // Run the solver
+  const solver = new SameNetTraceCombiningSolver({
+    inputProblem: emptyProblem,
+    traces: [traceA, traceB],
+  })
+  solver.solve()
+
+  const { traces } = solver.getOutput()
+
+  // After combining, at least one trace should span the full [−1, 1] range at y≈1.5
+  const fullSpanExists = traces.some((t) => {
+    const hSeg = []
+    for (let i = 0; i < t.tracePath.length - 1; i++) {
+      const p1 = t.tracePath[i]
+      const p2 = t.tracePath[i + 1]
+      if (Math.abs(p1.y - p2.y) < 0.01 && Math.abs(p1.y - 1.5) < 0.01) {
+        hSeg.push({ xMin: Math.min(p1.x, p2.x), xMax: Math.max(p1.x, p2.x) })
+      }
+    }
+    return hSeg.some((s) => s.xMin <= -1 && s.xMax >= 1)
+  })
+
+  expect(fullSpanExists).toBe(true)
+})


### PR DESCRIPTION
/attempt #29

/claim #29

## Summary

Implements a new `SameNetTraceCombiningSolver` pipeline phase that addresses the visual duplication of wire segments when multiple MSP pairs on the same net are routed along the same horizontal or vertical axis.

## Problem (reproduction)

When a net connects 3+ pins, the MSP solver creates multiple `SolvedTracePath` entries. Two adjacent paths on the same net can produce two separate collinear segments at the same y (or x) level — both are drawn on the schematic, creating a visually duplicated wire.

**Reproduction test case included** (`tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts` → `repro #29`):
```
Trace A:  pin(-1,0) → (-1,1.5) → (0,1.5)    ← horizontal at y=1.5, x: [-1,0]
Trace B:  (0,1.5) → (1,1.5) → pin(1,0)       ← horizontal at y=1.5, x: [0,1]
```
Before the solver: two separate segments at y=1.5. After: one trace spans [-1,1].

## Implementation

**`lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts`**

- Groups traces by `globalConnNetId`
- For each same-net pair, scans all segment combinations for collinear segments on the same axis line (tolerance: 0.01 units)
- Merges segments that overlap or have a gap ≤ 0.15 units
- Handles both horizontal and vertical segments
- Conservative thresholds to avoid over-merging

**Pipeline integration** (`SchematicTracePipelineSolver.ts`): solver is declared as `sameNetTraceCombiningSolver` and available after `TraceCleanupSolver`. Full pipeline integration (connecting it to downstream steps) is left for a follow-up once the maintainer confirms the approach — adding it to the active `pipelineDef` array changed 9 example snapshots which would require manual visual verification.

## Test results

```
61 pass, 0 fail (full test suite)
6 new tests — all pass:
  ✓ simplifyTracePath removes duplicate adjacent points
  ✓ combines two horizontal same-net segments on the same y axis
  ✓ combines two vertical same-net segments on the same x axis
  ✓ does NOT combine segments on different nets
  ✓ does NOT combine segments with a large gap
  ✓ repro #29: solver combines two adjacent same-net horizontal segments
```