### PR TITLE
Add same-net trace combining phase

### DIFF
--- a/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
+++ b/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
@@ -15,6 +15,7 @@ interface SegmentRef {
   start: number
   end: number
   length: number
+  isTerminal: boolean
 }
 
 interface SameNetTraceCombiningSolverInput {
@@ -54,7 +55,10 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
 
     for (const traces of tracesByNet.values()) {
       if (traces.length < 2) continue
-      this.combineTraceGroup(traces)
+      let didCombine = true
+      while (didCombine) {
+        didCombine = this.combineTraceGroup(traces)
+      }
     }
 
     this.outputTraces = this.outputTraces.map((trace) => ({
@@ -64,7 +68,7 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
     this.solved = true
   }
 
-  private combineTraceGroup(groupTraces: SolvedTracePath[]) {
+  private combineTraceGroup(groupTraces: SolvedTracePath[]): boolean {
     const traceIndexById = new Map(
       this.outputTraces.map((trace, index) => [trace.mspPairId, index]),
     )
@@ -87,11 +91,15 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
         if (!this.shouldCombineSegments(first, second)) continue
 
         const target = this.getTargetSegment(first, second)
+        if (!target) continue
         const source = target === first ? second : first
         this.snapSegmentToCoordinate(source, target.constantCoord)
         this.mergedSegmentCount++
+        return true
       }
     }
+
+    return false
   }
 
   private getSegmentRefs(trace: SolvedTracePath): SegmentRef[] {
@@ -112,6 +120,7 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
           start,
           end,
           length: end - start,
+          isTerminal: i === 0 || i + 1 === trace.tracePath.length - 1,
         })
       } else if (this.areEqual(startPoint.x, endPoint.x)) {
         const start = Math.min(startPoint.y, endPoint.y)
@@ -124,6 +133,7 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
           start,
           end,
           length: end - start,
+          isTerminal: i === 0 || i + 1 === trace.tracePath.length - 1,
         })
       }
     }
@@ -144,7 +154,14 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
     return overlap >= this.input.minOverlap
   }
 
-  private getTargetSegment(first: SegmentRef, second: SegmentRef): SegmentRef {
+  private getTargetSegment(
+    first: SegmentRef,
+    second: SegmentRef,
+  ): SegmentRef | null {
+    if (first.isTerminal && second.isTerminal) return null
+    if (first.isTerminal) return first
+    if (second.isTerminal) return second
+
     if (first.length !== second.length) {
       return first.length > second.length ? first : second
     }

--- a/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
+++ b/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
@@ -1,8 +1,15 @@
 import type { Point } from "@tscircuit/math-utils"
 import type { GraphicsObject, Line } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { segmentIntersectsRect } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+import {
+  getObstacleRects,
+  type ChipWithBounds,
+} from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+import type { InputProblem } from "lib/types/InputProblem"
 import { getColorFromString } from "lib/utils/getColorFromString"
 
 type Axis = "horizontal" | "vertical"
@@ -20,12 +27,17 @@ interface SegmentRef {
 
 interface SameNetTraceCombiningSolverInput {
   traces: SolvedTracePath[]
+  inputProblem?: InputProblem
+  netLabelPlacements?: NetLabelPlacement[]
   mergeDistance?: number
   minOverlap?: number
 }
 
 export class SameNetTraceCombiningSolver extends BaseSolver {
-  private input: Required<SameNetTraceCombiningSolverInput>
+  private input: SameNetTraceCombiningSolverInput & {
+    mergeDistance: number
+    minOverlap: number
+  }
   outputTraces: SolvedTracePath[]
   mergedSegmentCount = 0
 
@@ -93,6 +105,9 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
         const target = this.getTargetSegment(first, second)
         if (!target) continue
         const source = target === first ? second : first
+        if (!this.canSnapSegmentToCoordinate(source, target.constantCoord)) {
+          continue
+        }
         this.snapSegmentToCoordinate(source, target.constantCoord)
         this.mergedSegmentCount++
         return true
@@ -180,6 +195,187 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
       firstPoint.x = coordinate
       secondPoint.x = coordinate
     }
+  }
+
+  private canSnapSegmentToCoordinate(
+    segment: SegmentRef,
+    coordinate: number,
+  ): boolean {
+    const trace = this.outputTraces[segment.traceIndex]!
+    const candidatePath = trace.tracePath.map((point) => ({ ...point }))
+    const firstPoint = candidatePath[segment.pointIndex]!
+    const secondPoint = candidatePath[segment.pointIndex + 1]!
+
+    if (segment.axis === "horizontal") {
+      firstPoint.y = coordinate
+      secondPoint.y = coordinate
+    } else {
+      firstPoint.x = coordinate
+      secondPoint.x = coordinate
+    }
+
+    const originalCollisions = this.collectBlockingCollisionKeys(
+      trace,
+      trace.tracePath,
+    )
+    const candidateCollisions = this.collectBlockingCollisionKeys(
+      trace,
+      candidatePath,
+    )
+
+    for (const key of candidateCollisions) {
+      if (!originalCollisions.has(key)) return false
+    }
+
+    return true
+  }
+
+  private collectBlockingCollisionKeys(
+    trace: SolvedTracePath,
+    tracePath: Point[],
+  ): Set<string> {
+    return new Set([
+      ...this.collectRectCollisionKeys(tracePath),
+      ...this.collectDifferentNetTraceCollisionKeys(trace, tracePath),
+    ])
+  }
+
+  private collectRectCollisionKeys(tracePath: Point[]): string[] {
+    const rects = this.getBlockingRects()
+    const collisions: string[] = []
+
+    for (
+      let segmentIndex = 0;
+      segmentIndex < tracePath.length - 1;
+      segmentIndex++
+    ) {
+      const start = tracePath[segmentIndex]!
+      const end = tracePath[segmentIndex + 1]!
+
+      for (const rect of rects) {
+        if (segmentIntersectsRect(start, end, rect)) {
+          collisions.push(`rect:${rect.chipId}:segment:${segmentIndex}`)
+        }
+      }
+    }
+
+    return collisions
+  }
+
+  private getBlockingRects(): ChipWithBounds[] {
+    const chipRects = this.input.inputProblem
+      ? getObstacleRects(this.input.inputProblem)
+      : []
+    const labelRects =
+      this.input.netLabelPlacements?.map((label, index) => ({
+        chipId: `net-label-${index}-${label.globalConnNetId}`,
+        minX: label.center.x - label.width / 2,
+        minY: label.center.y - label.height / 2,
+        maxX: label.center.x + label.width / 2,
+        maxY: label.center.y + label.height / 2,
+      })) ?? []
+
+    return [...chipRects, ...labelRects]
+  }
+
+  private collectDifferentNetTraceCollisionKeys(
+    trace: SolvedTracePath,
+    tracePath: Point[],
+  ): string[] {
+    const collisions: string[] = []
+
+    for (const otherTrace of this.outputTraces) {
+      if (otherTrace.mspPairId === trace.mspPairId) continue
+      if (otherTrace.globalConnNetId === trace.globalConnNetId) continue
+
+      for (
+        let segmentIndex = 0;
+        segmentIndex < tracePath.length - 1;
+        segmentIndex++
+      ) {
+        const start = tracePath[segmentIndex]!
+        const end = tracePath[segmentIndex + 1]!
+
+        for (
+          let otherSegmentIndex = 0;
+          otherSegmentIndex < otherTrace.tracePath.length - 1;
+          otherSegmentIndex++
+        ) {
+          const otherStart = otherTrace.tracePath[otherSegmentIndex]!
+          const otherEnd = otherTrace.tracePath[otherSegmentIndex + 1]!
+
+          if (this.segmentsIntersect(start, end, otherStart, otherEnd)) {
+            collisions.push(
+              `trace:${otherTrace.mspPairId}:segment:${otherSegmentIndex}:with:${segmentIndex}`,
+            )
+          }
+        }
+      }
+    }
+
+    return collisions
+  }
+
+  private segmentsIntersect(
+    a1: Point,
+    a2: Point,
+    b1: Point,
+    b2: Point,
+  ): boolean {
+    const aHorizontal = this.areEqual(a1.y, a2.y)
+    const aVertical = this.areEqual(a1.x, a2.x)
+    const bHorizontal = this.areEqual(b1.y, b2.y)
+    const bVertical = this.areEqual(b1.x, b2.x)
+
+    if ((!aHorizontal && !aVertical) || (!bHorizontal && !bVertical)) {
+      return false
+    }
+
+    if (aHorizontal && bVertical) {
+      return (
+        this.pointOnSegment({ x: b1.x, y: a1.y }, a1, a2) &&
+        this.pointOnSegment({ x: b1.x, y: a1.y }, b1, b2)
+      )
+    }
+
+    if (aVertical && bHorizontal) {
+      return (
+        this.pointOnSegment({ x: a1.x, y: b1.y }, a1, a2) &&
+        this.pointOnSegment({ x: a1.x, y: b1.y }, b1, b2)
+      )
+    }
+
+    if (aHorizontal && bHorizontal && this.areEqual(a1.y, b1.y)) {
+      return this.rangesOverlap(a1.x, a2.x, b1.x, b2.x)
+    }
+
+    if (aVertical && bVertical && this.areEqual(a1.x, b1.x)) {
+      return this.rangesOverlap(a1.y, a2.y, b1.y, b2.y)
+    }
+
+    return false
+  }
+
+  private pointOnSegment(point: Point, start: Point, end: Point): boolean {
+    return (
+      point.x >= Math.min(start.x, end.x) - 1e-9 &&
+      point.x <= Math.max(start.x, end.x) + 1e-9 &&
+      point.y >= Math.min(start.y, end.y) - 1e-9 &&
+      point.y <= Math.max(start.y, end.y) + 1e-9
+    )
+  }
+
+  private rangesOverlap(
+    aStart: number,
+    aEnd: number,
+    bStart: number,
+    bEnd: number,
+  ): boolean {
+    return (
+      Math.min(Math.max(aStart, aEnd), Math.max(bStart, bEnd)) -
+        Math.max(Math.min(aStart, aEnd), Math.min(bStart, bEnd)) >
+      1e-9
+    )
   }
 
   private areEqual(first: number, second: number): boolean {

--- a/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
+++ b/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
@@ -1,0 +1,195 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject, Line } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+import { getColorFromString } from "lib/utils/getColorFromString"
+
+type Axis = "horizontal" | "vertical"
+
+interface SegmentRef {
+  traceIndex: number
+  pointIndex: number
+  axis: Axis
+  constantCoord: number
+  start: number
+  end: number
+  length: number
+}
+
+interface SameNetTraceCombiningSolverInput {
+  traces: SolvedTracePath[]
+  mergeDistance?: number
+  minOverlap?: number
+}
+
+export class SameNetTraceCombiningSolver extends BaseSolver {
+  private input: Required<SameNetTraceCombiningSolverInput>
+  outputTraces: SolvedTracePath[]
+  mergedSegmentCount = 0
+
+  constructor(input: SameNetTraceCombiningSolverInput) {
+    super()
+    this.input = {
+      ...input,
+      mergeDistance: input.mergeDistance ?? 0.15,
+      minOverlap: input.minOverlap ?? 0.05,
+    }
+    this.outputTraces = input.traces.map((trace) => ({
+      ...trace,
+      tracePath: trace.tracePath.map((point) => ({ ...point })),
+      mspConnectionPairIds: [...trace.mspConnectionPairIds],
+      pinIds: [...trace.pinIds],
+    }))
+  }
+
+  override _step() {
+    const tracesByNet = new Map<string, SolvedTracePath[]>()
+
+    for (const trace of this.outputTraces) {
+      const traces = tracesByNet.get(trace.globalConnNetId) ?? []
+      traces.push(trace)
+      tracesByNet.set(trace.globalConnNetId, traces)
+    }
+
+    for (const traces of tracesByNet.values()) {
+      if (traces.length < 2) continue
+      this.combineTraceGroup(traces)
+    }
+
+    this.outputTraces = this.outputTraces.map((trace) => ({
+      ...trace,
+      tracePath: simplifyPath(trace.tracePath),
+    }))
+    this.solved = true
+  }
+
+  private combineTraceGroup(groupTraces: SolvedTracePath[]) {
+    const traceIndexById = new Map(
+      this.outputTraces.map((trace, index) => [trace.mspPairId, index]),
+    )
+    const segments = groupTraces.flatMap((trace) =>
+      this.getSegmentRefs(
+        this.outputTraces[traceIndexById.get(trace.mspPairId)!]!,
+      ).map((segment) => ({
+        ...segment,
+        traceIndex: traceIndexById.get(trace.mspPairId)!,
+      })),
+    )
+
+    for (let i = 0; i < segments.length; i++) {
+      for (let j = i + 1; j < segments.length; j++) {
+        const first = segments[i]!
+        const second = segments[j]!
+
+        if (first.traceIndex === second.traceIndex) continue
+        if (first.axis !== second.axis) continue
+        if (!this.shouldCombineSegments(first, second)) continue
+
+        const target = this.getTargetSegment(first, second)
+        const source = target === first ? second : first
+        this.snapSegmentToCoordinate(source, target.constantCoord)
+        this.mergedSegmentCount++
+      }
+    }
+  }
+
+  private getSegmentRefs(trace: SolvedTracePath): SegmentRef[] {
+    const segments: SegmentRef[] = []
+
+    for (let i = 0; i < trace.tracePath.length - 1; i++) {
+      const startPoint = trace.tracePath[i]!
+      const endPoint = trace.tracePath[i + 1]!
+
+      if (this.areEqual(startPoint.y, endPoint.y)) {
+        const start = Math.min(startPoint.x, endPoint.x)
+        const end = Math.max(startPoint.x, endPoint.x)
+        segments.push({
+          traceIndex: -1,
+          pointIndex: i,
+          axis: "horizontal",
+          constantCoord: startPoint.y,
+          start,
+          end,
+          length: end - start,
+        })
+      } else if (this.areEqual(startPoint.x, endPoint.x)) {
+        const start = Math.min(startPoint.y, endPoint.y)
+        const end = Math.max(startPoint.y, endPoint.y)
+        segments.push({
+          traceIndex: -1,
+          pointIndex: i,
+          axis: "vertical",
+          constantCoord: startPoint.x,
+          start,
+          end,
+          length: end - start,
+        })
+      }
+    }
+
+    return segments
+  }
+
+  private shouldCombineSegments(
+    first: SegmentRef,
+    second: SegmentRef,
+  ): boolean {
+    const distance = Math.abs(first.constantCoord - second.constantCoord)
+    if (distance <= 1e-9 || distance > this.input.mergeDistance) return false
+
+    const overlap =
+      Math.min(first.end, second.end) - Math.max(first.start, second.start)
+
+    return overlap >= this.input.minOverlap
+  }
+
+  private getTargetSegment(first: SegmentRef, second: SegmentRef): SegmentRef {
+    if (first.length !== second.length) {
+      return first.length > second.length ? first : second
+    }
+    return first.constantCoord <= second.constantCoord ? first : second
+  }
+
+  private snapSegmentToCoordinate(segment: SegmentRef, coordinate: number) {
+    const trace = this.outputTraces[segment.traceIndex]!
+    const firstPoint = trace.tracePath[segment.pointIndex]!
+    const secondPoint = trace.tracePath[segment.pointIndex + 1]!
+
+    if (segment.axis === "horizontal") {
+      firstPoint.y = coordinate
+      secondPoint.y = coordinate
+    } else {
+      firstPoint.x = coordinate
+      secondPoint.x = coordinate
+    }
+  }
+
+  private areEqual(first: number, second: number): boolean {
+    return Math.abs(first - second) < 1e-9
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    const lines: Line[] = this.outputTraces.map((trace) => ({
+      points: trace.tracePath.map((point: Point) => ({
+        x: point.x,
+        y: point.y,
+      })),
+      strokeColor: getColorFromString(trace.globalConnNetId, 0.85),
+    }))
+
+    return {
+      lines,
+      points: [],
+      rects: [],
+      circles: [],
+      texts: [],
+    }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceCombiningSolver } from "../SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -75,6 +76,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetTraceCombiningSolver?: SameNetTraceCombiningSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -218,10 +220,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceCombiningSolver",
+      SameNetTraceCombiningSolver,
+      (instance) => [
+        {
+          traces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceCombiningSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +249,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceCombiningSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -223,11 +223,18 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     definePipelineStep(
       "sameNetTraceCombiningSolver",
       SameNetTraceCombiningSolver,
-      (instance) => [
-        {
-          traces: instance.traceCleanupSolver!.getOutput().traces,
-        },
-      ],
+      (instance) => {
+        const labelMergingOutput =
+          instance.traceLabelOverlapAvoidanceSolver!.labelMergingSolver!.getOutput()
+
+        return [
+          {
+            traces: instance.traceCleanupSolver!.getOutput().traces,
+            inputProblem: instance.inputProblem,
+            netLabelPlacements: labelMergingOutput.netLabelPlacements,
+          },
+        ]
+      },
     ),
     definePipelineStep(
       "postCombineNetLabelPlacementSolver",

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -77,6 +77,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
   sameNetTraceCombiningSolver?: SameNetTraceCombiningSolver
+  postCombineNetLabelPlacementSolver?: NetLabelPlacementSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -229,7 +230,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ],
     ),
     definePipelineStep(
-      "netLabelPlacementSolver",
+      "postCombineNetLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
@@ -258,7 +259,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
           inputProblem: instance.inputProblem,
           traces,
           netLabelPlacements:
-            instance.netLabelPlacementSolver!.netLabelPlacements,
+            instance.postCombineNetLabelPlacementSolver!.netLabelPlacements,
         },
       ]
     }),

--- a/tests/examples/__snapshots__/example03.snap.svg
+++ b/tests/examples/__snapshots__/example03.snap.svg
@@ -97,40 +97,196 @@ x+" data-x="3.5005768910000006" data-y="-1.5514824999999997" cx="568.04313733901
 x+" data-x="3.5005768910000006" data-y="-1.5514824999999997" cx="568.0431373390173" cy="429.0254427242018" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-3.7005768910000008" data-y="1.4489565000000004" cx="57.78530493992605" cy="216.42097033915468" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN2.1
+x-" data-x="-3.5005768910000006" data-y="1.4489565000000004" cx="71.9568626609827" cy="216.42097033915468" r="3" fill="hsl(328, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="2.4994231089999994" data-y="1.4489565000000004" cx="497.10359429268146" cy="216.42097033915468" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN2.2
+x-" data-x="-3.5005768910000006" data-y="1.4489565000000004" cx="71.9568626609827" cy="216.42097033915468" r="3" fill="hsl(328, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-3.5005768910000006" data-y="1.4489565000000004" cx="71.9568626609827" cy="216.42097033915468" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN2.3
+x+" data-x="-2.4994231089999994" data-y="1.4485175000000003" cx="142.8964057073185" cy="216.4520769083524" r="3" fill="hsl(328, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-3.7005768910000008" data-y="-1.5510434999999996" cx="57.78530493992605" cy="428.9943361550041" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN2.4
+x+" data-x="-2.4994231089999994" data-y="1.4485175000000003" cx="142.8964057073185" cy="216.4520769083524" r="3" fill="hsl(328, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="0.5005768910000006" data-y="1.4485175000000003" cx="355.4697715231679" cy="216.4520769083524" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN3.1
+x-" data-x="-0.5005768910000006" data-y="1.4489565000000004" cx="284.5302284768321" cy="216.42097033915468" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-2.4994231089999994" data-y="-1.5514824999999997" cx="142.8964057073185" cy="429.0254427242018" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN3.2
+x-" data-x="-0.5005768910000006" data-y="1.4489565000000004" cx="284.5302284768321" cy="216.42097033915468" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="3.5005768910000006" data-y="-1.5514824999999997" cx="568.0431373390173" cy="429.0254427242018" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN3.3
+x+" data-x="0.5005768910000006" data-y="1.4485175000000003" cx="355.4697715231679" cy="216.4520769083524" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="3.7005768910000008" data-y="1.4485175000000003" cx="582.214695060074" cy="216.4520769083524" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN3.4
+x+" data-x="0.5005768910000006" data-y="1.4485175000000003" cx="355.4697715231679" cy="216.4520769083524" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="0.5005768910000006" data-y="-1.5514824999999997" cx="355.4697715231679" cy="429.0254427242018" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="PIN1_PIN4.1
+x-" data-x="2.4994231089999994" data-y="1.4489565000000004" cx="497.10359429268146" cy="216.42097033915468" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN4.2
+x-" data-x="2.4994231089999994" data-y="1.4489565000000004" cx="497.10359429268146" cy="216.42097033915468" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN4.3
+x+" data-x="3.5005768910000006" data-y="1.4485175000000003" cx="568.0431373390173" cy="216.4520769083524" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN4.4
+x+" data-x="3.5005768910000006" data-y="1.4485175000000003" cx="568.0431373390173" cy="216.4520769083524" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN3.1
+x-" data-x="-3.5005768910000006" data-y="-1.5510434999999996" cx="71.9568626609827" cy="428.9943361550041" r="3" fill="hsl(240, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN3.2
+x-" data-x="-3.5005768910000006" data-y="-1.5510434999999996" cx="71.9568626609827" cy="428.9943361550041" r="3" fill="hsl(240, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN3.3
+x+" data-x="-2.4994231089999994" data-y="-1.5514824999999997" cx="142.8964057073185" cy="429.0254427242018" r="3" fill="hsl(240, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN3.4
+x+" data-x="-2.4994231089999994" data-y="-1.5514824999999997" cx="142.8964057073185" cy="429.0254427242018" r="3" fill="hsl(240, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN4.1
+x-" data-x="-0.5005768910000006" data-y="-1.5510434999999996" cx="284.5302284768321" cy="428.9943361550041" r="3" fill="hsl(120, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN4.2
+x-" data-x="-0.5005768910000006" data-y="-1.5510434999999996" cx="284.5302284768321" cy="428.9943361550041" r="3" fill="hsl(120, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN4.3
+x+" data-x="0.5005768910000006" data-y="-1.5514824999999997" cx="355.4697715231679" cy="429.0254427242018" r="3" fill="hsl(120, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN4.4
+x+" data-x="0.5005768910000006" data-y="-1.5514824999999997" cx="355.4697715231679" cy="429.0254427242018" r="3" fill="hsl(120, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN3_PIN4.1
+x-" data-x="2.4994231089999994" data-y="-1.5510434999999996" cx="497.10359429268146" cy="428.9943361550041" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN3_PIN4.2
+x-" data-x="2.4994231089999994" data-y="-1.5510434999999996" cx="497.10359429268146" cy="428.9943361550041" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN3_PIN4.3
+x+" data-x="3.5005768910000006" data-y="-1.5514824999999997" cx="568.0431373390173" cy="429.0254427242018" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN3_PIN4.4
+x+" data-x="3.5005768910000006" data-y="-1.5514824999999997" cx="568.0431373390173" cy="429.0254427242018" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN2.1
+x-" data-x="-3.5005768910000006" data-y="1.4489565000000004" cx="71.9568626609827" cy="216.42097033915468" r="3" fill="hsl(328, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN2.2
+x-" data-x="-3.5005768910000006" data-y="1.4489565000000004" cx="71.9568626609827" cy="216.42097033915468" r="3" fill="hsl(328, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN2.3
+x+" data-x="-2.4994231089999994" data-y="1.4485175000000003" cx="142.8964057073185" cy="216.4520769083524" r="3" fill="hsl(328, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN2.4
+x+" data-x="-2.4994231089999994" data-y="1.4485175000000003" cx="142.8964057073185" cy="216.4520769083524" r="3" fill="hsl(328, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN3.1
+x-" data-x="-0.5005768910000006" data-y="1.4489565000000004" cx="284.5302284768321" cy="216.42097033915468" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN3.2
+x-" data-x="-0.5005768910000006" data-y="1.4489565000000004" cx="284.5302284768321" cy="216.42097033915468" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN3.3
+x+" data-x="0.5005768910000006" data-y="1.4485175000000003" cx="355.4697715231679" cy="216.4520769083524" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN3.4
+x+" data-x="0.5005768910000006" data-y="1.4485175000000003" cx="355.4697715231679" cy="216.4520769083524" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN4.1
+x-" data-x="2.4994231089999994" data-y="1.4489565000000004" cx="497.10359429268146" cy="216.42097033915468" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN4.2
+x-" data-x="2.4994231089999994" data-y="1.4489565000000004" cx="497.10359429268146" cy="216.42097033915468" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN4.3
+x+" data-x="3.5005768910000006" data-y="1.4485175000000003" cx="568.0431373390173" cy="216.4520769083524" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN1_PIN4.4
+x+" data-x="3.5005768910000006" data-y="1.4485175000000003" cx="568.0431373390173" cy="216.4520769083524" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN3.1
+x-" data-x="-3.5005768910000006" data-y="-1.5510434999999996" cx="71.9568626609827" cy="428.9943361550041" r="3" fill="hsl(240, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN3.2
+x-" data-x="-3.5005768910000006" data-y="-1.5510434999999996" cx="71.9568626609827" cy="428.9943361550041" r="3" fill="hsl(240, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN3.3
+x+" data-x="-2.4994231089999994" data-y="-1.5514824999999997" cx="142.8964057073185" cy="429.0254427242018" r="3" fill="hsl(240, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN3.4
+x+" data-x="-2.4994231089999994" data-y="-1.5514824999999997" cx="142.8964057073185" cy="429.0254427242018" r="3" fill="hsl(240, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN4.1
+x-" data-x="-0.5005768910000006" data-y="-1.5510434999999996" cx="284.5302284768321" cy="428.9943361550041" r="3" fill="hsl(120, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN4.2
+x-" data-x="-0.5005768910000006" data-y="-1.5510434999999996" cx="284.5302284768321" cy="428.9943361550041" r="3" fill="hsl(120, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN4.3
+x+" data-x="0.5005768910000006" data-y="-1.5514824999999997" cx="355.4697715231679" cy="429.0254427242018" r="3" fill="hsl(120, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN2_PIN4.4
+x+" data-x="0.5005768910000006" data-y="-1.5514824999999997" cx="355.4697715231679" cy="429.0254427242018" r="3" fill="hsl(120, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN3_PIN4.1
+x-" data-x="2.4994231089999994" data-y="-1.5510434999999996" cx="497.10359429268146" cy="428.9943361550041" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN3_PIN4.2
+x-" data-x="2.4994231089999994" data-y="-1.5510434999999996" cx="497.10359429268146" cy="428.9943361550041" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN3_PIN4.3
+x+" data-x="3.5005768910000006" data-y="-1.5514824999999997" cx="568.0431373390173" cy="429.0254427242018" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="PIN3_PIN4.4
+x+" data-x="3.5005768910000006" data-y="-1.5514824999999997" cx="568.0431373390173" cy="429.0254427242018" r="3" fill="hsl(152, 100%, 50%, 0.8)" />
   </g>
   <g>
     <polyline data-points="-3.5005768910000006,1.4489565000000004 -0.5005768910000006,1.4489565000000004" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 284.5302284768321,216.42097033915468" fill="none" stroke="hsl(340, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
@@ -169,13 +325,91 @@ orientation: x+" data-x="0.5005768910000006" data-y="-1.5514824999999997" cx="35
     <polyline data-points="0.5005768910000006,-1.5514824999999997 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="355.4697715231679,429.0254427242018 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(343, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3.5005768910000006,1.4489565000000004 -3.7005768910000008,1.4489565000000004 -3.7005768910000008,1.0753815000000009 -0.7005768910000008,1.0753815000000009 -0.7005768910000008,1.4489565000000004 -0.5005768910000006,1.4489565000000004" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 57.78530493992605,216.42097033915468 57.78530493992605,242.8916687173733 270.35867075577545,242.8916687173733 270.35867075577545,216.42097033915468 284.5302284768321,216.42097033915468" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
     <polyline data-points="-3.5005768910000006,-1.5510434999999996 -3.7005768910000008,-1.5510434999999996 -3.7005768910000008,-1.9246184999999991 -0.7005768910000008,-1.9246184999999991 -0.7005768910000008,-1.5510434999999996 -0.5005768910000006,-1.5510434999999996" data-type="line" data-label="" points="71.9568626609827,428.9943361550041 57.78530493992605,428.9943361550041 57.78530493992605,455.4650345332227 270.35867075577545,455.4650345332227 270.35867075577545,428.9943361550041 284.5302284768321,428.9943361550041" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="3.5005768910000006,1.4485175000000003 3.7005768910000008,1.4485175000000003 3.7005768910000008,-1.5514824999999997 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="568.0431373390173,216.4520769083524 582.214695060074,216.4520769083524 582.214695060074,429.0254427242018 568.0431373390173,429.0254427242018" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 -0.5005768910000006,1.4489565000000004" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 284.5302284768321,216.42097033915468" fill="none" stroke="hsl(340, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 2.4994231089999994,1.4489565000000004" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 497.10359429268146,216.42097033915468" fill="none" stroke="hsl(340, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-0.5005768910000006,1.4489565000000004 2.4994231089999994,1.4489565000000004" data-type="line" data-label="" points="284.5302284768321,216.42097033915468 497.10359429268146,216.42097033915468" fill="none" stroke="hsl(340, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 -3.5005768910000006,-1.5510434999999996" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 71.9568626609827,428.9943361550041" fill="none" stroke="hsl(341, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 -0.5005768910000006,-1.5510434999999996" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 284.5302284768321,428.9943361550041" fill="none" stroke="hsl(341, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,-1.5510434999999996 -0.5005768910000006,-1.5510434999999996" data-type="line" data-label="" points="71.9568626609827,428.9943361550041 284.5302284768321,428.9943361550041" fill="none" stroke="hsl(341, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.5005768910000006,1.4485175000000003 -2.4994231089999994,-1.5514824999999997" data-type="line" data-label="" points="355.4697715231679,216.4520769083524 142.8964057073185,429.0254427242018" fill="none" stroke="hsl(342, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.5005768910000006,1.4485175000000003 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="355.4697715231679,216.4520769083524 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(342, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-2.4994231089999994,-1.5514824999999997 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="142.8964057073185,429.0254427242018 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(342, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="3.5005768910000006,1.4485175000000003 0.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="568.0431373390173,216.4520769083524 355.4697715231679,429.0254427242018" fill="none" stroke="hsl(343, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="3.5005768910000006,1.4485175000000003 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="568.0431373390173,216.4520769083524 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(343, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.5005768910000006,-1.5514824999999997 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="355.4697715231679,429.0254427242018 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(343, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 -3.7005768910000008,1.4489565000000004 -3.7005768910000008,1.0753815000000009 -0.7005768910000008,1.0753815000000009 -0.7005768910000008,1.4489565000000004 -0.5005768910000006,1.4489565000000004" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 57.78530493992605,216.42097033915468 57.78530493992605,242.8916687173733 270.35867075577545,242.8916687173733 270.35867075577545,216.42097033915468 284.5302284768321,216.42097033915468" fill="none" stroke="red" stroke-width="1" stroke-dasharray="4 4" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 -3.7005768910000008,1.4489565000000004 -3.7005768910000008,1.0753815000000009 -0.7005768910000008,1.0753815000000009 -0.7005768910000008,1.4489565000000004 -0.5005768910000006,1.4489565000000004" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 57.78530493992605,216.42097033915468 57.78530493992605,242.8916687173733 270.35867075577545,242.8916687173733 270.35867075577545,216.42097033915468 284.5302284768321,216.42097033915468" fill="none" stroke="orange" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 -0.5005768910000006,1.4489565000000004" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 284.5302284768321,216.42097033915468" fill="none" stroke="hsl(340, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 2.4994231089999994,1.4489565000000004" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 497.10359429268146,216.42097033915468" fill="none" stroke="hsl(340, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-0.5005768910000006,1.4489565000000004 2.4994231089999994,1.4489565000000004" data-type="line" data-label="" points="284.5302284768321,216.42097033915468 497.10359429268146,216.42097033915468" fill="none" stroke="hsl(340, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 -3.5005768910000006,-1.5510434999999996" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 71.9568626609827,428.9943361550041" fill="none" stroke="hsl(341, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,1.4489565000000004 -0.5005768910000006,-1.5510434999999996" data-type="line" data-label="" points="71.9568626609827,216.42097033915468 284.5302284768321,428.9943361550041" fill="none" stroke="hsl(341, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.5005768910000006,-1.5510434999999996 -0.5005768910000006,-1.5510434999999996" data-type="line" data-label="" points="71.9568626609827,428.9943361550041 284.5302284768321,428.9943361550041" fill="none" stroke="hsl(341, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.5005768910000006,1.4485175000000003 -2.4994231089999994,-1.5514824999999997" data-type="line" data-label="" points="355.4697715231679,216.4520769083524 142.8964057073185,429.0254427242018" fill="none" stroke="hsl(342, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.5005768910000006,1.4485175000000003 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="355.4697715231679,216.4520769083524 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(342, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-2.4994231089999994,-1.5514824999999997 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="142.8964057073185,429.0254427242018 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(342, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="3.5005768910000006,1.4485175000000003 0.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="568.0431373390173,216.4520769083524 355.4697715231679,429.0254427242018" fill="none" stroke="hsl(343, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="3.5005768910000006,1.4485175000000003 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="568.0431373390173,216.4520769083524 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(343, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.5005768910000006,-1.5514824999999997 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="355.4697715231679,429.0254427242018 568.0431373390173,429.0254427242018" fill="none" stroke="hsl(343, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="3.5005768910000006,1.4485175000000003 3.7005768910000008,1.4485175000000003 3.7005768910000008,-1.5514824999999997 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="568.0431373390173,216.4520769083524 582.214695060074,216.4520769083524 582.214695060074,429.0254427242018 568.0431373390173,429.0254427242018" fill="none" stroke="red" stroke-width="1" stroke-dasharray="4 4" />
+  </g>
+  <g>
+    <polyline data-points="3.5005768910000006,1.4485175000000003 3.7005768910000008,1.4485175000000003 3.5005768910000006,1.4485175000000003 3.5005768910000006,-1.5514824999999997" data-type="line" data-label="" points="568.0431373390173,216.4520769083524 582.214695060074,216.4520769083524 568.0431373390173,216.4520769083524 568.0431373390173,429.0254427242018" fill="none" stroke="orange" stroke-width="1" />
   </g>
   <g>
     <rect data-type="rect" data-label="schematic_component_0" data-x="-3" data-y="1.5" x="71.9568626609827" y="196.8881706166452" width="70.93954304633581" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.014112774610714288" />
@@ -196,40 +430,73 @@ orientation: x+" data-x="0.5005768910000006" data-y="-1.5514824999999997" cx="35
     <rect data-type="rect" data-label="schematic_component_5" data-x="3" data-y="-1.5" x="497.10359429268146" y="409.4615364324946" width="70.93954304633587" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN1
-globalConnNetId: connectivity_net0" data-x="-3.7005768910000008" data-y="1.6739565000000005" x="50.69952607939774" y="184.53496546677727" width="14.171557721056644" height="31.886004872377413" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="schematic_component_0" data-x="-3" data-y="1.5" x="71.9568626609827" y="196.8881706166452" width="70.93954304633581" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN1
-globalConnNetId: connectivity_net0" data-x="2.2734231089999994" data-y="1.4489565000000004" x="465.1467316316988" y="209.33519147862637" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="schematic_component_1" data-x="0" data-y="1.5" x="284.5302284768321" y="196.8881706166452" width="70.93954304633576" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN2
-globalConnNetId: connectivity_net1" data-x="-3.7265768910000006" data-y="1.4489565000000004" x="40" y="209.33519147862637" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="schematic_component_2" data-x="3" data-y="1.5" x="497.10359429268146" y="196.8881706166452" width="70.93954304633587" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN2
-globalConnNetId: connectivity_net1" data-x="-3.7005768910000008" data-y="-1.3260434999999995" x="50.69952607939774" y="397.10833128262664" width="14.171557721056644" height="31.88600487237744" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="schematic_component_3" data-x="-3" data-y="-1.5" x="71.9568626609827" y="409.4615364324946" width="70.93954304633581" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN3
-globalConnNetId: connectivity_net2" data-x="0.7265768910000006" data-y="1.4485175000000003" x="355.54062931177316" y="209.3662980478241" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="schematic_component_4" data-x="0" data-y="-1.5" x="284.5302284768321" y="409.4615364324946" width="70.93954304633576" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN3
-globalConnNetId: connectivity_net2" data-x="-2.2734231089999994" data-y="-1.5514824999999997" x="142.96726349592376" y="421.9396638636735" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="schematic_component_5" data-x="3" data-y="-1.5" x="497.10359429268146" y="409.4615364324946" width="70.93954304633587" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN3
-globalConnNetId: connectivity_net2" data-x="3.7265768910000006" data-y="-1.5514824999999997" x="568.1139951276225" y="421.9396638636735" width="31.886004872377498" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="" data-x="-3.7265768910000006" data-y="1.4489565000000004" x="40" y="209.33519147862637" width="31.88600487237744" height="14.171557721056615" fill="rgba(255, 0, 0, 0.2)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN4
-globalConnNetId: connectivity_net3" data-x="3.7005768910000008" data-y="1.6735175000000004" x="575.1289161995456" y="184.566072035975" width="14.171557721056615" height="31.886004872377413" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="schematic_component_0" data-x="-3" data-y="1.5" x="71.9568626609827" y="196.8881706166452" width="70.93954304633581" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: PIN4
-globalConnNetId: connectivity_net3" data-x="0.7265768910000006" data-y="-1.5514824999999997" x="355.54062931177316" y="421.9396638636735" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.014112774610714288" />
+    <rect data-type="rect" data-label="schematic_component_1" data-x="0" data-y="1.5" x="284.5302284768321" y="196.8881706166452" width="70.93954304633576" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_2" data-x="3" data-y="1.5" x="497.10359429268146" y="196.8881706166452" width="70.93954304633587" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_3" data-x="-3" data-y="-1.5" x="71.9568626609827" y="409.4615364324946" width="70.93954304633581" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_4" data-x="0" data-y="-1.5" x="284.5302284768321" y="409.4615364324946" width="70.93954304633576" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_5" data-x="3" data-y="-1.5" x="497.10359429268146" y="409.4615364324946" width="70.93954304633587" height="31.831940379671494" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="3.7265768910000006" data-y="-1.5514824999999997" x="568.1139951276225" y="421.9396638636735" width="31.886004872377498" height="14.171557721056615" fill="rgba(255, 0, 0, 0.2)" stroke="black" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net0" data-x="-3.7005768910000008" data-y="1.6739565000000005" x="50.69952607939774" y="184.53496546677727" width="14.171557721056644" height="31.886004872377413" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net0" data-x="2.2734231089999994" data-y="1.4489565000000004" x="465.1467316316988" y="209.33519147862637" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net1" data-x="-3.7265768910000006" data-y="1.4489565000000004" x="40" y="209.33519147862637" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net1" data-x="-3.7005768910000008" data-y="-1.3260434999999995" x="50.69952607939774" y="397.10833128262664" width="14.171557721056644" height="31.88600487237744" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net2" data-x="0.7265768910000006" data-y="1.4485175000000003" x="355.54062931177316" y="209.3662980478241" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net2" data-x="-2.2734231089999994" data-y="-1.5514824999999997" x="142.96726349592376" y="421.9396638636735" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net2" data-x="3.7265768910000006" data-y="-1.5514824999999997" x="568.1139951276225" y="421.9396638636735" width="31.886004872377498" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net3" data-x="3.7005768910000008" data-y="1.6735175000000004" x="575.1289161995456" y="184.566072035975" width="14.171557721056615" height="31.886004872377413" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net3" data-x="0.7265768910000006" data-y="-1.5514824999999997" x="355.54062931177316" y="421.9396638636735" width="31.88600487237744" height="14.171557721056615" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.014112774610714288" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/examples/__snapshots__/example32.snap.svg
+++ b/tests/examples/__snapshots__/example32.snap.svg
@@ -105,80 +105,108 @@ x-" data-x="3.935" data-y="-1.5" cx="522.1375825884181" cy="403.793237465993" r=
 x+" data-x="5.0649999999999995" data-y="-1.5" cx="583.6222308589195" cy="403.793237465993" r="3" fill="hsl(33, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-4.475" data-y="2.9699999999999998" cx="64.53944811504081" cy="160.57520404197436" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="B1.1
+x-" data-x="-4.475" data-y="2.9699999999999998" cx="64.53944811504081" cy="160.57520404197436" r="3" fill="hsl(210, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-2.38" data-y="3" cx="178.5308977846871" cy="158.94286824718228" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="B1.2
+x+" data-x="-3.525" data-y="2.9699999999999998" cx="116.23008161678973" cy="160.57520404197436" r="3" fill="hsl(211, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-2.9699999999999998" data-y="2.9699999999999998" cx="146.42829382044306" cy="160.57520404197436" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="SW1.1
+x-" data-x="-2.38" data-y="3" cx="178.5308977846871" cy="158.94286824718228" r="3" fill="hsl(104, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="4.75" data-y="1.5" cx="566.4827050136028" cy="240.55965798678585" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="SW1.2
+x+" data-x="-1.62" data-y="3" cx="219.88340458608627" cy="158.94286824718228" r="3" fill="hsl(105, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-2.45" data-y="-3" cx="174.7221142635056" cy="485.4100272055966" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="C3.1
+x-" data-x="-3.55" data-y="1.5" cx="114.86980178779635" cy="240.55965798678585" r="3" fill="hsl(243, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="5.0649999999999995" data-y="-1.5" cx="583.6222308589195" cy="403.793237465993" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="C3.2
+x+" data-x="-2.45" data-y="1.5" cx="174.7221142635056" cy="240.55965798678585" r="3" fill="hsl(244, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-1.62" data-y="3" cx="219.88340458608627" cy="158.94286824718228" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="U1.1
+x+" data-x="2.7" data-y="2.2" cx="454.93975903614455" cy="202.47182277497086" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-3.55" data-y="1.5" cx="114.86980178779635" cy="240.55965798678585" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="U1.2
+x-" data-x="0.2999999999999998" data-y="2.2" cx="324.35289545277885" cy="202.47182277497086" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="0.09999999999999981" data-y="3.2" cx="313.47065682083166" cy="148.06062961523511" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="U1.3
+x+" data-x="2.7" data-y="2.6" cx="454.93975903614455" cy="180.70734551107657" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-4.550000000000001" data-y="-1.5" cx="60.458608628060574" cy="403.793237465993" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="U1.4
+x-" data-x="0.2999999999999998" data-y="2.8" cx="324.35289545277885" cy="169.82510687912944" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="0.09999999999999981" data-y="2.4" cx="313.47065682083166" cy="191.5895841430237" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="U1.5
+x-" data-x="0.2999999999999998" data-y="2.6" cx="324.35289545277885" cy="180.70734551107657" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-1.25" data-y="-1.5" cx="240.01554605518848" cy="403.793237465993" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="U1.6
+x-" data-x="0.2999999999999998" data-y="2.4" cx="324.35289545277885" cy="191.5895841430237" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="2.7" data-y="2.6" cx="454.93975903614455" cy="180.70734551107657" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="U1.7
+x+" data-x="2.7" data-y="2.4" cx="454.93975903614455" cy="191.5895841430237" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="1.95" data-y="-1.5" cx="414.1313641663428" cy="403.793237465993" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="U1.8
+x+" data-x="2.7" data-y="2.8" cx="454.93975903614455" cy="169.82510687912944" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="0.2999999999999998" data-y="2.6" cx="324.35289545277885" cy="180.70734551107657" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="C2.1
+x-" data-x="3.45" data-y="1.5" cx="495.74815390594637" cy="240.55965798678585" r="3" fill="hsl(2, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.45" data-y="1.5" cx="495.74815390594637" cy="240.55965798678585" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="C2.2
+x+" data-x="4.55" data-y="1.5" cx="555.6004663816557" cy="240.55965798678585" r="3" fill="hsl(3, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-3" data-y="-1.5" cx="144.79595802565098" cy="403.793237465993" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="R1.1
+x-" data-x="-4.550000000000001" data-y="-1.5" cx="60.458608628060574" cy="403.793237465993" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="2.7" data-y="2.4" cx="454.93975903614455" cy="191.5895841430237" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="R1.2
+x+" data-x="-3.4499999999999997" data-y="-1.5" cx="120.31092110376991" cy="403.793237465993" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="3.4924999999999997" data-y="-1.5" cx="498.06062961523514" cy="403.793237465993" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="R2.1
+x-" data-x="-2.55" data-y="-1.5" cx="169.28099494753206" cy="403.793237465993" r="3" fill="hsl(107, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R2.2
+x+" data-x="-1.45" data-y="-1.5" cx="229.13330742324132" cy="403.793237465993" r="3" fill="hsl(108, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C1.1
+x-" data-x="-3.55" data-y="-3" cx="114.86980178779635" cy="485.4100272055966" r="3" fill="hsl(121, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C1.2
+x+" data-x="-2.45" data-y="-3" cx="174.7221142635056" cy="485.4100272055966" r="3" fill="hsl(122, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R3.1
+x-" data-x="1.95" data-y="-1.5" cx="414.1313641663428" cy="403.793237465993" r="3" fill="hsl(348, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R3.2
+x+" data-x="3.05" data-y="-1.5" cx="473.98367664205205" cy="403.793237465993" r="3" fill="hsl(349, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="D1.1
+x-" data-x="3.935" data-y="-1.5" cx="522.1375825884181" cy="403.793237465993" r="3" fill="hsl(32, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="D1.2
+x+" data-x="5.0649999999999995" data-y="-1.5" cx="583.6222308589195" cy="403.793237465993" r="3" fill="hsl(33, 100%, 50%, 0.8)" />
   </g>
   <g>
     <polyline data-points="-4.475,2.9699999999999998 -2.38,3" data-type="line" data-label="" points="64.53944811504081,160.57520404197436 178.5308977846871,158.94286824718228" fill="none" stroke="hsl(192, 100%, 50%, 0.8)" stroke-width="1" />
@@ -217,13 +245,40 @@ orientation: y+" data-x="3.4924999999999997" data-y="-1.5" cx="498.0606296152351
     <polyline data-points="-1.4500000000000002,-1.5 -1.25,-1.5 -1.25,-2.25 -3.75,-2.25 -3.75,-3 -3.55,-3" data-type="line" data-label="" points="229.13330742324132,403.793237465993 240.01554605518848,403.793237465993 240.01554605518848,444.60163233579476 103.98756315584919,444.60163233579476 103.98756315584919,485.4100272055966 114.86980178779635,485.4100272055966" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-3.525,2.9699999999999998 -2.415,2.9699999999999998 -2.415,1.5 -2.45,1.5" data-type="line" data-label="" points="116.23008161678973,160.57520404197436 176.62650602409636,160.57520404197436 176.62650602409636,240.55965798678585 174.7221142635056,240.55965798678585" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
     <polyline data-points="2.7,2.2 4.75,2.2 4.75,1.5 4.55,1.5" data-type="line" data-label="" points="454.93975903614455,202.47182277497086 566.4827050136028,202.47182277497086 566.4827050136028,240.55965798678585 555.6004663816557,240.55965798678585" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="0.2999999999999998,2.8 0.09999999999999981,2.8 0.09999999999999981,3.2 2.9000000000000004,3.2 2.9000000000000004,2.8 2.7,2.8" data-type="line" data-label="" points="324.35289545277885,169.82510687912944 313.47065682083166,169.82510687912944 313.47065682083166,148.06062961523511 465.82199766809174,148.06062961523511 465.82199766809174,169.82510687912944 454.93975903614455,169.82510687912944" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-4.475,2.9699999999999998 -2.38,3" data-type="line" data-label="" points="64.53944811504081,160.57520404197436 178.5308977846871,158.94286824718228" fill="none" stroke="hsl(192, 100%, 50%, 0.1)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.2999999999999998,2.6 3.45,1.5" data-type="line" data-label="" points="324.35289545277885,180.70734551107657 495.74815390594637,240.55965798678585" fill="none" stroke="hsl(120, 100%, 50%, 0.1)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.2999999999999998,2.4 0.2999999999999998,2.2" data-type="line" data-label="" points="324.35289545277885,191.5895841430237 324.35289545277885,202.47182277497086" fill="none" stroke="hsl(192, 100%, 50%, 0.1)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3.05,-1.5 3.935,-1.5" data-type="line" data-label="" points="473.98367664205205,403.793237465993 522.1375825884181,403.793237465993" fill="none" stroke="hsl(344, 100%, 50%, 0.1)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-3.525,2.9699999999999998 -2.45,1.5" data-type="line" data-label="" points="116.23008161678973,160.57520404197436 174.7221142635056,240.55965798678585" fill="none" stroke="hsl(157, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="2.7,2.2 4.55,1.5" data-type="line" data-label="" points="454.93975903614455,202.47182277497086 555.6004663816557,240.55965798678585" fill="none" stroke="hsl(157, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-1.62,3 -3.55,1.5" data-type="line" data-label="" points="219.88340458608627,158.94286824718228 114.86980178779635,240.55965798678585" fill="none" stroke="hsl(190, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.2999999999999998,2.8 2.7,2.8" data-type="line" data-label="" points="324.35289545277885,169.82510687912944 454.93975903614455,169.82510687912944" fill="none" stroke="hsl(190, 100%, 50%, 0.1)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.525,2.9699999999999998 -2.415,2.9699999999999998 -2.415,1.5 -2.45,1.5" data-type="line" data-label="" points="116.23008161678973,160.57520404197436 176.62650602409636,160.57520404197436 176.62650602409636,240.55965798678585 174.7221142635056,240.55965798678585" fill="none" stroke="red" stroke-width="1" stroke-dasharray="4 4" />
+  </g>
+  <g>
+    <polyline data-points="-3.525,2.9699999999999998 -2.415,2.9699999999999998 -2.415,1.5 -2.45,1.5" data-type="line" data-label="" points="116.23008161678973,160.57520404197436 176.62650602409636,160.57520404197436 176.62650602409636,240.55965798678585 174.7221142635056,240.55965798678585" fill="none" stroke="orange" stroke-width="1" />
   </g>
   <g>
     <rect data-type="rect" data-label="schematic_component_0" data-x="-4" data-y="3" x="64.53944811504081" y="151.05324523902058" width="51.69063350174892" height="15.779246016323384" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.018378571428571428" />
@@ -256,80 +311,94 @@ orientation: y+" data-x="3.4924999999999997" data-y="-1.5" cx="498.0606296152351
     <rect data-type="rect" data-label="schematic_component_9" data-x="4.5" data-y="-1.5" x="522.1375825884181" y="386.1095996890789" width="61.48464827050134" height="35.36727555382822" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .B1 &gt; .pin1 to .SW1 &gt; .pin1
-globalConnNetId: connectivity_net0" data-x="-4.701" data-y="2.9699999999999998" x="40" y="155.1340847260008" width="24.48503692188106" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_0" data-x="-4" data-y="3" x="64.53944811504081" y="151.05324523902058" width="51.69063350174892" height="15.779246016323384" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .B1 &gt; .pin1 to .SW1 &gt; .pin1
-globalConnNetId: connectivity_net0" data-x="-2.606" data-y="3" x="153.9914496696463" y="153.5017489312087" width="24.48503692188109" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_1" data-x="-2" data-y="3" x="178.5308977846871" y="145.34006995724835" width="41.35250680139916" height="27.20559657986786" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net6" data-x="-2.9699999999999998" data-y="2.82" x="140.9871745044695" y="160.57520404197436" width="10.882238631947132" height="16.323357947920698" fill="#00000066" stroke="#000000" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_2" data-x="-3" data-y="1.5" x="114.86980178779635" y="217.70695685969685" width="59.852312475709255" height="45.70540225417801" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net6" data-x="4.75" data-y="1.35" x="561.0415856976292" y="240.55965798678585" width="10.882238631947075" height="16.323357947920726" fill="#00000066" stroke="#000000" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_3" data-x="1.5" data-y="2.5" x="324.35289545277885" y="158.94286824718228" width="130.5868635833657" height="54.41119315973572" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net6" data-x="-2.2990000000000004" data-y="-3" x="174.77652545666535" y="479.968907889623" width="16.323357947920698" height="10.882238631947189" fill="#00000066" stroke="#000000" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_4" data-x="4" data-y="1.5" x="495.74815390594637" y="217.70695685969685" width="59.85231247570931" height="45.70540225417801" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net6" data-x="5.216" data-y="-1.5" x="583.6766420520793" y="398.3521181500194" width="16.323357947920726" height="10.882238631947189" fill="#00000066" stroke="#000000" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_5" data-x="-4" data-y="-1.5" x="60.458608628060574" y="393.212689856199" width="59.85231247570934" height="21.161095219587992" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net7" data-x="-1.4690000000000003" data-y="3" x="219.937815779246" y="153.5017489312087" width="16.323357947920698" height="10.882238631947132" fill="#ef444466" stroke="#ef4444" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_6" data-x="-2" data-y="-1.5" x="169.28099494753206" y="393.212689856199" width="59.852312475709255" height="21.161095219587992" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net7" data-x="-3.7009999999999996" data-y="1.5" x="98.4920326467159" y="235.11853867081226" width="16.323357947920698" height="10.882238631947189" fill="#ef444466" stroke="#ef4444" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_7" data-x="-3" data-y="-3" x="114.86980178779635" y="462.5573260785076" width="59.852312475709255" height="45.70540225417801" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net7" data-x="0.09999999999999981" data-y="3.35" x="308.0295375048581" y="131.73727166731442" width="10.882238631947132" height="16.323357947920698" fill="#ef444466" stroke="#ef4444" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_8" data-x="2.5" data-y="-1.5" x="414.1313641663428" y="393.212689856199" width="59.852312475709255" height="21.161095219587992" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net7" data-x="-4.701000000000001" data-y="-1.5" x="44.08083948698004" y="398.3521181500194" width="16.323357947920783" height="10.882238631947189" fill="#ef444466" stroke="#ef4444" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="schematic_component_9" data-x="4.5" data-y="-1.5" x="522.1375825884181" y="386.1095996890789" width="61.48464827050134" height="35.36727555382822" fill="hsl(24, 100%, 50%, 0.1)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .U1 &gt; .THRES to .C1 &gt; .pin1
-globalConnNetId: connectivity_net2" data-x="-0.1250000000000002" data-y="2.4" x="288.98561989895063" y="186.14846482705013" width="24.485036921881033" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="" data-x="-2.606" data-y="3" x="153.9914496696463" y="153.5017489312087" width="24.48503692188109" height="10.882238631947132" fill="rgba(255, 0, 0, 0.2)" stroke="black" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .R2 &gt; .pin2 to .U1 &gt; .THRES
-globalConnNetId: connectivity_net2" data-x="-1.25" data-y="-1.275" x="234.5744267392149" y="379.3082005441119" width="10.882238631947132" height="24.48503692188109" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="connectivity_net0" data-x="-4.701" data-y="2.9699999999999998" x="40" y="155.1340847260008" width="24.48503692188106" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .U1 &gt; .OUT to .R3 &gt; .pin1
-globalConnNetId: connectivity_net4" data-x="2.926" data-y="2.6" x="454.9941702293043" y="175.26622619510297" width="24.48503692188109" height="10.88223863194716" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="connectivity_net0" data-x="-2.606" data-y="3" x="153.9914496696463" y="153.5017489312087" width="24.48503692188109" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .U1 &gt; .OUT to .R3 &gt; .pin1
-globalConnNetId: connectivity_net4" data-x="1.724" data-y="-1.5" x="389.59191605130195" y="398.3521181500194" width="24.48503692188109" height="10.882238631947189" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="connectivity_net6" data-x="-2.9699999999999998" data-y="2.82" x="140.9871745044695" y="160.57520404197436" width="10.882238631947132" height="16.323357947920698" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .U1 &gt; .CTRL to .C2 &gt; .pin1
-globalConnNetId: connectivity_net1" data-x="0.07399999999999982" data-y="2.6" x="299.813447337738" y="175.26622619510297" width="24.48503692188109" height="10.88223863194716" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="connectivity_net6" data-x="4.75" data-y="1.35" x="561.0415856976292" y="240.55965798678585" width="10.882238631947075" height="16.323357947920726" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .U1 &gt; .CTRL to .C2 &gt; .pin1
-globalConnNetId: connectivity_net1" data-x="3.224" data-y="1.5" x="471.2087057909056" y="235.11853867081226" width="24.485036921881033" height="10.882238631947189" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="connectivity_net6" data-x="-2.2990000000000004" data-y="-3" x="174.77652545666535" y="479.968907889623" width="16.323357947920698" height="10.882238631947189" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .U1 &gt; .DISCH to .R2 &gt; .pin1
-globalConnNetId: connectivity_net3" data-x="-3" data-y="-1.275" x="139.3548387096774" y="379.3082005441119" width="10.882238631947132" height="24.48503692188109" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="connectivity_net6" data-x="5.216" data-y="-1.5" x="583.6766420520793" y="398.3521181500194" width="16.323357947920726" height="10.882238631947189" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .U1 &gt; .DISCH to .R2 &gt; .pin1
-globalConnNetId: connectivity_net3" data-x="2.926" data-y="2.4" x="454.9941702293043" y="186.14846482705013" width="24.48503692188109" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="connectivity_net7" data-x="-1.4690000000000003" data-y="3" x="219.937815779246" y="153.5017489312087" width="16.323357947920698" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: .R3 &gt; .pin2 to .D1 &gt; .pin1
-globalConnNetId: connectivity_net5" data-x="3.4924999999999997" data-y="-1.275" x="492.6195102992615" y="379.3082005441119" width="10.882238631947189" height="24.48503692188109" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018378571428571428" />
+    <rect data-type="rect" data-label="connectivity_net7" data-x="-3.7009999999999996" data-y="1.5" x="98.4920326467159" y="235.11853867081226" width="16.323357947920698" height="10.882238631947189" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net7" data-x="0.09999999999999981" data-y="3.35" x="308.0295375048581" y="131.73727166731442" width="10.882238631947132" height="16.323357947920698" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net7" data-x="-4.701000000000001" data-y="-1.5" x="44.08083948698004" y="398.3521181500194" width="16.323357947920783" height="10.882238631947189" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net2" data-x="-0.1250000000000002" data-y="2.4" x="288.98561989895063" y="186.14846482705013" width="24.485036921881033" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net2" data-x="-1.25" data-y="-1.275" x="234.5744267392149" y="379.3082005441119" width="10.882238631947132" height="24.48503692188109" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net4" data-x="2.926" data-y="2.6" x="454.9941702293043" y="175.26622619510297" width="24.48503692188109" height="10.88223863194716" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net4" data-x="1.724" data-y="-1.5" x="389.59191605130195" y="398.3521181500194" width="24.48503692188109" height="10.882238631947189" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net1" data-x="0.07399999999999982" data-y="2.6" x="299.813447337738" y="175.26622619510297" width="24.48503692188109" height="10.88223863194716" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net1" data-x="3.224" data-y="1.5" x="471.2087057909056" y="235.11853867081226" width="24.485036921881033" height="10.882238631947189" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net3" data-x="-3" data-y="-1.275" x="139.3548387096774" y="379.3082005441119" width="10.882238631947132" height="24.48503692188109" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net3" data-x="2.926" data-y="2.4" x="454.9941702293043" y="186.14846482705013" width="24.48503692188109" height="10.882238631947132" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="connectivity_net5" data-x="3.4924999999999997" data-y="-1.275" x="492.6195102992615" y="379.3082005441119" width="10.882238631947189" height="24.48503692188109" fill="hsl(40, 100%, 50%, 0.3)" stroke="hsl(40, 100%, 50%, 1)" stroke-width="0.018378571428571428" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
+++ b/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceCombiningSolver } from "lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const createTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [
+      { pinId: `${mspPairId}.1`, x: 0, y: 0, chipId: "U1" },
+      { pinId: `${mspPairId}.2`, x: 1, y: 0, chipId: "U2" },
+    ],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}.1`, `${mspPairId}.2`],
+  }) as SolvedTracePath
+
+test("SameNetTraceCombiningSolver snaps close parallel same-net segments together", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      createTrace("trace-a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+      ]),
+      createTrace("trace-b", "net-1", [
+        { x: 1, y: 0.1 },
+        { x: 3, y: 0.1 },
+      ]),
+    ],
+    mergeDistance: 0.15,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.mergedSegmentCount).toBe(1)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: 0 },
+    { x: 3, y: 0 },
+  ])
+})
+
+test("SameNetTraceCombiningSolver leaves nearby segments on different nets unchanged", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      createTrace("trace-a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+      ]),
+      createTrace("trace-b", "net-2", [
+        { x: 1, y: 0.1 },
+        { x: 3, y: 0.1 },
+      ]),
+    ],
+    mergeDistance: 0.15,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.mergedSegmentCount).toBe(0)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: 0.1 },
+    { x: 3, y: 0.1 },
+  ])
+})

--- a/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
+++ b/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
@@ -131,3 +131,77 @@ test("SameNetTraceCombiningSolver recomputes segment refs until close runs colla
   expect(solver.getOutput().traces[2]!.tracePath[1]!.y).toBe(0)
   expect(solver.getOutput().traces[2]!.tracePath[2]!.y).toBe(0)
 })
+
+test("SameNetTraceCombiningSolver does not snap through a different-net trace", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      createTrace("target", "net-1", [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+      ]),
+      createTrace("source", "net-1", [
+        { x: 1, y: -1 },
+        { x: 1, y: 0.1 },
+        { x: 3, y: 0.1 },
+        { x: 3, y: 1 },
+      ]),
+      createTrace("blocker", "net-2", [
+        { x: 2, y: -0.05 },
+        { x: 2, y: 0.05 },
+      ]),
+    ],
+    mergeDistance: 0.15,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.mergedSegmentCount).toBe(0)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: -1 },
+    { x: 1, y: 0.1 },
+    { x: 3, y: 0.1 },
+    { x: 3, y: 1 },
+  ])
+})
+
+test("SameNetTraceCombiningSolver does not snap through an existing net label obstacle", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      createTrace("target", "net-1", [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+      ]),
+      createTrace("source", "net-1", [
+        { x: 1, y: -1 },
+        { x: 1, y: 0.1 },
+        { x: 3, y: 0.1 },
+        { x: 3, y: 1 },
+      ]),
+    ],
+    netLabelPlacements: [
+      {
+        globalConnNetId: "net-2",
+        mspConnectionPairIds: [],
+        pinIds: [],
+        orientation: "x+",
+        anchorPoint: { x: 2, y: 0 },
+        center: { x: 2, y: 0 },
+        width: 0.2,
+        height: 0.05,
+      },
+    ],
+    mergeDistance: 0.15,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.mergedSegmentCount).toBe(0)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: -1 },
+    { x: 1, y: 0.1 },
+    { x: 3, y: 0.1 },
+    { x: 3, y: 1 },
+  ])
+})

--- a/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
+++ b/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
@@ -28,8 +28,10 @@ test("SameNetTraceCombiningSolver snaps close parallel same-net segments togethe
         { x: 4, y: 0 },
       ]),
       createTrace("trace-b", "net-1", [
+        { x: 1, y: -1 },
         { x: 1, y: 0.1 },
         { x: 3, y: 0.1 },
+        { x: 3, y: 1 },
       ]),
     ],
     mergeDistance: 0.15,
@@ -40,8 +42,10 @@ test("SameNetTraceCombiningSolver snaps close parallel same-net segments togethe
   expect(solver.solved).toBe(true)
   expect(solver.mergedSegmentCount).toBe(1)
   expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: -1 },
     { x: 1, y: 0 },
     { x: 3, y: 0 },
+    { x: 3, y: 1 },
   ])
 })
 
@@ -68,4 +72,62 @@ test("SameNetTraceCombiningSolver leaves nearby segments on different nets uncha
     { x: 1, y: 0.1 },
     { x: 3, y: 0.1 },
   ])
+})
+
+test("SameNetTraceCombiningSolver does not detach trace endpoints", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      createTrace("trace-a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+      ]),
+      createTrace("trace-b", "net-1", [
+        { x: 1, y: 0.1 },
+        { x: 3, y: 0.1 },
+      ]),
+    ],
+    mergeDistance: 0.15,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.mergedSegmentCount).toBe(0)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: 0.1 },
+    { x: 3, y: 0.1 },
+  ])
+})
+
+test("SameNetTraceCombiningSolver recomputes segment refs until close runs collapse", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      createTrace("trace-a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+      ]),
+      createTrace("trace-b", "net-1", [
+        { x: 1, y: -1 },
+        { x: 1, y: 0.1 },
+        { x: 3, y: 0.1 },
+        { x: 3, y: 1 },
+      ]),
+      createTrace("trace-c", "net-1", [
+        { x: 1.25, y: -1 },
+        { x: 1.25, y: 0.14 },
+        { x: 2.75, y: 0.14 },
+        { x: 2.75, y: 1 },
+      ]),
+    ],
+    mergeDistance: 0.15,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.mergedSegmentCount).toBe(2)
+  expect(solver.getOutput().traces[1]!.tracePath[1]!.y).toBe(0)
+  expect(solver.getOutput().traces[1]!.tracePath[2]!.y).toBe(0)
+  expect(solver.getOutput().traces[2]!.tracePath[1]!.y).toBe(0)
+  expect(solver.getOutput().traces[2]!.tracePath[2]!.y).toBe(0)
 })


### PR DESCRIPTION
## Summary
- add `SameNetTraceCombiningSolver` as a dedicated post-cleanup pipeline phase
- group traces by `globalConnNetId` and snap close overlapping parallel same-net segments onto a shared run
- keep terminal trace segments fixed so pin endpoints do not detach
- recompute segment refs after each snap and iterate until stable so close runs collapse consistently
- preserve different-net geometry and add focused regression coverage for all of the above

/claim #29
/claim #34

## Tests
- `npx --yes bun test tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts`
- `npx --yes bun run format:check`
- `npx --yes tsc --noEmit`
- `npx --yes bun run build`
- `npx --yes bun test`

## Review feedback addressed
- terminal/source endpoints are no longer moved during snapping
- segment references are rebuilt after every successful snap by iterating one combine at a time until stable