### PR TITLE
Add same-net trace merging phase

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+export { SameNetTraceMergingSolver } from "./solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver"

--- a/lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.ts
+++ b/lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.ts
@@ -1,0 +1,321 @@
+import type { Point } from "@tscircuit/math-utils"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
+import { getColorFromString } from "lib/utils/getColorFromString"
+
+type Orientation = "horizontal" | "vertical"
+
+interface TraceSegment {
+  traceIndex: number
+  segmentIndex: number
+  orientation: Orientation
+  axis: number
+  min: number
+  max: number
+  movable: boolean
+}
+
+interface MergeCandidate {
+  segmentA: TraceSegment
+  segmentB: TraceSegment
+  targetAxis: number
+}
+
+const EPS = 1e-6
+const DEFAULT_MERGE_TOLERANCE = 0.2
+const MIN_OVERLAP_LENGTH = 0.05
+
+export class SameNetTraceMergingSolver extends BaseSolver {
+  inputProblem: InputProblem
+  inputTraces: SolvedTracePath[]
+  outputTraces: SolvedTracePath[]
+  mergeTolerance: number
+  lastMergeCandidate: MergeCandidate | null = null
+
+  constructor(params: {
+    inputProblem: InputProblem
+    inputTraces: SolvedTracePath[]
+    mergeTolerance?: number
+  }) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.inputTraces = params.inputTraces
+    this.outputTraces = params.inputTraces.map(cloneTrace)
+    this.mergeTolerance = params.mergeTolerance ?? DEFAULT_MERGE_TOLERANCE
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceMergingSolver
+  >[0] {
+    return {
+      inputProblem: this.inputProblem,
+      inputTraces: this.inputTraces,
+      mergeTolerance: this.mergeTolerance,
+    }
+  }
+
+  override _step() {
+    const candidate = this.findNextMergeCandidate()
+
+    if (!candidate) {
+      this.solved = true
+      return
+    }
+
+    this.lastMergeCandidate = candidate
+    this.alignSegment(candidate.segmentA, candidate.targetAxis)
+    this.alignSegment(candidate.segmentB, candidate.targetAxis)
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  private findNextMergeCandidate(): MergeCandidate | null {
+    const tracesByNet = new Map<string, number[]>()
+
+    for (let i = 0; i < this.outputTraces.length; i++) {
+      const trace = this.outputTraces[i]!
+      const traces = tracesByNet.get(trace.globalConnNetId) ?? []
+      traces.push(i)
+      tracesByNet.set(trace.globalConnNetId, traces)
+    }
+
+    for (const traceIndexes of tracesByNet.values()) {
+      if (traceIndexes.length < 2) continue
+
+      const segments = traceIndexes.flatMap((traceIndex) =>
+        this.getSegmentsForTrace(traceIndex),
+      )
+
+      for (let i = 0; i < segments.length; i++) {
+        const segmentA = segments[i]!
+        for (let j = i + 1; j < segments.length; j++) {
+          const segmentB = segments[j]!
+          if (segmentA.traceIndex === segmentB.traceIndex) continue
+          if (segmentA.orientation !== segmentB.orientation) continue
+          if (!segmentA.movable && !segmentB.movable) continue
+
+          const axisDistance = Math.abs(segmentA.axis - segmentB.axis)
+          if (axisDistance < EPS || axisDistance > this.mergeTolerance) continue
+          if (getOverlapLength(segmentA, segmentB) < MIN_OVERLAP_LENGTH)
+            continue
+
+          const targetAxis = this.getTargetAxis(segmentA, segmentB)
+          if (!this.canAlignSegment(segmentA, targetAxis)) continue
+          if (!this.canAlignSegment(segmentB, targetAxis)) continue
+
+          return { segmentA, segmentB, targetAxis }
+        }
+      }
+    }
+
+    return null
+  }
+
+  private getTargetAxis(segmentA: TraceSegment, segmentB: TraceSegment) {
+    if (segmentA.movable && segmentB.movable) {
+      return (segmentA.axis + segmentB.axis) / 2
+    }
+    return segmentA.movable ? segmentB.axis : segmentA.axis
+  }
+
+  private getSegmentsForTrace(traceIndex: number): TraceSegment[] {
+    const trace = this.outputTraces[traceIndex]!
+    const segments: TraceSegment[] = []
+
+    for (
+      let segmentIndex = 0;
+      segmentIndex < trace.tracePath.length - 1;
+      segmentIndex++
+    ) {
+      const p1 = trace.tracePath[segmentIndex]!
+      const p2 = trace.tracePath[segmentIndex + 1]!
+      const isHorizontal = Math.abs(p1.y - p2.y) < EPS
+      const isVertical = Math.abs(p1.x - p2.x) < EPS
+
+      if (!isHorizontal && !isVertical) continue
+
+      const orientation: Orientation = isHorizontal ? "horizontal" : "vertical"
+      segments.push({
+        traceIndex,
+        segmentIndex,
+        orientation,
+        axis: orientation === "horizontal" ? p1.y : p1.x,
+        min:
+          orientation === "horizontal"
+            ? Math.min(p1.x, p2.x)
+            : Math.min(p1.y, p2.y),
+        max:
+          orientation === "horizontal"
+            ? Math.max(p1.x, p2.x)
+            : Math.max(p1.y, p2.y),
+        movable: this.isSegmentMovable(trace, segmentIndex),
+      })
+    }
+
+    return segments
+  }
+
+  private isSegmentMovable(trace: SolvedTracePath, segmentIndex: number) {
+    return segmentIndex > 0 && segmentIndex < trace.tracePath.length - 2
+  }
+
+  private canAlignSegment(segment: TraceSegment, targetAxis: number) {
+    if (Math.abs(segment.axis - targetAxis) < EPS) return true
+    if (!segment.movable) return false
+
+    const updatedTrace = cloneTrace(this.outputTraces[segment.traceIndex]!)
+    moveSegmentAxis(updatedTrace.tracePath, segment, targetAxis)
+    normalizeTracePath(updatedTrace.tracePath)
+
+    return !this.hasDifferentNetOverlap(updatedTrace, segment.traceIndex)
+  }
+
+  private alignSegment(segment: TraceSegment, targetAxis: number) {
+    if (!segment.movable || Math.abs(segment.axis - targetAxis) < EPS) return
+
+    const trace = this.outputTraces[segment.traceIndex]!
+    moveSegmentAxis(trace.tracePath, segment, targetAxis)
+    normalizeTracePath(trace.tracePath)
+  }
+
+  private hasDifferentNetOverlap(
+    updatedTrace: SolvedTracePath,
+    updatedTraceIndex: number,
+  ) {
+    const updatedSegments = getTraceSegments(updatedTrace)
+
+    for (
+      let traceIndex = 0;
+      traceIndex < this.outputTraces.length;
+      traceIndex++
+    ) {
+      if (traceIndex === updatedTraceIndex) continue
+
+      const otherTrace = this.outputTraces[traceIndex]!
+      if (otherTrace.globalConnNetId === updatedTrace.globalConnNetId) continue
+
+      for (const updatedSegment of updatedSegments) {
+        for (const otherSegment of getTraceSegments(otherTrace)) {
+          if (updatedSegment.orientation !== otherSegment.orientation) continue
+          if (Math.abs(updatedSegment.axis - otherSegment.axis) > EPS) continue
+          if (getOverlapLength(updatedSegment, otherSegment) > EPS) return true
+        }
+      }
+    }
+
+    return false
+  }
+
+  override visualize() {
+    const graphics = visualizeInputProblem(this.inputProblem, {
+      chipAlpha: 0.1,
+      connectionAlpha: 0.1,
+    })
+
+    for (const trace of this.outputTraces) {
+      graphics.lines!.push({
+        points: trace.tracePath,
+        strokeColor: getColorFromString(trace.globalConnNetId, 0.85),
+      })
+    }
+
+    return graphics
+  }
+}
+
+const cloneTrace = (trace: SolvedTracePath): SolvedTracePath => ({
+  ...trace,
+  pins: [...trace.pins] as SolvedTracePath["pins"],
+  tracePath: trace.tracePath.map((point) => ({ ...point })),
+  mspConnectionPairIds: [...trace.mspConnectionPairIds],
+  pinIds: [...trace.pinIds],
+})
+
+const moveSegmentAxis = (
+  tracePath: Point[],
+  segment: Pick<TraceSegment, "segmentIndex" | "orientation">,
+  targetAxis: number,
+) => {
+  const p1 = tracePath[segment.segmentIndex]!
+  const p2 = tracePath[segment.segmentIndex + 1]!
+
+  if (segment.orientation === "horizontal") {
+    p1.y = targetAxis
+    p2.y = targetAxis
+  } else {
+    p1.x = targetAxis
+    p2.x = targetAxis
+  }
+}
+
+const normalizeTracePath = (tracePath: Point[]) => {
+  for (let i = tracePath.length - 1; i > 0; i--) {
+    if (pointsEqual(tracePath[i]!, tracePath[i - 1]!)) {
+      tracePath.splice(i, 1)
+    }
+  }
+
+  for (let i = tracePath.length - 2; i > 0; i--) {
+    const prev = tracePath[i - 1]!
+    const cur = tracePath[i]!
+    const next = tracePath[i + 1]!
+    const allHorizontal =
+      Math.abs(prev.y - cur.y) < EPS && Math.abs(cur.y - next.y) < EPS
+    const allVertical =
+      Math.abs(prev.x - cur.x) < EPS && Math.abs(cur.x - next.x) < EPS
+
+    if (allHorizontal || allVertical) {
+      tracePath.splice(i, 1)
+    }
+  }
+}
+
+const pointsEqual = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) < EPS && Math.abs(a.y - b.y) < EPS
+
+const getTraceSegments = (trace: SolvedTracePath): TraceSegment[] => {
+  const segments: TraceSegment[] = []
+
+  for (
+    let segmentIndex = 0;
+    segmentIndex < trace.tracePath.length - 1;
+    segmentIndex++
+  ) {
+    const p1 = trace.tracePath[segmentIndex]!
+    const p2 = trace.tracePath[segmentIndex + 1]!
+    const isHorizontal = Math.abs(p1.y - p2.y) < EPS
+    const isVertical = Math.abs(p1.x - p2.x) < EPS
+
+    if (!isHorizontal && !isVertical) continue
+
+    const orientation: Orientation = isHorizontal ? "horizontal" : "vertical"
+    segments.push({
+      traceIndex: 0,
+      segmentIndex,
+      orientation,
+      axis: orientation === "horizontal" ? p1.y : p1.x,
+      min:
+        orientation === "horizontal"
+          ? Math.min(p1.x, p2.x)
+          : Math.min(p1.y, p2.y),
+      max:
+        orientation === "horizontal"
+          ? Math.max(p1.x, p2.x)
+          : Math.max(p1.y, p2.y),
+      movable: false,
+    })
+  }
+
+  return segments
+}
+
+const getOverlapLength = (
+  segmentA: Pick<TraceSegment, "min" | "max">,
+  segmentB: Pick<TraceSegment, "min" | "max">,
+) => Math.min(segmentA.max, segmentB.max) - Math.max(segmentA.min, segmentB.min)

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceMergingSolver } from "../SameNetTraceMergingSolver/SameNetTraceMergingSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -71,6 +72,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   schematicTraceLinesSolver?: SchematicTraceLinesSolver
   longDistancePairSolver?: LongDistancePairSolver
   traceOverlapShiftSolver?: TraceOverlapShiftSolver
+  sameNetTraceMergingSolver?: SameNetTraceMergingSolver
   netLabelPlacementSolver?: NetLabelPlacementSolver
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
@@ -155,18 +157,24 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       },
     ),
     definePipelineStep(
+      "sameNetTraceMergingSolver",
+      SameNetTraceMergingSolver,
+      (instance) => [
+        {
+          inputProblem: instance.inputProblem,
+          inputTraces: Object.values(
+            instance.traceOverlapShiftSolver!.correctedTraceMap,
+          ),
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       () => [
         {
           inputProblem: this.inputProblem,
-          inputTraceMap:
-            this.traceOverlapShiftSolver?.correctedTraceMap ??
-            Object.fromEntries(
-              this.longDistancePairSolver!.getOutput().allTracesMerged.map(
-                (p) => [p.mspPairId, p],
-              ),
-            ),
+          inputTraceMap: this.getTraceMapAfterSameNetMerging(),
         },
       ],
       {
@@ -179,13 +187,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       "traceLabelOverlapAvoidanceSolver",
       TraceLabelOverlapAvoidanceSolver,
       (instance) => {
-        const traceMap =
-          instance.traceOverlapShiftSolver?.correctedTraceMap ??
-          Object.fromEntries(
-            instance
-              .longDistancePairSolver!.getOutput()
-              .allTracesMerged.map((p) => [p.mspPairId, p]),
-          )
+        const traceMap = instance.getTraceMapAfterSameNetMerging()
         const traces = Object.values(traceMap)
         const netLabelPlacements =
           instance.netLabelPlacementSolver!.netLabelPlacements
@@ -332,6 +334,16 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     correctPinsInsideChips(cloned)
 
     return cloned
+  }
+
+  private getTraceMapAfterSameNetMerging(): Record<string, SolvedTracePath> {
+    const traces =
+      this.sameNetTraceMergingSolver?.getOutput().traces ??
+      (this.traceOverlapShiftSolver
+        ? Object.values(this.traceOverlapShiftSolver.correctedTraceMap)
+        : this.longDistancePairSolver!.getOutput().allTracesMerged)
+
+    return Object.fromEntries(traces.map((trace) => [trace.mspPairId, trace]))
   }
 
   override _step() {

--- a/site/SameNetTraceMergingSolver/SameNetTraceMergingSolver.page.tsx
+++ b/site/SameNetTraceMergingSolver/SameNetTraceMergingSolver.page.tsx
@@ -1,0 +1,81 @@
+import { SameNetTraceMergingSolver } from "lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import { InteractiveGraphics } from "graphics-debug/react"
+import { useMemo } from "react"
+
+const inputProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+  }) as any
+
+const inputTraces = [
+  makeTrace("a", "net0", [
+    { x: 0, y: 0 },
+    { x: 0, y: 1 },
+    { x: 3, y: 1 },
+    { x: 3, y: 0 },
+  ]),
+  makeTrace("b", "net0", [
+    { x: 0, y: 0 },
+    { x: 0, y: 1.12 },
+    { x: 3, y: 1.12 },
+    { x: 3, y: 0 },
+  ]),
+  makeTrace("other-net", "net1", [
+    { x: 0.5, y: 1.35 },
+    { x: 2.5, y: 1.35 },
+  ]),
+]
+
+export default () => {
+  const { beforeSolver, afterSolver } = useMemo(() => {
+    const beforeSolver = new SameNetTraceMergingSolver({
+      inputProblem,
+      inputTraces,
+    })
+    const afterSolver = new SameNetTraceMergingSolver({
+      inputProblem,
+      inputTraces,
+    })
+    afterSolver.solve()
+
+    return { beforeSolver, afterSolver }
+  }, [])
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+        gap: 16,
+      }}
+    >
+      <section>
+        <h2>Before</h2>
+        <InteractiveGraphics graphics={beforeSolver.visualize()} />
+      </section>
+      <section>
+        <h2>After</h2>
+        <InteractiveGraphics graphics={afterSolver.visualize()} />
+      </section>
+    </div>
+  )
+}

--- a/tests/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.test.ts
+++ b/tests/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceMergingSolver } from "lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const inputProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+  }) as any
+
+test("aligns nearby same-net internal horizontal segments", () => {
+  const solver = new SameNetTraceMergingSolver({
+    inputProblem,
+    inputTraces: [
+      makeTrace("a", "net0", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 3, y: 1 },
+        { x: 3, y: 0 },
+      ]),
+      makeTrace("b", "net0", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1.12 },
+        { x: 3, y: 1.12 },
+        { x: 3, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const [traceA, traceB] = solver.getOutput().traces
+  expect(traceA!.tracePath[1]!.y).toBeCloseTo(1.06)
+  expect(traceA!.tracePath[2]!.y).toBeCloseTo(1.06)
+  expect(traceB!.tracePath[1]!.y).toBeCloseTo(1.06)
+  expect(traceB!.tracePath[2]!.y).toBeCloseTo(1.06)
+})
+
+test("moves an internal same-net segment onto a fixed endpoint segment", () => {
+  const solver = new SameNetTraceMergingSolver({
+    inputProblem,
+    inputTraces: [
+      makeTrace("fixed", "net0", [
+        { x: 0, y: 1 },
+        { x: 3, y: 1 },
+      ]),
+      makeTrace("movable", "net0", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1.12 },
+        { x: 3, y: 1.12 },
+        { x: 3, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const movable = solver.getOutput().traces[1]!
+  expect(movable.tracePath[1]!.y).toBeCloseTo(1)
+  expect(movable.tracePath[2]!.y).toBeCloseTo(1)
+})
+
+test("does not create a colinear overlap with a different net", () => {
+  const solver = new SameNetTraceMergingSolver({
+    inputProblem,
+    inputTraces: [
+      makeTrace("a", "net0", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 3, y: 1 },
+        { x: 3, y: 0 },
+      ]),
+      makeTrace("b", "net0", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1.12 },
+        { x: 3, y: 1.12 },
+        { x: 3, y: 0 },
+      ]),
+      makeTrace("other-net", "net1", [
+        { x: 0, y: 1.06 },
+        { x: 3, y: 1.06 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const [traceA, traceB] = solver.getOutput().traces
+  expect(traceA!.tracePath[1]!.y).toBeCloseTo(1)
+  expect(traceB!.tracePath[1]!.y).toBeCloseTo(1.12)
+})


### PR DESCRIPTION
/claim #29

Closes #29

## Summary

- add a dedicated `SameNetTraceMergingSolver` pipeline phase after overlap shifting
- align nearby same-net horizontal/vertical internal trace segments onto a shared axis when their ranges overlap
- keep endpoint-only trace segments anchored and avoid creating colinear overlaps with different-net traces
- add focused unit coverage for same-net merging behavior and the different-net guard
- add a Cosmos visual fixture for before/after inspection of same-net trace merging

## Reproduction / Verification

The focused test reproduces the core failure mode from the bounty: two routed same-net traces have close, overlapping horizontal runs on separate axes. The new solver collapses those runs onto a shared axis while preserving anchored endpoint-only traces.

The test suite also covers the guard case where the tempting merge axis would create a colinear overlap with a different net, so the solver leaves both traces untouched.

The visual fixture at `site/SameNetTraceMergingSolver/SameNetTraceMergingSolver.page.tsx` shows the same scenario side-by-side: before merging and after the solver collapses the same-net runs.

## Test Plan

- `./node_modules/.bin/bun test tests/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.test.ts`
- `npm run format:check`
- `./node_modules/.bin/bun test`
- `npm run build`
