### PR TITLE
feat: add SameNetTraceMergingSolver to merge close same-net trace segments

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+export * from "./solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver"

--- a/lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.ts
+++ b/lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.ts
@@ -1,0 +1,187 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { GraphicsObject, Line } from "graphics-debug"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+
+/** Maximum distance between parallel same-net segments for them to be merged */
+const MERGE_THRESHOLD = 0.2
+
+/** Minimum overlap length required before merging two parallel segments */
+const MIN_OVERLAP = 0.05
+
+/**
+ * SameNetTraceMergingSolver finds pairs of traces that belong to the same
+ * electrical net and have parallel segments running close together, then
+ * snaps those segments onto a shared axis to eliminate the visual clutter
+ * of near-duplicate wires.
+ *
+ * Only interior segment endpoints are moved — the first and last points of
+ * each trace (which sit at pin locations) are never displaced.
+ *
+ * The solver runs iteratively: each _step() finds and applies one merge,
+ * then re-scans.  It terminates when no more candidate pairs exist.
+ */
+export class SameNetTraceMergingSolver extends BaseSolver {
+  inputProblem: InputProblem
+  outputTraces: SolvedTracePath[]
+
+  constructor(params: {
+    inputProblem: InputProblem
+    traces: SolvedTracePath[]
+  }) {
+    super()
+    this.inputProblem = params.inputProblem
+    // Deep-copy trace paths so we don't mutate upstream data
+    this.outputTraces = params.traces.map((t) => ({
+      ...t,
+      tracePath: t.tracePath.map((p) => ({ ...p })),
+    }))
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceMergingSolver
+  >[0] {
+    return { inputProblem: this.inputProblem, traces: this.outputTraces }
+  }
+
+  override _step() {
+    // Group traces by globalConnNetId
+    const groups = new Map<string, SolvedTracePath[]>()
+    for (const trace of this.outputTraces) {
+      const key = trace.globalConnNetId
+      if (!groups.has(key)) groups.set(key, [])
+      groups.get(key)!.push(trace)
+    }
+
+    for (const traces of groups.values()) {
+      if (traces.length < 2) continue
+      for (let i = 0; i < traces.length; i++) {
+        for (let j = i + 1; j < traces.length; j++) {
+          if (this._tryMerge(traces[i], traces[j])) return
+        }
+      }
+    }
+
+    // No merge was possible — we're done
+    this.solved = true
+  }
+
+  /**
+   * Attempt to find one pair of parallel same-net segments across t1 and t2
+   * that are close enough to snap together.  Returns true if a merge occurred.
+   */
+  private _tryMerge(t1: SolvedTracePath, t2: SolvedTracePath): boolean {
+    const p1 = t1.tracePath
+    const p2 = t2.tracePath
+
+    for (let i = 0; i < p1.length - 1; i++) {
+      for (let j = 0; j < p2.length - 1; j++) {
+        const a1 = p1[i]
+        const b1 = p1[i + 1]
+        const a2 = p2[j]
+        const b2 = p2[j + 1]
+
+        const seg1IsHoriz = Math.abs(a1.y - b1.y) < 1e-6
+        const seg2IsHoriz = Math.abs(a2.y - b2.y) < 1e-6
+
+        if (seg1IsHoriz !== seg2IsHoriz) continue
+
+        if (seg1IsHoriz) {
+          // Both horizontal — check vertical proximity & x overlap
+          const dy = Math.abs(a1.y - a2.y)
+          if (dy < 1e-6 || dy > MERGE_THRESHOLD) continue
+
+          const xMin1 = Math.min(a1.x, b1.x)
+          const xMax1 = Math.max(a1.x, b1.x)
+          const xMin2 = Math.min(a2.x, b2.x)
+          const xMax2 = Math.max(a2.x, b2.x)
+          const overlap = Math.min(xMax1, xMax2) - Math.max(xMin1, xMin2)
+          if (overlap < MIN_OVERLAP) continue
+
+          // Snap the movable segment to the fixed one's axis.
+          // Prefer moving t2 onto t1; never move a pin endpoint.
+          const t2CanMove = j > 0 && j + 1 < p2.length - 1
+          const t1CanMove = i > 0 && i + 1 < p1.length - 1
+
+          if (t2CanMove) {
+            p2[j] = { ...p2[j], y: a1.y }
+            p2[j + 1] = { ...p2[j + 1], y: a1.y }
+            this._removeDuplicatePoints(t2)
+            return true
+          }
+          if (t1CanMove) {
+            p1[i] = { ...p1[i], y: a2.y }
+            p1[i + 1] = { ...p1[i + 1], y: a2.y }
+            this._removeDuplicatePoints(t1)
+            return true
+          }
+        } else {
+          // Both vertical — check horizontal proximity & y overlap
+          const dx = Math.abs(a1.x - a2.x)
+          if (dx < 1e-6 || dx > MERGE_THRESHOLD) continue
+
+          const yMin1 = Math.min(a1.y, b1.y)
+          const yMax1 = Math.max(a1.y, b1.y)
+          const yMin2 = Math.min(a2.y, b2.y)
+          const yMax2 = Math.max(a2.y, b2.y)
+          const overlap = Math.min(yMax1, yMax2) - Math.max(yMin1, yMin2)
+          if (overlap < MIN_OVERLAP) continue
+
+          const t2CanMove = j > 0 && j + 1 < p2.length - 1
+          const t1CanMove = i > 0 && i + 1 < p1.length - 1
+
+          if (t2CanMove) {
+            p2[j] = { ...p2[j], x: a1.x }
+            p2[j + 1] = { ...p2[j + 1], x: a1.x }
+            this._removeDuplicatePoints(t2)
+            return true
+          }
+          if (t1CanMove) {
+            p1[i] = { ...p1[i], x: a2.x }
+            p1[i + 1] = { ...p1[i + 1], x: a2.x }
+            this._removeDuplicatePoints(t1)
+            return true
+          }
+        }
+      }
+    }
+
+    return false
+  }
+
+  /**
+   * Remove consecutive duplicate / zero-length points that may arise after
+   * snapping a segment to an adjacent axis.
+   */
+  private _removeDuplicatePoints(trace: SolvedTracePath) {
+    const path = trace.tracePath
+    const cleaned = [path[0]]
+    for (let k = 1; k < path.length; k++) {
+      const prev = cleaned[cleaned.length - 1]
+      if (
+        Math.abs(path[k].x - prev.x) > 1e-9 ||
+        Math.abs(path[k].y - prev.y) > 1e-9
+      ) {
+        cleaned.push(path[k])
+      }
+    }
+    trace.tracePath = cleaned
+  }
+
+  getOutput() {
+    return { traces: this.outputTraces }
+  }
+
+  override visualize(): GraphicsObject {
+    const base = visualizeInputProblem(this.inputProblem, {
+      chipAlpha: 0.1,
+      connectionAlpha: 0.1,
+    })
+    const lines: Line[] = this.outputTraces.map((t) => ({
+      points: t.tracePath.map((p) => ({ x: p.x, y: p.y })),
+      strokeColor: "blue",
+    }))
+    return { ...base, lines: [...(base.lines ?? []), ...lines] }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceMergingSolver } from "../SameNetTraceMergingSolver/SameNetTraceMergingSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -80,6 +81,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
   traceAnchoredNetLabelOverlapSolver?: TraceAnchoredNetLabelOverlapSolver
   netLabelTraceCollisionSolver?: NetLabelTraceCollisionSolver
+  sameNetTraceMergingSolver?: SameNetTraceMergingSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -218,10 +220,21 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceMergingSolver",
+      SameNetTraceMergingSolver,
+      (instance) => {
+        const traces =
+          instance.traceCleanupSolver?.getOutput().traces ??
+          instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
+        return [{ inputProblem: instance.inputProblem, traces }]
+      },
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceMergingSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +250,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceMergingSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/site/SameNetTraceMergingSolver/SameNetTraceMergingSolver.page.tsx
+++ b/site/SameNetTraceMergingSolver/SameNetTraceMergingSolver.page.tsx
@@ -1,0 +1,167 @@
+import { useMemo } from "react"
+import { InteractiveGraphics } from "graphics-debug/react"
+import { SameNetTraceMergingSolver } from "lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+/**
+ * Visual demo: issue #29 — two same-net GND traces routed close together.
+ *
+ * The MST router produced two nearly-parallel horizontal runs for the GND
+ * net (one at y = 0, one at y = 0.12).  SameNetTraceMergingSolver collapses
+ * the interior of the second run onto y = 0, eliminating the visual clutter.
+ */
+
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "JP6",
+      center: { x: -3, y: 0 },
+      width: 1,
+      height: 0.8,
+      pins: [
+        { pinId: "JP6.VOUT", x: -2.5, y: 0.2 },
+        { pinId: "JP6.GND", x: -2.5, y: -0.2 },
+      ],
+    },
+    {
+      chipId: "R1",
+      center: { x: 2, y: 0.06 },
+      width: 0.4,
+      height: 0.6,
+      pins: [
+        { pinId: "R1.A", x: 2, y: 0.36 },
+        { pinId: "R1.B", x: 2, y: -0.24 },
+      ],
+    },
+    {
+      chipId: "SJ2",
+      center: { x: 2, y: -0.8 },
+      width: 0.4,
+      height: 0.4,
+      pins: [
+        { pinId: "SJ2.A", x: 2, y: -0.6 },
+        { pinId: "SJ2.B", x: 2, y: -1.0 },
+      ],
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    { netId: "VOUT", pinIds: ["JP6.VOUT", "R1.A", "SJ2.A"] },
+    { netId: "GND", pinIds: ["JP6.GND", "R1.B", "SJ2.B"] },
+  ],
+  availableNetLabelOrientations: { VOUT: ["y+"], GND: ["y-"] },
+}
+
+function makeTrace(
+  id: string,
+  netId: string,
+  path: Array<{ x: number; y: number }>,
+): SolvedTracePath {
+  return {
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [
+      { pinId: `${id}-a`, x: path[0].x, y: path[0].y, chipId: "JP6" },
+      {
+        pinId: `${id}-b`,
+        x: path[path.length - 1].x,
+        y: path[path.length - 1].y,
+        chipId: "R1",
+      },
+    ],
+    tracePath: path,
+    mspConnectionPairIds: [id],
+    pinIds: [`${id}-a`, `${id}-b`],
+  }
+}
+
+/**
+ * Two GND traces that the MST router produced — nearly identical horizontal
+ * runs only 0.12 units apart.  Without the solver these appear as a pair of
+ * parallel wires.
+ */
+const tracesBeforeMerge: SolvedTracePath[] = [
+  // GND trace 1: JP6.GND → R1.B  (y = 0)
+  makeTrace("gnd-1", "GND", [
+    { x: -2.5, y: -0.2 }, // pin — JP6.GND
+    { x: -1.0, y: -0.2 }, // turn
+    { x: -1.0, y: 0.0 }, // interior
+    { x: 1.5, y: 0.0 }, // interior
+    { x: 1.5, y: -0.24 }, // turn
+    { x: 2.0, y: -0.24 }, // pin — R1.B
+  ]),
+  // GND trace 2: JP6.GND → SJ2.B  (y = 0.12, close to trace 1)
+  makeTrace("gnd-2", "GND", [
+    { x: -2.5, y: -0.2 }, // pin — JP6.GND
+    { x: -1.2, y: -0.2 }, // turn
+    { x: -1.2, y: 0.12 }, // interior — slightly above trace 1
+    { x: 1.5, y: 0.12 }, // interior
+    { x: 1.5, y: -1.0 }, // turn
+    { x: 2.0, y: -1.0 }, // pin — SJ2.B
+  ]),
+]
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 600,
+  marginBottom: 4,
+  color: "#333",
+}
+
+const PANEL_STYLE: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  flex: 1,
+  minWidth: 0,
+  border: "1px solid #ddd",
+  borderRadius: 6,
+  padding: 8,
+  background: "#fafafa",
+}
+
+export default () => {
+  const beforeSolver = useMemo(() => {
+    const s = new SameNetTraceMergingSolver({
+      inputProblem,
+      traces: tracesBeforeMerge,
+    })
+    // Don't solve — show the initial (broken) state
+    return s
+  }, [])
+
+  const afterSolver = useMemo(() => {
+    const s = new SameNetTraceMergingSolver({
+      inputProblem,
+      traces: tracesBeforeMerge,
+    })
+    s.solve()
+    return s
+  }, [])
+
+  return (
+    <div style={{ fontFamily: "sans-serif", padding: 16 }}>
+      <h2 style={{ marginBottom: 4 }}>SameNetTraceMergingSolver — issue #29</h2>
+      <p style={{ color: "#555", marginBottom: 16, fontSize: 13 }}>
+        Two GND traces routed by the MST at y = 0 and y = 0.12. The solver snaps
+        the interior of the second trace onto y = 0, eliminating the
+        parallel-wire clutter.
+      </p>
+      <div style={{ display: "flex", gap: 16 }}>
+        <div style={PANEL_STYLE}>
+          <div style={{ ...LABEL_STYLE, color: "#c0392b" }}>
+            ❌ Before — two parallel GND traces (y = 0 and y = 0.12)
+          </div>
+          <InteractiveGraphics graphics={beforeSolver.visualize()} />
+        </div>
+        <div style={PANEL_STYLE}>
+          <div style={{ ...LABEL_STYLE, color: "#27ae60" }}>
+            ✅ After — merged onto a single axis
+          </div>
+          <InteractiveGraphics graphics={afterSolver.visualize()} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tests/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.test.ts
+++ b/tests/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.test.ts
@@ -1,0 +1,166 @@
+import { test, expect } from "bun:test"
+import { SameNetTraceMergingSolver } from "lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+/**
+ * Helpers to build minimal traces for testing.
+ * Each trace connects two pins and carries a globalConnNetId.
+ */
+function makeTrace(
+  id: string,
+  netId: string,
+  path: Array<{ x: number; y: number }>,
+): SolvedTracePath {
+  return {
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [
+      { pinId: `${id}-a`, x: path[0].x, y: path[0].y, chipId: "U1" },
+      {
+        pinId: `${id}-b`,
+        x: path[path.length - 1].x,
+        y: path[path.length - 1].y,
+        chipId: "U2",
+      },
+    ],
+    tracePath: path,
+    mspConnectionPairIds: [id],
+    pinIds: [`${id}-a`, `${id}-b`],
+  }
+}
+
+const EMPTY_PROBLEM: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+// ─── repro: two same-net horizontal runs close in y ──────────────────────────
+
+test("merges two same-net horizontal segments that are close in y", () => {
+  /**
+   * Before:
+   *   trace1: (0,0) → (4,0)          y = 0.0
+   *   trace2: (0,0.12) → (4,0.12)    y = 0.12  (interior only — pins would be at edges)
+   *
+   * We give trace2 interior points so snapping is allowed:
+   *   trace2: (0,0.12) → (1,0.12) → (3,0.12) → (4,0.12)
+   *            pin        interior   interior     pin
+   *
+   * After merge, the two interior points of trace2 should move to y = 0.
+   */
+  const trace1 = makeTrace("t1", "GND", [
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+  ])
+  const trace2 = makeTrace("t2", "GND", [
+    { x: 0, y: 0.12 }, // pin — fixed
+    { x: 1, y: 0.12 }, // interior
+    { x: 3, y: 0.12 }, // interior
+    { x: 4, y: 0.12 }, // pin — fixed
+  ])
+
+  const solver = new SameNetTraceMergingSolver({
+    inputProblem: EMPTY_PROBLEM,
+    traces: [trace1, trace2],
+  })
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+
+  const out = solver.getOutput()
+  const t2 = out.traces.find((t) => t.mspPairId === "t2")!
+
+  // Interior points should now sit on y = 0 (snapped to trace1)
+  expect(t2.tracePath[1].y).toBeCloseTo(0, 5)
+  expect(t2.tracePath[2].y).toBeCloseTo(0, 5)
+
+  // Pin endpoints must not move
+  expect(t2.tracePath[0].y).toBeCloseTo(0.12, 5)
+  expect(t2.tracePath[t2.tracePath.length - 1].y).toBeCloseTo(0.12, 5)
+})
+
+// ─── merges vertical segments ─────────────────────────────────────────────────
+
+test("merges two same-net vertical segments that are close in x", () => {
+  const trace1 = makeTrace("t1", "VCC", [
+    { x: 0, y: 0 },
+    { x: 0, y: 4 },
+  ])
+  const trace2 = makeTrace("t2", "VCC", [
+    { x: 0.1, y: 0 }, // pin
+    { x: 0.1, y: 1 }, // interior
+    { x: 0.1, y: 3 }, // interior
+    { x: 0.1, y: 4 }, // pin
+  ])
+
+  const solver = new SameNetTraceMergingSolver({
+    inputProblem: EMPTY_PROBLEM,
+    traces: [trace1, trace2],
+  })
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+
+  const t2 = solver.getOutput().traces.find((t) => t.mspPairId === "t2")!
+  expect(t2.tracePath[1].x).toBeCloseTo(0, 5)
+  expect(t2.tracePath[2].x).toBeCloseTo(0, 5)
+})
+
+// ─── different nets must NOT be merged ────────────────────────────────────────
+
+test("does not merge segments from different nets", () => {
+  const trace1 = makeTrace("t1", "GND", [
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+  ])
+  const trace2 = makeTrace("t2", "VCC", [
+    { x: 0, y: 0.1 }, // pin
+    { x: 1, y: 0.1 }, // interior
+    { x: 3, y: 0.1 }, // interior
+    { x: 4, y: 0.1 }, // pin
+  ])
+
+  const solver = new SameNetTraceMergingSolver({
+    inputProblem: EMPTY_PROBLEM,
+    traces: [trace1, trace2],
+  })
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+
+  const t2 = solver.getOutput().traces.find((t) => t.mspPairId === "t2")!
+  // y must remain unchanged — different nets
+  for (const pt of t2.tracePath) {
+    expect(pt.y).toBeCloseTo(0.1, 5)
+  }
+})
+
+// ─── too far apart — no merge ─────────────────────────────────────────────────
+
+test("does not merge same-net segments that are too far apart", () => {
+  const trace1 = makeTrace("t1", "GND", [
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+  ])
+  const trace2 = makeTrace("t2", "GND", [
+    { x: 0, y: 1.0 }, // pin
+    { x: 1, y: 1.0 }, // interior
+    { x: 3, y: 1.0 }, // interior
+    { x: 4, y: 1.0 }, // pin
+  ])
+
+  const solver = new SameNetTraceMergingSolver({
+    inputProblem: EMPTY_PROBLEM,
+    traces: [trace1, trace2],
+  })
+  solver.solve()
+
+  const t2 = solver.getOutput().traces.find((t) => t.mspPairId === "t2")!
+  for (const pt of t2.tracePath) {
+    expect(pt.y).toBeCloseTo(1.0, 5)
+  }
+})


### PR DESCRIPTION
feat: add SameNetTraceMergingSolver to merge close same-net trace segments

/claim #29
/claim #34

Closes #29
Closes #34

## Problem

When 3+ pins share the same net, the MST router creates multiple trace pairs that often route as parallel lines very close together (< 0.2 units), creating visual clutter in schematics — exactly as shown in issue #29.

## Solution

A new `SameNetTraceMergingSolver` pipeline phase, inserted after `traceCleanupSolver`, that:

1. Groups traces by `globalConnNetId`
2. Finds pairs of parallel segments (horizontal or vertical) within 0.2 units that overlap by at least 0.05 units
3. Snaps interior points of one segment onto the other's axis — **pin endpoints are never moved**
4. Repeats until no more mergeable pairs remain

## Visual Demo

🔗 **Live before/after preview:** [https://schematic-trace-solver-git-fork-watcharapontho-d3da79-tscircuit.vercel.app/SameNetTraceMergingSolver](https://schematic-trace-solver-git-fork-watcharapontho-d3da79-tscircuit.vercel.app/SameNetTraceMergingSolver)

| Before | After |
|--------|-------|
| Two GND traces at y = 0 and y = 0.12 running in parallel | Interior snapped to y = 0, one clean wire |

## Tests

- 4 focused unit tests: merges horizontal, merges vertical, guards different nets, guards distant segments  
- All 61 existing tests continue to pass ✅
-  clean ✅
-  clean ✅
