### PR TITLE
Add same-net trace merge pipeline phase

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+export * from "./solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"

--- a/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
+++ b/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
@@ -1,0 +1,178 @@
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { MspConnectionPairId } from "../MspConnectionPairSolver/MspConnectionPairSolver"
+
+type SegmentRef = {
+  trace: SolvedTracePath
+  segmentIndex: number
+}
+
+const EPS = 2e-3
+
+const rangesOverlap = (
+  a1: number,
+  a2: number,
+  b1: number,
+  b2: number,
+): boolean => {
+  const minA = Math.min(a1, a2)
+  const maxA = Math.max(a1, a2)
+  const minB = Math.min(b1, b2)
+  const maxB = Math.max(b1, b2)
+  return Math.min(maxA, maxB) - Math.max(minA, minB) > EPS
+}
+
+/**
+ * Snaps close, overlapping same-net internal trace segments onto a shared
+ * coordinate so the renderer presents them as one combined net segment.
+ */
+export class SameNetTraceMergeSolver extends BaseSolver {
+  inputProblem: InputProblem
+  inputTraces: SolvedTracePath[]
+  mergeDistance: number
+
+  outputTraces: SolvedTracePath[]
+  outputTraceMap: Record<MspConnectionPairId, SolvedTracePath>
+  mergedSegments: Array<SegmentRef[]> = []
+
+  constructor(params: {
+    inputProblem: InputProblem
+    inputTraces: SolvedTracePath[]
+    mergeDistance?: number
+  }) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.inputTraces = params.inputTraces
+    this.mergeDistance = params.mergeDistance ?? 0.12
+    this.outputTraces = params.inputTraces.map((trace) => ({
+      ...trace,
+      tracePath: trace.tracePath.map((point) => ({ ...point })),
+    }))
+    this.outputTraceMap = Object.fromEntries(
+      this.outputTraces.map((trace) => [trace.mspPairId, trace]),
+    )
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceMergeSolver
+  >[0] {
+    return {
+      inputProblem: this.inputProblem,
+      inputTraces: this.inputTraces,
+      mergeDistance: this.mergeDistance,
+    }
+  }
+
+  override _step() {
+    const tracesByNet = new Map<string, SolvedTracePath[]>()
+    for (const trace of this.outputTraces) {
+      const traces = tracesByNet.get(trace.globalConnNetId) ?? []
+      traces.push(trace)
+      tracesByNet.set(trace.globalConnNetId, traces)
+    }
+
+    for (const traces of tracesByNet.values()) {
+      this.mergeSameNetTraceSegments(traces)
+    }
+
+    this.solved = true
+  }
+
+  private mergeSameNetTraceSegments(traces: SolvedTracePath[]) {
+    for (let traceAIndex = 0; traceAIndex < traces.length; traceAIndex++) {
+      const traceA = traces[traceAIndex]!
+      for (
+        let traceBIndex = traceAIndex + 1;
+        traceBIndex < traces.length;
+        traceBIndex++
+      ) {
+        const traceB = traces[traceBIndex]!
+        this.mergeTracePair(traceA, traceB)
+      }
+    }
+  }
+
+  private mergeTracePair(traceA: SolvedTracePath, traceB: SolvedTracePath) {
+    for (
+      let segmentAIndex = 1;
+      segmentAIndex < traceA.tracePath.length - 2;
+      segmentAIndex++
+    ) {
+      const a1 = traceA.tracePath[segmentAIndex]!
+      const a2 = traceA.tracePath[segmentAIndex + 1]!
+      const aHorizontal = Math.abs(a1.y - a2.y) < EPS
+      const aVertical = Math.abs(a1.x - a2.x) < EPS
+      if (!aHorizontal && !aVertical) continue
+
+      for (
+        let segmentBIndex = 1;
+        segmentBIndex < traceB.tracePath.length - 2;
+        segmentBIndex++
+      ) {
+        const b1 = traceB.tracePath[segmentBIndex]!
+        const b2 = traceB.tracePath[segmentBIndex + 1]!
+        const bHorizontal = Math.abs(b1.y - b2.y) < EPS
+        const bVertical = Math.abs(b1.x - b2.x) < EPS
+        if (!bHorizontal && !bVertical) continue
+
+        if (aHorizontal && bHorizontal) {
+          const distance = Math.abs(a1.y - b1.y)
+          if (
+            distance > EPS &&
+            distance <= this.mergeDistance &&
+            rangesOverlap(a1.x, a2.x, b1.x, b2.x)
+          ) {
+            const sharedY = (a1.y + b1.y) / 2
+            a1.y = sharedY
+            a2.y = sharedY
+            b1.y = sharedY
+            b2.y = sharedY
+            this.mergedSegments.push([
+              { trace: traceA, segmentIndex: segmentAIndex },
+              { trace: traceB, segmentIndex: segmentBIndex },
+            ])
+          }
+        }
+
+        if (aVertical && bVertical) {
+          const distance = Math.abs(a1.x - b1.x)
+          if (
+            distance > EPS &&
+            distance <= this.mergeDistance &&
+            rangesOverlap(a1.y, a2.y, b1.y, b2.y)
+          ) {
+            const sharedX = (a1.x + b1.x) / 2
+            a1.x = sharedX
+            a2.x = sharedX
+            b1.x = sharedX
+            b2.x = sharedX
+            this.mergedSegments.push([
+              { trace: traceA, segmentIndex: segmentAIndex },
+              { trace: traceB, segmentIndex: segmentBIndex },
+            ])
+          }
+        }
+      }
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    return {
+      lines: this.outputTraces.map((trace) => ({
+        points: trace.tracePath,
+        strokeColor: this.mergedSegments.some((segments) =>
+          segments.some(
+            (segment) => segment.trace.mspPairId === trace.mspPairId,
+          ),
+        )
+          ? "orange"
+          : "green",
+      })),
+      points: [],
+      rects: [],
+      circles: [],
+    }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceMergeSolver } from "../SameNetTraceMergeSolver/SameNetTraceMergeSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -80,6 +81,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
   traceAnchoredNetLabelOverlapSolver?: TraceAnchoredNetLabelOverlapSolver
   netLabelTraceCollisionSolver?: NetLabelTraceCollisionSolver
+  sameNetTraceMergeSolver?: SameNetTraceMergeSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -155,12 +157,30 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       },
     ),
     definePipelineStep(
+      "sameNetTraceMergeSolver",
+      SameNetTraceMergeSolver,
+      (instance) => [
+        {
+          inputProblem: instance.inputProblem,
+          inputTraces: Object.values(
+            instance.traceOverlapShiftSolver?.correctedTraceMap ??
+              Object.fromEntries(
+                instance
+                  .longDistancePairSolver!.getOutput()
+                  .allTracesMerged.map((p) => [p.mspPairId, p]),
+              ),
+          ),
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       () => [
         {
           inputProblem: this.inputProblem,
           inputTraceMap:
+            this.sameNetTraceMergeSolver?.outputTraceMap ??
             this.traceOverlapShiftSolver?.correctedTraceMap ??
             Object.fromEntries(
               this.longDistancePairSolver!.getOutput().allTracesMerged.map(
@@ -180,6 +200,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       TraceLabelOverlapAvoidanceSolver,
       (instance) => {
         const traceMap =
+          instance.sameNetTraceMergeSolver?.outputTraceMap ??
           instance.traceOverlapShiftSolver?.correctedTraceMap ??
           Object.fromEntries(
             instance

--- a/tests/solvers/SameNetTraceMergeSolver.test.ts
+++ b/tests/solvers/SameNetTraceMergeSolver.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceMergeSolver } from "lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const inputProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+function makeTrace(
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: SolvedTracePath["tracePath"],
+): SolvedTracePath {
+  return {
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [
+      { chipId: "U1", pinId: `${mspPairId}.1`, x: 0, y: 0 },
+      { chipId: "U1", pinId: `${mspPairId}.2`, x: 1, y: 1 },
+    ],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}.1`, `${mspPairId}.2`],
+  }
+}
+
+test("snaps close overlapping same-net horizontal internal segments", () => {
+  const solver = new SameNetTraceMergeSolver({
+    inputProblem,
+    inputTraces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 2, y: 1 },
+        { x: 2, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 0.5, y: 2 },
+        { x: 0.5, y: 1.08 },
+        { x: 2.5, y: 1.08 },
+        { x: 2.5, y: 2 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.outputTraceMap.a!.tracePath[1]!.y).toBeCloseTo(1.04)
+  expect(solver.outputTraceMap.a!.tracePath[2]!.y).toBeCloseTo(1.04)
+  expect(solver.outputTraceMap.b!.tracePath[1]!.y).toBeCloseTo(1.04)
+  expect(solver.outputTraceMap.b!.tracePath[2]!.y).toBeCloseTo(1.04)
+  expect(solver.mergedSegments).toHaveLength(1)
+})
+
+test("does not snap close segments from different nets", () => {
+  const solver = new SameNetTraceMergeSolver({
+    inputProblem,
+    inputTraces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 2, y: 1 },
+        { x: 2, y: 0 },
+      ]),
+      makeTrace("b", "net2", [
+        { x: 0.5, y: 2 },
+        { x: 0.5, y: 1.08 },
+        { x: 2.5, y: 1.08 },
+        { x: 2.5, y: 2 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.outputTraceMap.a!.tracePath[1]!.y).toBe(1)
+  expect(solver.outputTraceMap.b!.tracePath[1]!.y).toBe(1.08)
+  expect(solver.mergedSegments).toHaveLength(0)
+})


### PR DESCRIPTION
Adds a conservative pipeline phase for issue #29 that snaps close, overlapping same-net internal trace segments onto a shared coordinate before net-label placement.

The phase skips endpoint segments so pin endpoints are not moved, groups traces by `globalConnNetId`, and includes focused Bun tests for same-net and different-net behavior.

Testing:
- `bun test` (59 pass, 4 skipped)
- `bun run format:check`
- `bun node_modules/tsup/dist/cli-node.js lib/index.ts --format esm --dts`

Note: `bun run build` hits a local macOS sandbox native-addon signing restriction while loading Rollup; running tsup through Bun directly succeeds.

/claim #29
Closes #29