### PR TITLE
Align close same-net trace segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -6,6 +6,7 @@ import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { alignCloseSameNetTraceSegments } from "./alignCloseSameNetTraceSegments"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "aligning_close_same_net_segments"
   | "untangling_traces"
 
 /**
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "aligning_close_same_net_segments":
+        this._runAlignCloseSameNetSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +113,17 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "aligning_close_same_net_segments"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runAlignCloseSameNetSegmentsStep() {
+    this.outputTraces = alignCloseSameNetTraceSegments(this.outputTraces)
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/alignCloseSameNetTraceSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignCloseSameNetTraceSegments.ts
@@ -1,0 +1,150 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+type Axis = "x" | "y"
+
+interface SegmentRef {
+  traceIndex: number
+  startIndex: number
+  endIndex: number
+  axis: Axis
+  fixedCoord: number
+  min: number
+  max: number
+}
+
+const DEFAULT_MAX_AXIS_DISTANCE = 0.15
+const DEFAULT_MIN_OVERLAP = 0.05
+const EPSILON = 1e-6
+
+const clonePoint = (point: Point): Point => ({ x: point.x, y: point.y })
+
+const getSegmentRef = (
+  traceIndex: number,
+  startIndex: number,
+  start: Point,
+  end: Point,
+): SegmentRef | null => {
+  if (Math.abs(start.y - end.y) <= EPSILON) {
+    return {
+      traceIndex,
+      startIndex,
+      endIndex: startIndex + 1,
+      axis: "y",
+      fixedCoord: start.y,
+      min: Math.min(start.x, end.x),
+      max: Math.max(start.x, end.x),
+    }
+  }
+
+  if (Math.abs(start.x - end.x) <= EPSILON) {
+    return {
+      traceIndex,
+      startIndex,
+      endIndex: startIndex + 1,
+      axis: "x",
+      fixedCoord: start.x,
+      min: Math.min(start.y, end.y),
+      max: Math.max(start.y, end.y),
+    }
+  }
+
+  return null
+}
+
+const getMovableSegments = (traces: SolvedTracePath[]): SegmentRef[] => {
+  const segments: SegmentRef[] = []
+
+  for (let traceIndex = 0; traceIndex < traces.length; traceIndex++) {
+    const tracePath = traces[traceIndex]!.tracePath
+    for (let i = 0; i < tracePath.length - 1; i++) {
+      if (i === 0 || i + 1 === tracePath.length - 1) continue
+
+      const segment = getSegmentRef(
+        traceIndex,
+        i,
+        tracePath[i]!,
+        tracePath[i + 1]!,
+      )
+      if (segment) segments.push(segment)
+    }
+  }
+
+  return segments
+}
+
+const getOverlapLength = (a: SegmentRef, b: SegmentRef): number => {
+  return Math.min(a.max, b.max) - Math.max(a.min, b.min)
+}
+
+const getLength = (segment: SegmentRef): number => {
+  return segment.max - segment.min
+}
+
+const snapSegment = (
+  trace: SolvedTracePath,
+  segment: SegmentRef,
+  fixedCoord: number,
+) => {
+  const start = trace.tracePath[segment.startIndex]!
+  const end = trace.tracePath[segment.endIndex]!
+
+  if (segment.axis === "y") {
+    start.y = fixedCoord
+    end.y = fixedCoord
+  } else {
+    start.x = fixedCoord
+    end.x = fixedCoord
+  }
+}
+
+export function alignCloseSameNetTraceSegments(
+  traces: SolvedTracePath[],
+  {
+    maxAxisDistance = DEFAULT_MAX_AXIS_DISTANCE,
+    minOverlap = DEFAULT_MIN_OVERLAP,
+    maxPasses = 8,
+  }: {
+    maxAxisDistance?: number
+    minOverlap?: number
+    maxPasses?: number
+  } = {},
+): SolvedTracePath[] {
+  const output = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map(clonePoint),
+  }))
+
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let changed = false
+    const segments = getMovableSegments(output)
+
+    for (let i = 0; i < segments.length; i++) {
+      for (let j = i + 1; j < segments.length; j++) {
+        const a = segments[i]!
+        const b = segments[j]!
+        const aTrace = output[a.traceIndex]!
+        const bTrace = output[b.traceIndex]!
+
+        if (aTrace.globalConnNetId !== bTrace.globalConnNetId) continue
+        if (aTrace.mspPairId === bTrace.mspPairId) continue
+        if (a.axis !== b.axis) continue
+        if (Math.abs(a.fixedCoord - b.fixedCoord) > maxAxisDistance) continue
+        if (getOverlapLength(a, b) < minOverlap) continue
+
+        const target = getLength(a) >= getLength(b) ? a : b
+        const movable = target === a ? b : a
+        if (Math.abs(movable.fixedCoord - target.fixedCoord) <= EPSILON) {
+          continue
+        }
+
+        snapSegment(output[movable.traceIndex]!, movable, target.fixedCoord)
+        changed = true
+      }
+    }
+
+    if (!changed) break
+  }
+
+  return output
+}

--- a/tests/solvers/TraceCleanupSolver/alignCloseSameNetTraceSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignCloseSameNetTraceSegments.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { alignCloseSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/alignCloseSameNetTraceSegments"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const trace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    globalConnNetId,
+    dcConnNetId: globalConnNetId,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+    pins: [] as any,
+    tracePath,
+  }) as SolvedTracePath
+
+test("aligns close overlapping internal same-net horizontal segments", () => {
+  const output = alignCloseSameNetTraceSegments([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0.2, y: 0.2 },
+      { x: 1.8, y: 0.2 },
+      { x: 2, y: 0 },
+    ]),
+    trace("b", "net1", [
+      { x: 0, y: 1 },
+      { x: 0.4, y: 0.28 },
+      { x: 1.4, y: 0.28 },
+      { x: 2, y: 1 },
+    ]),
+  ])
+
+  expect(output[1]!.tracePath[1]!.y).toBe(0.2)
+  expect(output[1]!.tracePath[2]!.y).toBe(0.2)
+  expect(output[1]!.tracePath[0]!.y).toBe(1)
+  expect(output[1]!.tracePath[3]!.y).toBe(1)
+})
+
+test("leaves close different-net segments alone", () => {
+  const output = alignCloseSameNetTraceSegments([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0.2, y: 0.2 },
+      { x: 1.8, y: 0.2 },
+      { x: 2, y: 0 },
+    ]),
+    trace("b", "net2", [
+      { x: 0, y: 1 },
+      { x: 0.4, y: 0.28 },
+      { x: 1.4, y: 0.28 },
+      { x: 2, y: 1 },
+    ]),
+  ])
+
+  expect(output[1]!.tracePath[1]!.y).toBe(0.28)
+  expect(output[1]!.tracePath[2]!.y).toBe(0.28)
+})


### PR DESCRIPTION
## Summary
- add a final TraceCleanupSolver step that aligns close overlapping same-net horizontal/vertical internal segments onto a shared axis
- preserve trace endpoint segments so pin coordinates are not moved by the cleanup pass
- add focused coverage for same-net alignment and the different-net guard

## Testing
- npx bun test tests\solvers\TraceCleanupSolver\alignCloseSameNetTraceSegments.test.ts
- npx bun test
- npx tsc --noEmit
- npm run build
- git diff --check

/claim #34