### PR TITLE
Add same-net trace combining phase

### DIFF
--- a/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
+++ b/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
@@ -1,0 +1,284 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { GraphicsObject, Line } from "graphics-debug"
+import type { Point } from "@tscircuit/math-utils"
+
+type Orientation = "horizontal" | "vertical"
+
+interface SegmentRef {
+  traceIndex: number
+  segmentIndex: number
+  trace: SolvedTracePath
+  orientation: Orientation
+  p0: Point
+  p1: Point
+  constCoord: number
+  min: number
+  max: number
+}
+
+interface SameNetTraceCombiningSolverInput {
+  traces: SolvedTracePath[]
+  mergeDistance?: number
+  minOverlap?: number
+}
+
+const EPSILON = 1e-9
+
+export class SameNetTraceCombiningSolver extends BaseSolver {
+  private input: Required<SameNetTraceCombiningSolverInput>
+  outputTraces: SolvedTracePath[]
+  movedSegments: Array<{
+    mspPairId: string
+    segmentIndex: number
+    from: number
+    to: number
+    orientation: Orientation
+  }> = []
+
+  constructor(input: SameNetTraceCombiningSolverInput) {
+    super()
+    this.input = {
+      traces: input.traces,
+      mergeDistance: input.mergeDistance ?? 0.15,
+      minOverlap: input.minOverlap ?? 0.05,
+    }
+    this.outputTraces = input.traces.map((trace) => ({
+      ...trace,
+      tracePath: trace.tracePath.map((p) => ({ ...p })),
+    }))
+  }
+
+  override _step() {
+    this.combineCloseSameNetSegments()
+    this.solved = true
+  }
+
+  private combineCloseSameNetSegments() {
+    let changed = true
+    let passCount = 0
+
+    while (changed && passCount < 10) {
+      changed = false
+      passCount++
+
+      const segments = this.getSegments()
+
+      for (let i = 0; i < segments.length; i++) {
+        const a = segments[i]!
+        for (let j = i + 1; j < segments.length; j++) {
+          const b = segments[j]!
+          if (!this.canCombine(a, b)) continue
+
+          const firstChoice =
+            this.segmentLength(a) <= this.segmentLength(b)
+              ? { moving: a, target: b }
+              : { moving: b, target: a }
+          const secondChoice =
+            firstChoice.moving === a
+              ? { moving: b, target: a }
+              : { moving: a, target: b }
+
+          if (this.trySnapSegment(firstChoice.moving, firstChoice.target)) {
+            changed = true
+            break
+          }
+
+          if (this.trySnapSegment(secondChoice.moving, secondChoice.target)) {
+            changed = true
+            break
+          }
+        }
+        if (changed) break
+      }
+    }
+  }
+
+  private getSegments(): SegmentRef[] {
+    const segments: SegmentRef[] = []
+    for (let traceIndex = 0; traceIndex < this.outputTraces.length; traceIndex++) {
+      const trace = this.outputTraces[traceIndex]!
+      for (let segmentIndex = 0; segmentIndex < trace.tracePath.length - 1; segmentIndex++) {
+        const p0 = trace.tracePath[segmentIndex]!
+        const p1 = trace.tracePath[segmentIndex + 1]!
+        if (Math.abs(p0.y - p1.y) < EPSILON) {
+          segments.push({
+            traceIndex,
+            segmentIndex,
+            trace,
+            orientation: "horizontal",
+            p0,
+            p1,
+            constCoord: p0.y,
+            min: Math.min(p0.x, p1.x),
+            max: Math.max(p0.x, p1.x),
+          })
+        } else if (Math.abs(p0.x - p1.x) < EPSILON) {
+          segments.push({
+            traceIndex,
+            segmentIndex,
+            trace,
+            orientation: "vertical",
+            p0,
+            p1,
+            constCoord: p0.x,
+            min: Math.min(p0.y, p1.y),
+            max: Math.max(p0.y, p1.y),
+          })
+        }
+      }
+    }
+    return segments
+  }
+
+  private canCombine(a: SegmentRef, b: SegmentRef): boolean {
+    if (a.trace.mspPairId === b.trace.mspPairId) return false
+    if (a.trace.globalConnNetId !== b.trace.globalConnNetId) return false
+    if (a.orientation !== b.orientation) return false
+    if (Math.abs(a.constCoord - b.constCoord) > this.input.mergeDistance) {
+      return false
+    }
+    return this.overlapLength(a, b) >= this.input.minOverlap
+  }
+
+  private trySnapSegment(moving: SegmentRef, target: SegmentRef): boolean {
+    if (!this.isInternalSegment(moving)) return false
+    if (Math.abs(moving.constCoord - target.constCoord) < EPSILON) return false
+
+    const candidate = this.outputTraces.map((trace) => ({
+      ...trace,
+      tracePath: trace.tracePath.map((p) => ({ ...p })),
+    }))
+
+    const candidateTrace = candidate[moving.traceIndex]!
+    const p0 = candidateTrace.tracePath[moving.segmentIndex]!
+    const p1 = candidateTrace.tracePath[moving.segmentIndex + 1]!
+
+    if (moving.orientation === "horizontal") {
+      p0.y = target.constCoord
+      p1.y = target.constCoord
+    } else {
+      p0.x = target.constCoord
+      p1.x = target.constCoord
+    }
+
+    if (this.hasDifferentNetIntersection(candidate, moving.traceIndex)) {
+      return false
+    }
+
+    this.outputTraces = candidate
+    this.movedSegments.push({
+      mspPairId: moving.trace.mspPairId,
+      segmentIndex: moving.segmentIndex,
+      from: moving.constCoord,
+      to: target.constCoord,
+      orientation: moving.orientation,
+    })
+    return true
+  }
+
+  private isInternalSegment(segment: SegmentRef): boolean {
+    return (
+      segment.segmentIndex > 0 &&
+      segment.segmentIndex < segment.trace.tracePath.length - 2
+    )
+  }
+
+  private hasDifferentNetIntersection(
+    candidate: SolvedTracePath[],
+    movedTraceIndex: number,
+  ): boolean {
+    const movedTrace = candidate[movedTraceIndex]!
+    const movedSegments = this.traceSegments(movedTrace)
+
+    for (let traceIndex = 0; traceIndex < candidate.length; traceIndex++) {
+      if (traceIndex === movedTraceIndex) continue
+      const otherTrace = candidate[traceIndex]!
+      if (otherTrace.globalConnNetId === movedTrace.globalConnNetId) continue
+
+      for (const moved of movedSegments) {
+        for (const other of this.traceSegments(otherTrace)) {
+          if (segmentsIntersect(moved[0], moved[1], other[0], other[1])) {
+            return true
+          }
+        }
+      }
+    }
+
+    return false
+  }
+
+  private traceSegments(trace: SolvedTracePath): Array<[Point, Point]> {
+    const segments: Array<[Point, Point]> = []
+    for (let i = 0; i < trace.tracePath.length - 1; i++) {
+      segments.push([trace.tracePath[i]!, trace.tracePath[i + 1]!])
+    }
+    return segments
+  }
+
+  private overlapLength(a: SegmentRef, b: SegmentRef): number {
+    return Math.max(0, Math.min(a.max, b.max) - Math.max(a.min, b.min))
+  }
+
+  private segmentLength(segment: SegmentRef): number {
+    return segment.max - segment.min
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+      movedSegments: this.movedSegments,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    const lines: Line[] = this.outputTraces.map((trace) => ({
+      points: trace.tracePath.map((p) => ({ x: p.x, y: p.y })),
+      strokeColor: "blue",
+    }))
+
+    return {
+      lines,
+      points: [],
+      rects: [],
+      circles: [],
+    }
+  }
+}
+
+function segmentsIntersect(a0: Point, a1: Point, b0: Point, b1: Point) {
+  const aHorizontal = Math.abs(a0.y - a1.y) < EPSILON
+  const aVertical = Math.abs(a0.x - a1.x) < EPSILON
+  const bHorizontal = Math.abs(b0.y - b1.y) < EPSILON
+  const bVertical = Math.abs(b0.x - b1.x) < EPSILON
+
+  if (aHorizontal && bHorizontal) {
+    if (Math.abs(a0.y - b0.y) >= EPSILON) return false
+    return rangesOverlap(a0.x, a1.x, b0.x, b1.x)
+  }
+
+  if (aVertical && bVertical) {
+    if (Math.abs(a0.x - b0.x) >= EPSILON) return false
+    return rangesOverlap(a0.y, a1.y, b0.y, b1.y)
+  }
+
+  const horizontal = aHorizontal ? [a0, a1] : [b0, b1]
+  const vertical = aVertical ? [a0, a1] : [b0, b1]
+  const hx0 = Math.min(horizontal[0]!.x, horizontal[1]!.x)
+  const hx1 = Math.max(horizontal[0]!.x, horizontal[1]!.x)
+  const hy = horizontal[0]!.y
+  const vx = vertical[0]!.x
+  const vy0 = Math.min(vertical[0]!.y, vertical[1]!.y)
+  const vy1 = Math.max(vertical[0]!.y, vertical[1]!.y)
+
+  return vx >= hx0 - EPSILON && vx <= hx1 + EPSILON && hy >= vy0 - EPSILON && hy <= vy1 + EPSILON
+}
+
+function rangesOverlap(a0: number, a1: number, b0: number, b1: number) {
+  const minA = Math.min(a0, a1)
+  const maxA = Math.max(a0, a1)
+  const minB = Math.min(b0, b1)
+  const maxB = Math.max(b0, b1)
+
+  return Math.min(maxA, maxB) - Math.max(minA, minB) >= EPSILON
+}

--- a/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
+++ b/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
@@ -96,9 +96,17 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
 
   private getSegments(): SegmentRef[] {
     const segments: SegmentRef[] = []
-    for (let traceIndex = 0; traceIndex < this.outputTraces.length; traceIndex++) {
+    for (
+      let traceIndex = 0;
+      traceIndex < this.outputTraces.length;
+      traceIndex++
+    ) {
       const trace = this.outputTraces[traceIndex]!
-      for (let segmentIndex = 0; segmentIndex < trace.tracePath.length - 1; segmentIndex++) {
+      for (
+        let segmentIndex = 0;
+        segmentIndex < trace.tracePath.length - 1;
+        segmentIndex++
+      ) {
         const p0 = trace.tracePath[segmentIndex]!
         const p1 = trace.tracePath[segmentIndex + 1]!
         if (Math.abs(p0.y - p1.y) < EPSILON) {
@@ -271,7 +279,12 @@ function segmentsIntersect(a0: Point, a1: Point, b0: Point, b1: Point) {
   const vy0 = Math.min(vertical[0]!.y, vertical[1]!.y)
   const vy1 = Math.max(vertical[0]!.y, vertical[1]!.y)
 
-  return vx >= hx0 - EPSILON && vx <= hx1 + EPSILON && hy >= vy0 - EPSILON && hy <= vy1 + EPSILON
+  return (
+    vx >= hx0 - EPSILON &&
+    vx <= hx1 + EPSILON &&
+    hy >= vy0 - EPSILON &&
+    hy <= vy1 + EPSILON
+  )
 }
 
 function rangesOverlap(a0: number, a1: number, b0: number, b1: number) {

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceCombiningSolver } from "../SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -75,6 +76,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetTraceCombiningSolver?: SameNetTraceCombiningSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -218,10 +220,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceCombiningSolver",
+      SameNetTraceCombiningSolver,
+      (instance) => [
+        {
+          traces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceCombiningSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +249,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceCombiningSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
+++ b/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceCombiningSolver } from "lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [
+      { pinId: `${mspPairId}-a`, chipId: "chip-a", x: 0, y: 0 },
+      { pinId: `${mspPairId}-b`, chipId: "chip-b", x: 0, y: 0 },
+    ],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}-a`, `${mspPairId}-b`],
+  }) as SolvedTracePath
+
+test("snaps close overlapping internal same-net segments onto a shared run", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    mergeDistance: 0.15,
+    traces: [
+      makeTrace("a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 2 },
+      ]),
+      makeTrace("b", "net-1", [
+        { x: 1, y: 3 },
+        { x: 1, y: 1.1 },
+        { x: 3, y: 1.1 },
+        { x: 3, y: 4 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toHaveLength(1)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: 3 },
+    { x: 1, y: 1 },
+    { x: 3, y: 1 },
+    { x: 3, y: 4 },
+  ])
+})
+
+test("does not move pin endpoint segments", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    mergeDistance: 0.15,
+    traces: [
+      makeTrace("a", "net-1", [
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+      ]),
+      makeTrace("b", "net-1", [
+        { x: 1, y: 1.1 },
+        { x: 3, y: 1.1 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toHaveLength(0)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: 1.1 },
+    { x: 3, y: 1.1 },
+  ])
+})
+
+test("rejects snaps that would cross a different net", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    mergeDistance: 0.15,
+    traces: [
+      makeTrace("a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 2 },
+      ]),
+      makeTrace("b", "net-1", [
+        { x: 1, y: 3 },
+        { x: 1, y: 1.1 },
+        { x: 3, y: 1.1 },
+        { x: 3, y: 4 },
+      ]),
+      makeTrace("c", "net-2", [
+        { x: 2, y: 0.5 },
+        { x: 2, y: 1.5 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toHaveLength(0)
+  expect(solver.getOutput().traces[1]!.tracePath[1]!.y).toBe(1.1)
+})

--- a/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
+++ b/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
@@ -50,6 +50,36 @@ test("snaps close overlapping internal same-net segments onto a shared run", () 
   ])
 })
 
+test("snaps close overlapping vertical same-net segments onto a shared run", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    mergeDistance: 0.15,
+    traces: [
+      makeTrace("a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 4 },
+        { x: 2, y: 4 },
+      ]),
+      makeTrace("b", "net-1", [
+        { x: 3, y: 1 },
+        { x: 1.1, y: 1 },
+        { x: 1.1, y: 3 },
+        { x: 4, y: 3 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toHaveLength(1)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 3, y: 1 },
+    { x: 1, y: 1 },
+    { x: 1, y: 3 },
+    { x: 4, y: 3 },
+  ])
+})
+
 test("does not move pin endpoint segments", () => {
   const solver = new SameNetTraceCombiningSolver({
     mergeDistance: 0.15,
@@ -72,6 +102,39 @@ test("does not move pin endpoint segments", () => {
     { x: 1, y: 1.1 },
     { x: 3, y: 1.1 },
   ])
+})
+
+test("leaves same-net segments alone when distance or overlap thresholds fail", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    mergeDistance: 0.15,
+    minOverlap: 0.5,
+    traces: [
+      makeTrace("a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 2 },
+      ]),
+      makeTrace("b", "net-1", [
+        { x: 4.9, y: 3 },
+        { x: 4.9, y: 1.1 },
+        { x: 5.2, y: 1.1 },
+        { x: 5.2, y: 4 },
+      ]),
+      makeTrace("c", "net-1", [
+        { x: 1, y: 3 },
+        { x: 1, y: 1.25 },
+        { x: 3, y: 1.25 },
+        { x: 3, y: 4 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toHaveLength(0)
+  expect(solver.getOutput().traces[1]!.tracePath[1]!.y).toBe(1.1)
+  expect(solver.getOutput().traces[2]!.tracePath[1]!.y).toBe(1.25)
 })
 
 test("rejects snaps that would cross a different net", () => {


### PR DESCRIPTION
/claim #34
/claim #29

## Summary
- add a post-cleanup SameNetTraceCombiningSolver phase to the schematic trace pipeline
- snap only close overlapping internal same-net horizontal/vertical segments onto a shared run
- preserve pin endpoint segments and reject snaps that would intersect different-net traces
- also covers the same-X/same-Y close same-net merge case from #34; `example34` passes with this pipeline phase

## Verification
- `npx --yes bun test tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts`
- `npx --yes bun test tests/examples/example29.test.ts`
- `npx --yes bun test tests/examples/example30.test.ts`
- `npx --yes bun test tests/examples/example34.test.ts`
- `npx --yes bun run build`
- `npx --yes biome format lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts`
- `git diff --check`

Note: `bun run format:check` currently reports repo-wide CRLF formatting drift in many pre-existing files, so I verified formatting on the changed files directly.