### PR TITLE
[codex] Add same-net trace consolidation phase

### DIFF
--- a/lib/solvers/SameNetTraceConsolidationSolver/SameNetTraceConsolidationSolver.ts
+++ b/lib/solvers/SameNetTraceConsolidationSolver/SameNetTraceConsolidationSolver.ts
@@ -1,0 +1,317 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject, Line } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+type SegmentOrientation = "horizontal" | "vertical"
+
+type SegmentCandidate = {
+  traceIndex: number
+  segmentIndex: number
+  trace: SolvedTracePath
+  orientation: SegmentOrientation
+  fixedAxisValue: number
+  rangeStart: number
+  rangeEnd: number
+}
+
+export type SameNetTraceConsolidationSolverInput = {
+  traces: SolvedTracePath[]
+  mergeDistance?: number
+  minimumOverlap?: number
+}
+
+const EPS = 1e-9
+
+export class SameNetTraceConsolidationSolver extends BaseSolver {
+  outputTraces: SolvedTracePath[]
+  movedSegments: Array<{
+    mspPairId: string
+    segmentIndex: number
+    orientation: SegmentOrientation
+    from: number
+    to: number
+  }> = []
+
+  private mergeDistance: number
+  private minimumOverlap: number
+
+  constructor(input: SameNetTraceConsolidationSolverInput) {
+    super()
+    this.outputTraces = input.traces.map(cloneTrace)
+    this.mergeDistance = input.mergeDistance ?? 0.15
+    this.minimumOverlap = input.minimumOverlap ?? 0.05
+  }
+
+  override _step() {
+    this.consolidateSameNetRuns()
+    this.solved = true
+  }
+
+  private consolidateSameNetRuns() {
+    for (let pass = 0; pass < 10; pass++) {
+      const mergeCandidates = this.findMergeCandidates()
+      const appliedMerge = mergeCandidates.some((merge) =>
+        this.tryApplyMerge(merge.moving, merge.target),
+      )
+      if (!appliedMerge) return
+    }
+  }
+
+  private findMergeCandidates(): Array<{
+    moving: SegmentCandidate
+    target: SegmentCandidate
+    distance: number
+    overlap: number
+  }> {
+    const segments = this.collectSegments()
+    const mergeCandidates: Array<{
+      moving: SegmentCandidate
+      target: SegmentCandidate
+      distance: number
+      overlap: number
+    }> = []
+
+    for (let i = 0; i < segments.length; i++) {
+      for (let j = i + 1; j < segments.length; j++) {
+        const first = segments[i]!
+        const second = segments[j]!
+        if (!this.areMergeCandidates(first, second)) continue
+
+        const firstInternal = this.isInternalSegment(first)
+        const secondInternal = this.isInternalSegment(second)
+        if (!firstInternal && !secondInternal) continue
+
+        const distance = Math.abs(first.fixedAxisValue - second.fixedAxisValue)
+        const overlap = getOverlapLength(first, second)
+        let moving: SegmentCandidate
+        let target: SegmentCandidate
+
+        if (firstInternal && !secondInternal) {
+          moving = first
+          target = second
+        } else if (secondInternal && !firstInternal) {
+          moving = second
+          target = first
+        } else if (this.lengthOf(first) <= this.lengthOf(second)) {
+          moving = first
+          target = second
+        } else {
+          moving = second
+          target = first
+        }
+
+        mergeCandidates.push({ moving, target, distance, overlap })
+      }
+    }
+
+    return mergeCandidates.sort(
+      (a, b) => a.distance - b.distance || b.overlap - a.overlap,
+    )
+  }
+
+  private collectSegments(): SegmentCandidate[] {
+    const segments: SegmentCandidate[] = []
+
+    for (
+      let traceIndex = 0;
+      traceIndex < this.outputTraces.length;
+      traceIndex++
+    ) {
+      const trace = this.outputTraces[traceIndex]!
+      for (
+        let segmentIndex = 0;
+        segmentIndex < trace.tracePath.length - 1;
+        segmentIndex++
+      ) {
+        const start = trace.tracePath[segmentIndex]!
+        const end = trace.tracePath[segmentIndex + 1]!
+
+        if (Math.abs(start.y - end.y) < EPS) {
+          segments.push({
+            traceIndex,
+            segmentIndex,
+            trace,
+            orientation: "horizontal",
+            fixedAxisValue: start.y,
+            rangeStart: Math.min(start.x, end.x),
+            rangeEnd: Math.max(start.x, end.x),
+          })
+        } else if (Math.abs(start.x - end.x) < EPS) {
+          segments.push({
+            traceIndex,
+            segmentIndex,
+            trace,
+            orientation: "vertical",
+            fixedAxisValue: start.x,
+            rangeStart: Math.min(start.y, end.y),
+            rangeEnd: Math.max(start.y, end.y),
+          })
+        }
+      }
+    }
+
+    return segments
+  }
+
+  private areMergeCandidates(a: SegmentCandidate, b: SegmentCandidate) {
+    if (a.trace.mspPairId === b.trace.mspPairId) return false
+    if (a.trace.globalConnNetId !== b.trace.globalConnNetId) return false
+    if (a.orientation !== b.orientation) return false
+    if (Math.abs(a.fixedAxisValue - b.fixedAxisValue) > this.mergeDistance) {
+      return false
+    }
+
+    return getOverlapLength(a, b) >= this.minimumOverlap
+  }
+
+  private tryApplyMerge(
+    moving: SegmentCandidate,
+    target: SegmentCandidate,
+  ): boolean {
+    if (Math.abs(moving.fixedAxisValue - target.fixedAxisValue) < EPS) {
+      return false
+    }
+
+    const nextTraces = this.outputTraces.map(cloneTrace)
+    const movingTrace = nextTraces[moving.traceIndex]!
+    const p0 = movingTrace.tracePath[moving.segmentIndex]!
+    const p1 = movingTrace.tracePath[moving.segmentIndex + 1]!
+
+    if (moving.orientation === "horizontal") {
+      p0.y = target.fixedAxisValue
+      p1.y = target.fixedAxisValue
+    } else {
+      p0.x = target.fixedAxisValue
+      p1.x = target.fixedAxisValue
+    }
+
+    if (this.hasDifferentNetIntersection(nextTraces, moving.traceIndex)) {
+      return false
+    }
+
+    this.outputTraces = nextTraces
+    this.movedSegments.push({
+      mspPairId: moving.trace.mspPairId,
+      segmentIndex: moving.segmentIndex,
+      orientation: moving.orientation,
+      from: moving.fixedAxisValue,
+      to: target.fixedAxisValue,
+    })
+    return true
+  }
+
+  private hasDifferentNetIntersection(
+    traces: SolvedTracePath[],
+    changedTraceIndex: number,
+  ) {
+    const changedTrace = traces[changedTraceIndex]!
+    const changedSegments = getTraceSegments(changedTrace)
+
+    for (let traceIndex = 0; traceIndex < traces.length; traceIndex++) {
+      if (traceIndex === changedTraceIndex) continue
+      const otherTrace = traces[traceIndex]!
+      if (otherTrace.globalConnNetId === changedTrace.globalConnNetId) {
+        continue
+      }
+
+      for (const changed of changedSegments) {
+        for (const other of getTraceSegments(otherTrace)) {
+          if (segmentsIntersect(changed[0], changed[1], other[0], other[1])) {
+            return true
+          }
+        }
+      }
+    }
+
+    return false
+  }
+
+  private isInternalSegment(segment: SegmentCandidate) {
+    return (
+      segment.segmentIndex > 0 &&
+      segment.segmentIndex < segment.trace.tracePath.length - 2
+    )
+  }
+
+  private lengthOf(segment: SegmentCandidate) {
+    return segment.rangeEnd - segment.rangeStart
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+      movedSegments: this.movedSegments,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    const lines: Line[] = this.outputTraces.map((trace) => ({
+      points: trace.tracePath.map((point) => ({ x: point.x, y: point.y })),
+      strokeColor: "blue",
+    }))
+
+    return { lines, points: [], rects: [], circles: [] }
+  }
+}
+
+function cloneTrace(trace: SolvedTracePath): SolvedTracePath {
+  return {
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }
+}
+
+function getTraceSegments(trace: SolvedTracePath): Array<[Point, Point]> {
+  const segments: Array<[Point, Point]> = []
+  for (let i = 0; i < trace.tracePath.length - 1; i++) {
+    segments.push([trace.tracePath[i]!, trace.tracePath[i + 1]!])
+  }
+  return segments
+}
+
+function getOverlapLength(a: SegmentCandidate, b: SegmentCandidate) {
+  return Math.max(
+    0,
+    Math.min(a.rangeEnd, b.rangeEnd) - Math.max(a.rangeStart, b.rangeStart),
+  )
+}
+
+function segmentsIntersect(a0: Point, a1: Point, b0: Point, b1: Point) {
+  const aHorizontal = Math.abs(a0.y - a1.y) < EPS
+  const aVertical = Math.abs(a0.x - a1.x) < EPS
+  const bHorizontal = Math.abs(b0.y - b1.y) < EPS
+  const bVertical = Math.abs(b0.x - b1.x) < EPS
+
+  if (aHorizontal && bHorizontal) {
+    return Math.abs(a0.y - b0.y) < EPS && rangesOverlap(a0.x, a1.x, b0.x, b1.x)
+  }
+
+  if (aVertical && bVertical) {
+    return Math.abs(a0.x - b0.x) < EPS && rangesOverlap(a0.y, a1.y, b0.y, b1.y)
+  }
+
+  const horizontal = aHorizontal ? [a0, a1] : [b0, b1]
+  const vertical = aVertical ? [a0, a1] : [b0, b1]
+  const horizontalMinX = Math.min(horizontal[0]!.x, horizontal[1]!.x)
+  const horizontalMaxX = Math.max(horizontal[0]!.x, horizontal[1]!.x)
+  const horizontalY = horizontal[0]!.y
+  const verticalX = vertical[0]!.x
+  const verticalMinY = Math.min(vertical[0]!.y, vertical[1]!.y)
+  const verticalMaxY = Math.max(vertical[0]!.y, vertical[1]!.y)
+
+  return (
+    verticalX >= horizontalMinX - EPS &&
+    verticalX <= horizontalMaxX + EPS &&
+    horizontalY >= verticalMinY - EPS &&
+    horizontalY <= verticalMaxY + EPS
+  )
+}
+
+function rangesOverlap(a0: number, a1: number, b0: number, b1: number) {
+  return (
+    Math.min(Math.max(a0, a1), Math.max(b0, b1)) -
+      Math.max(Math.min(a0, a1), Math.min(b0, b1)) >=
+    EPS
+  )
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceConsolidationSolver } from "../SameNetTraceConsolidationSolver/SameNetTraceConsolidationSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -75,6 +76,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetTraceConsolidationSolver?: SameNetTraceConsolidationSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -218,10 +220,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceConsolidationSolver",
+      SameNetTraceConsolidationSolver,
+      (instance) => [
+        {
+          traces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceConsolidationSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +249,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceConsolidationSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/solvers/SameNetTraceConsolidationSolver/SameNetTraceConsolidationSolver.test.ts
+++ b/tests/solvers/SameNetTraceConsolidationSolver/SameNetTraceConsolidationSolver.test.ts
@@ -1,0 +1,184 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceConsolidationSolver } from "lib/solvers/SameNetTraceConsolidationSolver/SameNetTraceConsolidationSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [
+      { pinId: `${mspPairId}-a`, chipId: "U1", x: 0, y: 0 },
+      { pinId: `${mspPairId}-b`, chipId: "U2", x: 0, y: 0 },
+    ],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}-a`, `${mspPairId}-b`],
+  }) as SolvedTracePath
+
+test("consolidates close overlapping internal same-net horizontal runs", () => {
+  const solver = new SameNetTraceConsolidationSolver({
+    traces: [
+      makeTrace("trace-a", "net-a", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 2 },
+      ]),
+      makeTrace("trace-b", "net-a", [
+        { x: 1, y: 3 },
+        { x: 1, y: 1.1 },
+        { x: 3, y: 1.1 },
+        { x: 3, y: 4 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toEqual([
+    {
+      mspPairId: "trace-b",
+      segmentIndex: 1,
+      orientation: "horizontal",
+      from: 1.1,
+      to: 1,
+    },
+  ])
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 1, y: 3 },
+    { x: 1, y: 1 },
+    { x: 3, y: 1 },
+    { x: 3, y: 4 },
+  ])
+})
+
+test("consolidates close overlapping internal same-net vertical runs", () => {
+  const solver = new SameNetTraceConsolidationSolver({
+    traces: [
+      makeTrace("trace-a", "net-a", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 4 },
+        { x: 2, y: 4 },
+      ]),
+      makeTrace("trace-b", "net-a", [
+        { x: 3, y: 1 },
+        { x: 1.1, y: 1 },
+        { x: 1.1, y: 3 },
+        { x: 4, y: 3 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toHaveLength(1)
+  expect(solver.getOutput().traces[1]!.tracePath).toEqual([
+    { x: 3, y: 1 },
+    { x: 1, y: 1 },
+    { x: 1, y: 3 },
+    { x: 4, y: 3 },
+  ])
+})
+
+test("leaves endpoint-only traces unchanged", () => {
+  const solver = new SameNetTraceConsolidationSolver({
+    traces: [
+      makeTrace("trace-a", "net-a", [
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+      ]),
+      makeTrace("trace-b", "net-a", [
+        { x: 1, y: 1.1 },
+        { x: 3, y: 1.1 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toHaveLength(0)
+  expect(solver.getOutput().traces[1]!.tracePath[0]!.y).toBe(1.1)
+})
+
+test("rejects a same-net snap when it would cross a different net", () => {
+  const solver = new SameNetTraceConsolidationSolver({
+    traces: [
+      makeTrace("trace-a", "net-a", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 2 },
+      ]),
+      makeTrace("trace-b", "net-a", [
+        { x: 1, y: 3 },
+        { x: 1, y: 1.1 },
+        { x: 3, y: 1.1 },
+        { x: 3, y: 4 },
+      ]),
+      makeTrace("trace-c", "net-b", [
+        { x: 2, y: 0.5 },
+        { x: 2, y: 1.5 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toHaveLength(0)
+  expect(solver.getOutput().traces[1]!.tracePath[1]!.y).toBe(1.1)
+})
+
+test("continues after a blocked candidate and applies another valid snap", () => {
+  const solver = new SameNetTraceConsolidationSolver({
+    traces: [
+      makeTrace("blocked-a", "net-a", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 2 },
+      ]),
+      makeTrace("blocked-b", "net-a", [
+        { x: 1, y: 3 },
+        { x: 1, y: 1.05 },
+        { x: 3, y: 1.05 },
+        { x: 3, y: 4 },
+      ]),
+      makeTrace("blocker", "net-b", [
+        { x: 2, y: 0.8 },
+        { x: 2, y: 1.2 },
+      ]),
+      makeTrace("valid-a", "net-a", [
+        { x: 5, y: 0 },
+        { x: 5, y: 2 },
+        { x: 8, y: 2 },
+        { x: 8, y: 3 },
+      ]),
+      makeTrace("valid-b", "net-a", [
+        { x: 6, y: 4 },
+        { x: 6, y: 2.05 },
+        { x: 7, y: 2.05 },
+        { x: 7, y: 5 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().movedSegments).toEqual([
+    {
+      mspPairId: "valid-b",
+      segmentIndex: 1,
+      orientation: "horizontal",
+      from: 2.05,
+      to: 2,
+    },
+  ])
+  expect(solver.getOutput().traces[1]!.tracePath[1]!.y).toBe(1.05)
+  expect(solver.getOutput().traces[4]!.tracePath[1]!.y).toBe(2)
+})


### PR DESCRIPTION
## Summary
- add a SameNetTraceConsolidationSolver phase after trace cleanup
- snap close overlapping same-net horizontal/vertical trace segments together
- reject snaps that would create different-net intersections
- feed consolidated traces into the later label placement/example28 phases

/claim #29
/claim #34

## Validation
- npx --yes bun test tests/solvers/SameNetTraceConsolidationSolver/SameNetTraceConsolidationSolver.test.ts
- npx --yes bun test tests/examples/example29.test.ts
- npx --yes bun test tests/examples/example30.test.ts
- npx --yes bun test tests/examples/example34.test.ts tests/solvers/SameNetTraceConsolidationSolver/SameNetTraceConsolidationSolver.test.ts
- npx --yes bun run build
- npx --yes bun run format:check
- git diff --check
- npx --yes bun test