### PR TITLE
Add same-net trace alignment phase

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+export { SameNetTraceAlignmentSolver } from "./solvers/SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver"
+export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 export * from "./types/InputProblem"
-export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"

--- a/lib/solvers/SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver.ts
+++ b/lib/solvers/SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver.ts
@@ -1,0 +1,243 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+const EPS = 1e-6
+
+interface SegmentLocator {
+  traceIndex: number
+  segmentIndex: number
+  orientation: "horizontal" | "vertical"
+  fixedCoord: number
+  start: number
+  end: number
+  length: number
+}
+
+export class SameNetTraceAlignmentSolver extends BaseSolver {
+  private inputTraces: SolvedTracePath[]
+  outputTraces: SolvedTracePath[]
+  alignmentTolerance: number
+
+  constructor(params: {
+    traces: SolvedTracePath[]
+    alignmentTolerance?: number
+  }) {
+    super()
+    this.inputTraces = params.traces
+    this.outputTraces = params.traces.map((trace) => ({
+      ...trace,
+      tracePath: trace.tracePath.map((point) => ({ ...point })),
+    }))
+    this.alignmentTolerance = params.alignmentTolerance ?? 0.2
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceAlignmentSolver
+  >[0] {
+    return {
+      traces: this.inputTraces,
+      alignmentTolerance: this.alignmentTolerance,
+    }
+  }
+
+  override _step() {
+    const changed = this.alignNextSegmentPair()
+    if (!changed) {
+      this.solved = true
+    }
+  }
+
+  private alignNextSegmentPair(): boolean {
+    const netIds = Array.from(
+      new Set(this.outputTraces.map((trace) => trace.globalConnNetId)),
+    )
+
+    for (const netId of netIds) {
+      const traceIndexes = this.outputTraces
+        .map((trace, traceIndex) => ({ trace, traceIndex }))
+        .filter(({ trace }) => trace.globalConnNetId === netId)
+        .map(({ traceIndex }) => traceIndex)
+
+      for (let i = 0; i < traceIndexes.length; i++) {
+        for (let j = i + 1; j < traceIndexes.length; j++) {
+          const traceIndexA = traceIndexes[i]!
+          const traceIndexB = traceIndexes[j]!
+          const segmentsA = this.getInteriorSegments(traceIndexA)
+          const segmentsB = this.getInteriorSegments(traceIndexB)
+
+          for (const segmentA of segmentsA) {
+            for (const segmentB of segmentsB) {
+              if (segmentA.orientation !== segmentB.orientation) continue
+              const fixedCoordDistance = Math.abs(
+                segmentA.fixedCoord - segmentB.fixedCoord,
+              )
+              if (
+                fixedCoordDistance <= EPS ||
+                fixedCoordDistance > this.alignmentTolerance
+              ) {
+                continue
+              }
+              if (!rangesOverlap(segmentA, segmentB)) continue
+
+              const [segmentToMove, targetCoord] =
+                segmentA.length <= segmentB.length
+                  ? [segmentA, segmentB.fixedCoord]
+                  : [segmentB, segmentA.fixedCoord]
+
+              if (this.wouldOverlapDifferentNet(segmentToMove, targetCoord)) {
+                continue
+              }
+
+              this.moveSegment(segmentToMove, targetCoord)
+              return true
+            }
+          }
+        }
+      }
+    }
+
+    return false
+  }
+
+  private getInteriorSegments(traceIndex: number): SegmentLocator[] {
+    const trace = this.outputTraces[traceIndex]!
+    const segments: SegmentLocator[] = []
+    const path = trace.tracePath
+
+    for (let segmentIndex = 1; segmentIndex < path.length - 2; segmentIndex++) {
+      const p1 = path[segmentIndex]!
+      const p2 = path[segmentIndex + 1]!
+      const horizontal = Math.abs(p1.y - p2.y) < EPS
+      const vertical = Math.abs(p1.x - p2.x) < EPS
+      if (!horizontal && !vertical) continue
+
+      const start = horizontal ? Math.min(p1.x, p2.x) : Math.min(p1.y, p2.y)
+      const end = horizontal ? Math.max(p1.x, p2.x) : Math.max(p1.y, p2.y)
+      const length = end - start
+      if (length <= EPS) continue
+
+      segments.push({
+        traceIndex,
+        segmentIndex,
+        orientation: horizontal ? "horizontal" : "vertical",
+        fixedCoord: horizontal ? p1.y : p1.x,
+        start,
+        end,
+        length,
+      })
+    }
+
+    return segments
+  }
+
+  private wouldOverlapDifferentNet(
+    segment: SegmentLocator,
+    targetCoord: number,
+  ) {
+    const movingTrace = this.outputTraces[segment.traceIndex]!
+    const movedSegment = {
+      ...segment,
+      fixedCoord: targetCoord,
+    }
+
+    for (
+      let traceIndex = 0;
+      traceIndex < this.outputTraces.length;
+      traceIndex++
+    ) {
+      const trace = this.outputTraces[traceIndex]!
+      if (trace.globalConnNetId === movingTrace.globalConnNetId) continue
+
+      for (const otherSegment of this.getAllSegments(traceIndex)) {
+        if (segmentsCoincidentlyOverlap(movedSegment, otherSegment)) {
+          return true
+        }
+      }
+    }
+
+    return false
+  }
+
+  private getAllSegments(traceIndex: number): SegmentLocator[] {
+    const trace = this.outputTraces[traceIndex]!
+    const segments: SegmentLocator[] = []
+    const path = trace.tracePath
+
+    for (let segmentIndex = 0; segmentIndex < path.length - 1; segmentIndex++) {
+      const p1 = path[segmentIndex]!
+      const p2 = path[segmentIndex + 1]!
+      const horizontal = Math.abs(p1.y - p2.y) < EPS
+      const vertical = Math.abs(p1.x - p2.x) < EPS
+      if (!horizontal && !vertical) continue
+
+      const start = horizontal ? Math.min(p1.x, p2.x) : Math.min(p1.y, p2.y)
+      const end = horizontal ? Math.max(p1.x, p2.x) : Math.max(p1.y, p2.y)
+      const length = end - start
+      if (length <= EPS) continue
+
+      segments.push({
+        traceIndex,
+        segmentIndex,
+        orientation: horizontal ? "horizontal" : "vertical",
+        fixedCoord: horizontal ? p1.y : p1.x,
+        start,
+        end,
+        length,
+      })
+    }
+
+    return segments
+  }
+
+  private moveSegment(segment: SegmentLocator, targetCoord: number) {
+    const trace = this.outputTraces[segment.traceIndex]!
+    const path = trace.tracePath.map((point) => ({ ...point }))
+    const p1 = path[segment.segmentIndex]!
+    const p2 = path[segment.segmentIndex + 1]!
+
+    if (segment.orientation === "horizontal") {
+      p1.y = targetCoord
+      p2.y = targetCoord
+    } else {
+      p1.x = targetCoord
+      p2.x = targetCoord
+    }
+
+    this.outputTraces[segment.traceIndex] = {
+      ...trace,
+      tracePath: simplifyPath(path as Point[]),
+    }
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    return {
+      lines: this.outputTraces.map((trace) => ({
+        points: trace.tracePath,
+        strokeColor: "green",
+      })),
+      points: [],
+      rects: [],
+      circles: [],
+    }
+  }
+}
+
+const rangesOverlap = (a: SegmentLocator, b: SegmentLocator) => {
+  const overlap = Math.min(a.end, b.end) - Math.max(a.start, b.start)
+  return overlap > EPS
+}
+
+const segmentsCoincidentlyOverlap = (a: SegmentLocator, b: SegmentLocator) => {
+  if (a.orientation !== b.orientation) return false
+  if (Math.abs(a.fixedCoord - b.fixedCoord) > EPS) return false
+  return rangesOverlap(a, b)
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -6,26 +6,27 @@
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { InputProblem } from "lib/types/InputProblem"
+import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
+import { Example28Solver } from "../Example28Solver/Example28Solver"
+import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MspConnectionPairSolver } from "../MspConnectionPairSolver/MspConnectionPairSolver"
+import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceAlignmentSolver } from "../SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver"
 import {
   SchematicTraceLinesSolver,
   type SolvedTracePath,
 } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
-import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
-import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
-import { visualizeInputProblem } from "./visualizeInputProblem"
+import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
+import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import type { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceLabelOverlapAvoidanceSolver } from "../TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver"
+import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
+import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
+import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
 import { correctPinsInsideChips } from "./correctPinsInsideChip"
 import { expandChipsToFitPins } from "./expandChipsToFitPins"
-import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
-import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
-import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
-import { Example28Solver } from "../Example28Solver/Example28Solver"
-import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
-import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
-import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
-import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { visualizeInputProblem } from "./visualizeInputProblem"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -71,6 +72,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   schematicTraceLinesSolver?: SchematicTraceLinesSolver
   longDistancePairSolver?: LongDistancePairSolver
   traceOverlapShiftSolver?: TraceOverlapShiftSolver
+  sameNetTraceAlignmentSolver?: SameNetTraceAlignmentSolver
   netLabelPlacementSolver?: NetLabelPlacementSolver
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
@@ -94,7 +96,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       MspConnectionPairSolver,
       () => [{ inputProblem: this.inputProblem }],
       {
-        onSolved: (mspSolver) => {},
+        onSolved: (_mspSolver) => {},
       },
     ),
     // definePipelineStep(
@@ -136,7 +138,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
         },
       ],
       {
-        onSolved: (schematicTraceLinesSolver) => {},
+        onSolved: (_schematicTraceLinesSolver) => {},
       },
     ),
     definePipelineStep(
@@ -146,7 +148,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
         {
           inputProblem: this.inputProblem,
           inputTracePaths:
-            this.longDistancePairSolver?.getOutput().allTracesMerged!,
+            this.longDistancePairSolver!.getOutput().allTracesMerged,
           globalConnMap: this.mspConnectionPairSolver!.globalConnMap,
         },
       ],
@@ -155,18 +157,36 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       },
     ),
     definePipelineStep(
+      "sameNetTraceAlignmentSolver",
+      SameNetTraceAlignmentSolver,
+      (instance) => {
+        const traces =
+          instance.traceOverlapShiftSolver?.correctedTraceMap ??
+          Object.fromEntries(
+            instance
+              .longDistancePairSolver!.getOutput()
+              .allTracesMerged.map((p) => [p.mspPairId, p]),
+          )
+
+        return [
+          {
+            traces: Object.values(traces),
+          },
+        ]
+      },
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       () => [
         {
           inputProblem: this.inputProblem,
-          inputTraceMap:
-            this.traceOverlapShiftSolver?.correctedTraceMap ??
-            Object.fromEntries(
-              this.longDistancePairSolver!.getOutput().allTracesMerged.map(
-                (p) => [p.mspPairId, p],
-              ),
-            ),
+          inputTraceMap: Object.fromEntries(
+            this.sameNetTraceAlignmentSolver!.getOutput().traces.map((p) => [
+              p.mspPairId,
+              p,
+            ]),
+          ),
         },
       ],
       {
@@ -179,14 +199,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       "traceLabelOverlapAvoidanceSolver",
       TraceLabelOverlapAvoidanceSolver,
       (instance) => {
-        const traceMap =
-          instance.traceOverlapShiftSolver?.correctedTraceMap ??
-          Object.fromEntries(
-            instance
-              .longDistancePairSolver!.getOutput()
-              .allTracesMerged.map((p) => [p.mspPairId, p]),
-          )
-        const traces = Object.values(traceMap)
+        const traces = instance.sameNetTraceAlignmentSolver!.getOutput().traces
         const netLabelPlacements =
           instance.netLabelPlacementSolver!.netLabelPlacements
 
@@ -360,7 +373,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     }
 
     const constructorParams = pipelineStepDef.getConstructorParams(this)
-    // @ts-ignore
+    // @ts-expect-error
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
     ;(this as any)[pipelineStepDef.solverName] = this.activeSubSolver
     this.timeSpentOnPhase[pipelineStepDef.solverName] = 0

--- a/tests/solvers/SameNetTraceAlignmentSolver/same-net-trace-alignment-solver.test.ts
+++ b/tests/solvers/SameNetTraceAlignmentSolver/same-net-trace-alignment-solver.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceAlignmentSolver } from "lib/solvers/SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [
+      { pinId: `${mspPairId}.1`, chipId: "U1", x: 0, y: 0 },
+      { pinId: `${mspPairId}.2`, chipId: "U2", x: 0, y: 0 },
+    ],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}.1`, `${mspPairId}.2`],
+  }) as SolvedTracePath
+
+test("aligns close same-net horizontal interior segments", () => {
+  const solver = new SameNetTraceAlignmentSolver({
+    alignmentTolerance: 0.2,
+    traces: [
+      makeTrace("a", "GND", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 0 },
+      ]),
+      makeTrace("b", "GND", [
+        { x: 1, y: 0 },
+        { x: 1, y: 1.12 },
+        { x: 3, y: 1.12 },
+        { x: 3, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const [, alignedTrace] = solver.getOutput().traces
+  expect(alignedTrace!.tracePath).toEqual([
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 3, y: 1 },
+    { x: 3, y: 0 },
+  ])
+})
+
+test("does not align close segments from different nets", () => {
+  const solver = new SameNetTraceAlignmentSolver({
+    alignmentTolerance: 0.2,
+    traces: [
+      makeTrace("a", "GND", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 0 },
+      ]),
+      makeTrace("b", "VCC", [
+        { x: 1, y: 0 },
+        { x: 1, y: 1.12 },
+        { x: 3, y: 1.12 },
+        { x: 3, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const [, untouchedTrace] = solver.getOutput().traces
+  expect(untouchedTrace!.tracePath[1]!.y).toBe(1.12)
+  expect(untouchedTrace!.tracePath[2]!.y).toBe(1.12)
+})
+
+test("aligns close same-net vertical interior segments", () => {
+  const solver = new SameNetTraceAlignmentSolver({
+    alignmentTolerance: 0.2,
+    traces: [
+      makeTrace("a", "SDA", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 4 },
+        { x: 0, y: 4 },
+      ]),
+      makeTrace("b", "SDA", [
+        { x: 0, y: 1 },
+        { x: 1.12, y: 1 },
+        { x: 1.12, y: 3 },
+        { x: 0, y: 3 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const [, alignedTrace] = solver.getOutput().traces
+  expect(alignedTrace!.tracePath).toEqual([
+    { x: 0, y: 1 },
+    { x: 1, y: 1 },
+    { x: 1, y: 3 },
+    { x: 0, y: 3 },
+  ])
+})
+
+test("does not align when the moved tail would overlap a different net", () => {
+  const solver = new SameNetTraceAlignmentSolver({
+    alignmentTolerance: 0.2,
+    traces: [
+      makeTrace("gnd-a", "GND", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 3, y: 1 },
+        { x: 3, y: 0 },
+      ]),
+      makeTrace("gnd-b", "GND", [
+        { x: 2, y: 0 },
+        { x: 2, y: 1.1 },
+        { x: 4, y: 1.1 },
+        { x: 4, y: 0 },
+      ]),
+      makeTrace("vcc", "VCC", [
+        { x: 3.2, y: 0 },
+        { x: 3.2, y: 1 },
+        { x: 3.8, y: 1 },
+        { x: 3.8, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const [, gndTrace] = solver.getOutput().traces
+  expect(gndTrace!.tracePath[1]!.y).toBe(1.1)
+  expect(gndTrace!.tracePath[2]!.y).toBe(1.1)
+})


### PR DESCRIPTION
Fixes #29.
/claim #29

Also addresses #34.
/claim #34

Closes #34

Adds a pipeline phase that aligns nearby same-net trace segments onto a shared X or Y coordinate when their ranges overlap. This runs after overlap shifting and before net label placement so later stages consume the cleaned-up traces.

The alignment solver:
- handles horizontal and vertical interior segments
- preserves trace endpoints connected to pins
- skips different-net segments
- rejects a candidate move if it would introduce a coincident overlap with another net

Review proof:
- Strong focused behavior MP4: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/pr-306-same-net-alignment-strong-demo.mp4
- Strong focused behavior GIF: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/pr-306-same-net-alignment-strong-demo.gif
- Strong contact sheet: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/pr-306-strong-contact-sheet.jpg
- Live Cosmos example34 pipeline run MP4: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/pr-306-example34-live-cosmos-demo.mp4
- Live Cosmos example34 GIF: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/pr-306-example34-live-cosmos-demo.gif
- Live Cosmos contact sheet: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/pr-306-live-cosmos-contact-sheet.jpg
- example34 before/after image: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/example34-before-after-pr306.png
- example34 before SVG from origin/main: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/example34-before-origin-main.svg
- example34 after SVG from this PR: https://github.com/digzrow-coder/schematic-trace-solver/releases/download/pr-306-demo-20260514/example34-after-pr306.svg

Verified locally:
- bun test tests/examples/example34.test.ts tests/solvers/SameNetTraceAlignmentSolver/same-net-trace-alignment-solver.test.ts (5 pass, 0 fail)
- Previous full local verification: bun test (61 passing, 4 skipped), bunx tsc --noEmit, bun run build, and bunx biome check lib/solvers/SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver.ts tests/solvers/SameNetTraceAlignmentSolver/same-net-trace-alignment-solver.test.ts lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts lib/index.ts

Algora claim for #29: https://algora.io/claims/cd492mGixrp6yZ5q

AI-assisted with OpenAI Codex; I reviewed the diff, proof assets, and validation output before posting.