### PR TITLE
Deduplicate same-net trace cleanup segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,6 +20,7 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { dedupeSameNetTraceSegments } from "./dedupeSameNetTraceSegments"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -148,7 +149,7 @@ export class TraceCleanupSolver extends BaseSolver {
 
   getOutput() {
     return {
-      traces: this.outputTraces,
+      traces: dedupeSameNetTraceSegments(this.outputTraces),
     }
   }
 

--- a/lib/solvers/TraceCleanupSolver/dedupeSameNetTraceSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/dedupeSameNetTraceSegments.ts
@@ -1,0 +1,78 @@
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const COORD_PRECISION = 6
+
+const pointKey = (point: { x: number; y: number }) =>
+  `${point.x.toFixed(COORD_PRECISION)},${point.y.toFixed(COORD_PRECISION)}`
+
+const segmentKey = (
+  p1: { x: number; y: number },
+  p2: { x: number; y: number },
+) => {
+  const endpoints = [pointKey(p1), pointKey(p2)].sort()
+  return `${endpoints[0]}|${endpoints[1]}`
+}
+
+const getTraceSegments = (trace: SolvedTracePath) => {
+  const segments: string[] = []
+  for (let i = 0; i < trace.tracePath.length - 1; i++) {
+    segments.push(segmentKey(trace.tracePath[i]!, trace.tracePath[i + 1]!))
+  }
+  return segments
+}
+
+const getContiguousKeptPath = (
+  trace: SolvedTracePath,
+  keepSegment: boolean[],
+) => {
+  const keptIndexes = keepSegment
+    .map((keep, index) => (keep ? index : -1))
+    .filter((index) => index !== -1)
+
+  if (keptIndexes.length === 0) return []
+
+  for (let i = 1; i < keptIndexes.length; i++) {
+    if (keptIndexes[i] !== keptIndexes[i - 1]! + 1) {
+      return trace.tracePath
+    }
+  }
+
+  const firstSegmentIndex = keptIndexes[0]!
+  const lastSegmentIndex = keptIndexes[keptIndexes.length - 1]!
+
+  return trace.tracePath.slice(firstSegmentIndex, lastSegmentIndex + 2)
+}
+
+export const dedupeSameNetTraceSegments = (
+  traces: SolvedTracePath[],
+): SolvedTracePath[] => {
+  const seenByNet = new Map<string, Set<string>>()
+  const output: SolvedTracePath[] = []
+
+  for (const trace of traces) {
+    const netId = trace.globalConnNetId ?? trace.dcConnNetId ?? ""
+    const seenSegments = seenByNet.get(netId) ?? new Set<string>()
+    seenByNet.set(netId, seenSegments)
+
+    const segments = getTraceSegments(trace)
+    const keepSegment = segments.map((segment) => !seenSegments.has(segment))
+    const dedupedPath = getContiguousKeptPath(trace, keepSegment)
+
+    for (const segment of segments) {
+      seenSegments.add(segment)
+    }
+
+    if (dedupedPath.length < 2) continue
+
+    output.push(
+      dedupedPath === trace.tracePath
+        ? trace
+        : {
+            ...trace,
+            tracePath: dedupedPath,
+          },
+    )
+  }
+
+  return output
+}

--- a/tests/solvers/TraceCleanupSolver/dedupeSameNetTraceSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/dedupeSameNetTraceSegments.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test"
+import { dedupeSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/dedupeSameNetTraceSegments"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: SolvedTracePath["tracePath"],
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    globalConnNetId,
+    dcConnNetId: globalConnNetId,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+    pins: [],
+  }) as unknown as SolvedTracePath
+
+test("dedupeSameNetTraceSegments removes duplicate same-net traces", () => {
+  const traces = [
+    makeTrace("a", "VCC", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ]),
+    makeTrace("b", "VCC", [
+      { x: 1, y: 0 },
+      { x: 0, y: 0 },
+    ]),
+    makeTrace("c", "GND", [
+      { x: 1, y: 0 },
+      { x: 0, y: 0 },
+    ]),
+  ]
+
+  expect(dedupeSameNetTraceSegments(traces).map((trace) => trace.mspPairId)).toEqual([
+    "a",
+    "c",
+  ])
+})
+
+test("dedupeSameNetTraceSegments trims duplicate edge segments only when the remaining path is contiguous", () => {
+  const traces = [
+    makeTrace("a", "OUT", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ]),
+    makeTrace("b", "OUT", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ]),
+    makeTrace("c", "OUT", [
+      { x: 2, y: 0 },
+      { x: 3, y: 0 },
+      { x: 3, y: 1 },
+      { x: 4, y: 1 },
+    ]),
+    makeTrace("d", "OUT", [
+      { x: 3, y: 0 },
+      { x: 3, y: 1 },
+      { x: 5, y: 1 },
+      { x: 4, y: 1 },
+    ]),
+  ]
+
+  const deduped = dedupeSameNetTraceSegments(traces)
+
+  expect(deduped.find((trace) => trace.mspPairId === "b")!.tracePath).toEqual([
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+  ])
+  expect(deduped.find((trace) => trace.mspPairId === "d")!.tracePath).toEqual([
+    { x: 3, y: 0 },
+    { x: 3, y: 1 },
+    { x: 5, y: 1 },
+    { x: 4, y: 1 },
+  ])
+})


### PR DESCRIPTION
Fixes #78.

/claim #78

Summary:
- deduplicates exact duplicate trace segments per net during trace cleanup output
- drops fully duplicated same-net traces
- trims duplicated edge segments only when the remaining trace path stays contiguous
- adds focused regression coverage for full duplicate removal and conservative edge trimming

Verification:
- git diff --check
- not run: bun test (bun is not installed in this environment)