### PR TITLE
Add same-net trace merging pipeline phase

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+export { SameNetTraceMergingSolver } from "./solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver"

--- a/lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.ts
+++ b/lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.ts
@@ -1,0 +1,212 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject, Line } from "graphics-debug"
+import { getColorFromString } from "lib/utils/getColorFromString"
+import { BaseSolver } from "../BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const DEFAULT_MERGE_DISTANCE = 0.12
+const EPS = 1e-6
+
+type Orientation = "horizontal" | "vertical"
+
+type SegmentLocator = {
+  traceIndex: number
+  segmentIndex: number
+  trace: SolvedTracePath
+  orientation: Orientation
+  constant: number
+  min: number
+  max: number
+  length: number
+  canMove: boolean
+}
+
+interface SameNetTraceMergingSolverParams {
+  allTraces: SolvedTracePath[]
+  mergeDistance?: number
+}
+
+const samePoint = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) < EPS && Math.abs(a.y - b.y) < EPS
+
+const cloneTrace = (trace: SolvedTracePath): SolvedTracePath => ({
+  ...trace,
+  pins: [{ ...trace.pins[0] }, { ...trace.pins[1] }],
+  tracePath: trace.tracePath.map((p) => ({ ...p })),
+  mspConnectionPairIds: [...trace.mspConnectionPairIds],
+  pinIds: [...trace.pinIds],
+})
+
+const isTracePinPoint = (trace: SolvedTracePath, point: Point) =>
+  trace.pins.some((pin) => samePoint(pin, point))
+
+const getSegmentLocator = (
+  trace: SolvedTracePath,
+  traceIndex: number,
+  segmentIndex: number,
+): SegmentLocator | null => {
+  const a = trace.tracePath[segmentIndex]
+  const b = trace.tracePath[segmentIndex + 1]
+  if (!a || !b) return null
+
+  const isHorizontal = Math.abs(a.y - b.y) < EPS
+  const isVertical = Math.abs(a.x - b.x) < EPS
+  if (!isHorizontal && !isVertical) return null
+
+  const orientation: Orientation = isHorizontal ? "horizontal" : "vertical"
+  const min = isHorizontal ? Math.min(a.x, b.x) : Math.min(a.y, b.y)
+  const max = isHorizontal ? Math.max(a.x, b.x) : Math.max(a.y, b.y)
+
+  return {
+    traceIndex,
+    segmentIndex,
+    trace,
+    orientation,
+    constant: isHorizontal ? a.y : a.x,
+    min,
+    max,
+    length: max - min,
+    canMove: !isTracePinPoint(trace, a) && !isTracePinPoint(trace, b),
+  }
+}
+
+const simplifyPath = (path: Point[]) => {
+  const deduped: Point[] = []
+  for (const point of path) {
+    if (!deduped.at(-1) || !samePoint(deduped.at(-1)!, point)) {
+      deduped.push(point)
+    }
+  }
+
+  const simplified: Point[] = []
+  for (const point of deduped) {
+    simplified.push(point)
+    while (simplified.length >= 3) {
+      const a = simplified[simplified.length - 3]!
+      const b = simplified[simplified.length - 2]!
+      const c = simplified[simplified.length - 1]!
+      const colinearHorizontal =
+        Math.abs(a.y - b.y) < EPS && Math.abs(b.y - c.y) < EPS
+      const colinearVertical =
+        Math.abs(a.x - b.x) < EPS && Math.abs(b.x - c.x) < EPS
+      if (!colinearHorizontal && !colinearVertical) break
+      simplified.splice(simplified.length - 2, 1)
+    }
+  }
+
+  return simplified
+}
+
+export class SameNetTraceMergingSolver extends BaseSolver {
+  private traces: SolvedTracePath[]
+  private mergeDistance: number
+
+  constructor(params: SameNetTraceMergingSolverParams) {
+    super()
+    this.traces = params.allTraces.map(cloneTrace)
+    this.mergeDistance = params.mergeDistance ?? DEFAULT_MERGE_DISTANCE
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceMergingSolver
+  >[0] {
+    return {
+      allTraces: this.traces,
+      mergeDistance: this.mergeDistance,
+    }
+  }
+
+  private getSegments() {
+    const segments: SegmentLocator[] = []
+    for (let traceIndex = 0; traceIndex < this.traces.length; traceIndex++) {
+      const trace = this.traces[traceIndex]!
+      for (
+        let segmentIndex = 0;
+        segmentIndex < trace.tracePath.length - 1;
+        segmentIndex++
+      ) {
+        const segment = getSegmentLocator(trace, traceIndex, segmentIndex)
+        if (segment) segments.push(segment)
+      }
+    }
+    return segments
+  }
+
+  private findNextMergeCandidate() {
+    const segments = this.getSegments()
+    for (let i = 0; i < segments.length; i++) {
+      const a = segments[i]!
+      for (let j = i + 1; j < segments.length; j++) {
+        const b = segments[j]!
+        if (a.trace.globalConnNetId !== b.trace.globalConnNetId) continue
+        if (a.orientation !== b.orientation) continue
+        if (Math.abs(a.constant - b.constant) < EPS) continue
+        if (Math.abs(a.constant - b.constant) > this.mergeDistance) continue
+
+        const overlap = Math.min(a.max, b.max) - Math.max(a.min, b.min)
+        if (overlap <= EPS) continue
+
+        const source =
+          a.canMove && b.canMove
+            ? a.length <= b.length
+              ? a
+              : b
+            : a.canMove
+              ? a
+              : b.canMove
+                ? b
+                : null
+        if (!source) continue
+
+        const target = source === a ? b : a
+        return { source, target }
+      }
+    }
+
+    return null
+  }
+
+  override _step() {
+    const candidate = this.findNextMergeCandidate()
+    if (!candidate) {
+      this.solved = true
+      return
+    }
+
+    const { source, target } = candidate
+    const trace = this.traces[source.traceIndex]!
+    const first = trace.tracePath[source.segmentIndex]!
+    const second = trace.tracePath[source.segmentIndex + 1]!
+
+    if (source.orientation === "horizontal") {
+      first.y = target.constant
+      second.y = target.constant
+    } else {
+      first.x = target.constant
+      second.x = target.constant
+    }
+
+    trace.tracePath = simplifyPath(trace.tracePath)
+    this.stats.mergedSegments = (this.stats.mergedSegments ?? 0) + 1
+  }
+
+  getOutput() {
+    return {
+      traces: this.traces,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    return {
+      lines: this.traces.map(
+        (trace): Line => ({
+          points: trace.tracePath,
+          strokeColor: getColorFromString(trace.globalConnNetId),
+        }),
+      ),
+      points: [],
+      rects: [],
+      circles: [],
+    }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceMergingSolver } from "../SameNetTraceMergingSolver/SameNetTraceMergingSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -80,6 +81,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
   traceAnchoredNetLabelOverlapSolver?: TraceAnchoredNetLabelOverlapSolver
   netLabelTraceCollisionSolver?: NetLabelTraceCollisionSolver
+  sameNetTraceMergingSolver?: SameNetTraceMergingSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -218,10 +220,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceMergingSolver",
+      SameNetTraceMergingSolver,
+      (instance) => [
+        {
+          allTraces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceMergingSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +249,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceMergingSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.test.ts
+++ b/tests/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceMergingSolver } from "lib/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath => ({
+  mspPairId,
+  dcConnNetId: globalConnNetId,
+  globalConnNetId,
+  pins: [
+    { pinId: `${mspPairId}.start`, chipId: "chip", ...tracePath[0]! },
+    { pinId: `${mspPairId}.end`, chipId: "chip", ...tracePath.at(-1)! },
+  ],
+  tracePath,
+  mspConnectionPairIds: [mspPairId],
+  pinIds: [`${mspPairId}.start`, `${mspPairId}.end`],
+})
+
+test("snaps close parallel same-net segments together", () => {
+  const fixedTrace = makeTrace("a", "net0", [
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+  ])
+  const traceWithCloseRun = makeTrace("b", "net0", [
+    { x: 1, y: -0.5 },
+    { x: 1, y: 0.08 },
+    { x: 3, y: 0.08 },
+    { x: 3, y: -0.5 },
+  ])
+
+  const solver = new SameNetTraceMergingSolver({
+    allTraces: [fixedTrace, traceWithCloseRun],
+    mergeDistance: 0.1,
+  })
+  solver.solve()
+
+  const [, mergedTrace] = solver.getOutput().traces
+  expect(mergedTrace!.tracePath).toEqual([
+    { x: 1, y: -0.5 },
+    { x: 1, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: -0.5 },
+  ])
+  expect(solver.stats.mergedSegments).toBe(1)
+})
+
+test("leaves close segments on different nets unchanged", () => {
+  const solver = new SameNetTraceMergingSolver({
+    allTraces: [
+      makeTrace("a", "net0", [
+        { x: 0, y: 0 },
+        { x: 4, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 1, y: -0.5 },
+        { x: 1, y: 0.08 },
+        { x: 3, y: 0.08 },
+        { x: 3, y: -0.5 },
+      ]),
+    ],
+    mergeDistance: 0.1,
+  })
+  solver.solve()
+
+  const [, unchangedTrace] = solver.getOutput().traces
+  expect(unchangedTrace!.tracePath[1]!.y).toBe(0.08)
+  expect(solver.stats.mergedSegments).toBeUndefined()
+})


### PR DESCRIPTION
Fixes #29
Fixes #34

/claim #29
/claim #34

## Summary
- add a `SameNetTraceMergingSolver` phase after trace cleanup
- snap close, overlapping, parallel trace segments on the same global net onto a shared run while leaving different-net segments unchanged
- feed merged traces into the final net-label placement and downstream cleanup phases
- export the solver and add targeted unit coverage

## Verification
- `npx --yes bun test tests/solvers/SameNetTraceMergingSolver/SameNetTraceMergingSolver.test.ts`
- `npx --yes bun test tests/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver_repro03.test.ts`
- `npx --yes bun test`
- `npx --yes -p typescript@^5 tsc --noEmit`
- `npm run build`