### PR TITLE
Align close internal same-net trace segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -1,11 +1,14 @@
-import type { InputProblem } from "lib/types/InputProblem"
 import type { GraphicsObject, Line } from "graphics-debug"
-import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
-import { balanceZShapes } from "./balanceZShapes"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { alignCloseSameNetSegments } from "./alignCloseSameNetSegments"
+import { balanceZShapes } from "./balanceZShapes"
+import { is4PointRectangle } from "./is4PointRectangle"
+import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
+import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -18,15 +21,13 @@ interface TraceCleanupSolverInput {
   paddingBuffer: number
 }
 
-import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
-import { is4PointRectangle } from "./is4PointRectangle"
-
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
  */
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "aligning_same_net_segments"
   | "untangling_traces"
 
 /**
@@ -84,6 +85,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "aligning_same_net_segments":
+        this._runAlignSameNetSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +112,19 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "aligning_same_net_segments"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runAlignSameNetSegmentsStep() {
+    this.outputTraces = alignCloseSameNetSegments(
+      Array.from(this.tracesMap.values()),
+    )
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/alignCloseSameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignCloseSameNetSegments.ts
@@ -1,0 +1,141 @@
+import type { Point } from "graphics-debug"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+type Segment = {
+  trace: SolvedTracePath
+  traceIndex: number
+  segmentIndex: number
+  p1: Point
+  p2: Point
+  orientation: "horizontal" | "vertical"
+}
+
+const DEFAULT_MAX_DISTANCE = 0.15
+const MIN_OVERLAP = 0.01
+const MAX_PASSES = 6
+
+const isHorizontal = (p1: Point, p2: Point) => p1.y === p2.y && p1.x !== p2.x
+const isVertical = (p1: Point, p2: Point) => p1.x === p2.x && p1.y !== p2.y
+
+const getOverlap = (a1: number, a2: number, b1: number, b2: number) =>
+  Math.min(Math.max(a1, a2), Math.max(b1, b2)) -
+  Math.max(Math.min(a1, a2), Math.min(b1, b2))
+
+const getInternalSegments = (
+  trace: SolvedTracePath,
+  traceIndex: number,
+): Segment[] => {
+  const segments: Segment[] = []
+  const { tracePath } = trace
+
+  for (let i = 1; i < tracePath.length - 2; i++) {
+    const p1 = tracePath[i]
+    const p2 = tracePath[i + 1]
+    if (isHorizontal(p1, p2)) {
+      segments.push({
+        trace,
+        traceIndex,
+        segmentIndex: i,
+        p1,
+        p2,
+        orientation: "horizontal",
+      })
+    } else if (isVertical(p1, p2)) {
+      segments.push({
+        trace,
+        traceIndex,
+        segmentIndex: i,
+        p1,
+        p2,
+        orientation: "vertical",
+      })
+    }
+  }
+
+  return segments
+}
+
+const setSegmentAxis = (
+  traces: SolvedTracePath[],
+  segment: Segment,
+  axisValue: number,
+) => {
+  const trace = traces[segment.traceIndex]
+  const path = trace.tracePath.map((point) => ({ ...point }))
+  const p1 = path[segment.segmentIndex]
+  const p2 = path[segment.segmentIndex + 1]
+
+  if (segment.orientation === "horizontal") {
+    p1.y = axisValue
+    p2.y = axisValue
+  } else {
+    p1.x = axisValue
+    p2.x = axisValue
+  }
+
+  traces[segment.traceIndex] = {
+    ...trace,
+    tracePath: simplifyPath(path),
+  }
+}
+
+export const alignCloseSameNetSegments = (
+  traces: SolvedTracePath[],
+  maxDistance = DEFAULT_MAX_DISTANCE,
+): SolvedTracePath[] => {
+  const output = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  for (let pass = 0; pass < MAX_PASSES; pass++) {
+    const segments = output.flatMap((trace, traceIndex) =>
+      getInternalSegments(trace, traceIndex),
+    )
+    let changed = false
+
+    for (let i = 0; i < segments.length; i++) {
+      for (let j = i + 1; j < segments.length; j++) {
+        const a = segments[i]
+        const b = segments[j]
+        if (a.traceIndex === b.traceIndex) continue
+        if (a.trace.globalConnNetId !== b.trace.globalConnNetId) continue
+        if (a.orientation !== b.orientation) continue
+
+        if (a.orientation === "horizontal") {
+          const distance = Math.abs(a.p1.y - b.p1.y)
+          const overlap = getOverlap(a.p1.x, a.p2.x, b.p1.x, b.p2.x)
+          if (
+            distance === 0 ||
+            distance > maxDistance ||
+            overlap < MIN_OVERLAP
+          ) {
+            continue
+          }
+          const sharedY = (a.p1.y + b.p1.y) / 2
+          setSegmentAxis(output, a, sharedY)
+          setSegmentAxis(output, b, sharedY)
+          changed = true
+          break
+        }
+
+        const distance = Math.abs(a.p1.x - b.p1.x)
+        const overlap = getOverlap(a.p1.y, a.p2.y, b.p1.y, b.p2.y)
+        if (distance === 0 || distance > maxDistance || overlap < MIN_OVERLAP) {
+          continue
+        }
+        const sharedX = (a.p1.x + b.p1.x) / 2
+        setSegmentAxis(output, a, sharedX)
+        setSegmentAxis(output, b, sharedX)
+        changed = true
+        break
+      }
+      if (changed) break
+    }
+
+    if (!changed) break
+  }
+
+  return output
+}

--- a/tests/solvers/TraceCleanupSolver/align-close-same-net-segments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/align-close-same-net-segments.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { alignCloseSameNetSegments } from "lib/solvers/TraceCleanupSolver/alignCloseSameNetSegments"
+
+const trace = (
+  id: string,
+  globalConnNetId: string,
+  tracePath: SolvedTracePath["tracePath"],
+): SolvedTracePath =>
+  ({
+    mspPairId: id,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    tracePath,
+    mspConnectionPairIds: [id],
+    pinIds: [`${id}-a`, `${id}-b`],
+    pins: [],
+  }) as any
+
+test("aligns close overlapping internal horizontal same-net segments", () => {
+  const output = alignCloseSameNetSegments([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 0 },
+    ]),
+    trace("b", "net1", [
+      { x: 0, y: 0.2 },
+      { x: 1, y: 0.2 },
+      { x: 1, y: 1.12 },
+      { x: 4, y: 1.12 },
+      { x: 4, y: 0.2 },
+    ]),
+  ])
+
+  expect(output[0].tracePath[2].y).toBeCloseTo(1.06)
+  expect(output[0].tracePath[3].y).toBeCloseTo(1.06)
+  expect(output[1].tracePath[2].y).toBeCloseTo(1.06)
+  expect(output[1].tracePath[3].y).toBeCloseTo(1.06)
+})
+
+test("aligns close overlapping internal vertical same-net segments", () => {
+  const output = alignCloseSameNetSegments([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 1, y: 4 },
+      { x: 0, y: 4 },
+    ]),
+    trace("b", "net1", [
+      { x: 0.2, y: 0 },
+      { x: 0.2, y: 1 },
+      { x: 1.1, y: 1 },
+      { x: 1.1, y: 4 },
+      { x: 0.2, y: 4 },
+    ]),
+  ])
+
+  expect(output[0].tracePath[2].x).toBeCloseTo(1.05)
+  expect(output[0].tracePath[3].x).toBeCloseTo(1.05)
+  expect(output[1].tracePath[2].x).toBeCloseTo(1.05)
+  expect(output[1].tracePath[3].x).toBeCloseTo(1.05)
+})
+
+test("does not align different nets or endpoint-only segments", () => {
+  const output = alignCloseSameNetSegments([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 3, y: 0 },
+    ]),
+    trace("b", "net1", [
+      { x: 0, y: 0.1 },
+      { x: 3, y: 0.1 },
+    ]),
+    trace("c", "net2", [
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 1, y: 2 },
+      { x: 4, y: 2 },
+      { x: 4, y: 1 },
+    ]),
+    trace("d", "net3", [
+      { x: 0, y: 1.1 },
+      { x: 1, y: 1.1 },
+      { x: 1, y: 2.1 },
+      { x: 4, y: 2.1 },
+      { x: 4, y: 1.1 },
+    ]),
+  ])
+
+  expect(output[0].tracePath[0].y).toBe(0)
+  expect(output[0].tracePath[1].y).toBe(0)
+  expect(output[1].tracePath[0].y).toBe(0.1)
+  expect(output[1].tracePath[1].y).toBe(0.1)
+  expect(output[2].tracePath[2].y).toBe(2)
+  expect(output[2].tracePath[3].y).toBe(2)
+  expect(output[3].tracePath[2].y).toBe(2.1)
+  expect(output[3].tracePath[3].y).toBe(2.1)
+})


### PR DESCRIPTION
## Summary
- add a final TraceCleanupSolver phase that aligns close overlapping internal same-net horizontal/vertical segments onto a shared axis
- keep endpoint segments fixed so pin anchors are not moved
- add focused regression coverage for horizontal alignment, vertical alignment, different-net protection, and endpoint-only protection

/claim #29

## Verification
- `npm exec --yes bun -- test tests/solvers/TraceCleanupSolver/align-close-same-net-segments.test.ts tests/solvers/TraceCleanupSolver/TraceCleanupSolver.test.ts`
- `npm exec --yes bun -- test` -> 60 pass, 4 skip, 0 fail
- `npx @biomejs/biome check lib/solvers/TraceCleanupSolver/alignCloseSameNetSegments.ts tests/solvers/TraceCleanupSolver/align-close-same-net-segments.test.ts lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts`
- `npx -p typescript@5.9.3 tsc --noEmit`
- `git diff --check -- lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts lib/solvers/TraceCleanupSolver/alignCloseSameNetSegments.ts tests/solvers/TraceCleanupSolver/align-close-same-net-segments.test.ts`

Note: the local `bun run build` JS bundle step succeeds, but DTS generation requires `typescript` installed as a local peer dependency. I verified types separately with `tsc --noEmit`; CI should run with its normal dependency setup.

AI-assisted with Codex; I reviewed the diff and ran the verification above.