### PR TITLE
Add trace segment merge pipeline phase

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+export { TraceSegmentMergeSolver } from "./solvers/TraceSegmentMergeSolver"

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -148,6 +148,8 @@ export class SchematicTracePipelineSolver extends BaseSolver {
         {
           inputProblem: instance.inputProblem,
           traces: instance.longDistancePairSolver!.getOutput().allTracesMerged,
+          mergeDistance: 0.02,
+          alignmentDistance: 0.01,
         },
       ],
       {

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { TraceSegmentMergeSolver } from "../TraceSegmentMergeSolver/TraceSegmentMergeSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -70,6 +71,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   // guidelinesSolver?: GuidelinesSolver
   schematicTraceLinesSolver?: SchematicTraceLinesSolver
   longDistancePairSolver?: LongDistancePairSolver
+  traceSegmentMergeSolver?: TraceSegmentMergeSolver
   traceOverlapShiftSolver?: TraceOverlapShiftSolver
   netLabelPlacementSolver?: NetLabelPlacementSolver
   labelMergingSolver?: MergedNetLabelObstacleSolver
@@ -140,12 +142,26 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       },
     ),
     definePipelineStep(
+      "traceSegmentMergeSolver",
+      TraceSegmentMergeSolver,
+      (instance) => [
+        {
+          inputProblem: instance.inputProblem,
+          traces: instance.longDistancePairSolver!.getOutput().allTracesMerged,
+        },
+      ],
+      {
+        onSolved: (_solver) => {},
+      },
+    ),
+    definePipelineStep(
       "traceOverlapShiftSolver",
       TraceOverlapShiftSolver,
       () => [
         {
           inputProblem: this.inputProblem,
           inputTracePaths:
+            this.traceSegmentMergeSolver?.getOutput().traces ??
             this.longDistancePairSolver?.getOutput().allTracesMerged!,
           globalConnMap: this.mspConnectionPairSolver!.globalConnMap,
         },

--- a/lib/solvers/TraceSegmentMergeSolver/TraceSegmentMergeSolver.ts
+++ b/lib/solvers/TraceSegmentMergeSolver/TraceSegmentMergeSolver.ts
@@ -243,9 +243,6 @@ export class TraceSegmentMergeSolver extends BaseSolver {
     const end = Math.min(maxA, maxB)
     if (start <= end) return [start, end]
 
-    const gap = start - end
-    if (gap <= this.mergeDistance) return [end, start]
-
     return null
   }
 

--- a/lib/solvers/TraceSegmentMergeSolver/TraceSegmentMergeSolver.ts
+++ b/lib/solvers/TraceSegmentMergeSolver/TraceSegmentMergeSolver.ts
@@ -1,0 +1,376 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import { getColorFromString } from "lib/utils/getColorFromString"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+
+type TraceEndpoint = {
+  point: Point
+}
+
+type OrthogonalSegment = {
+  start: Point
+  end: Point
+  orientation: "horizontal" | "vertical"
+}
+
+type BridgeCandidate = {
+  traceA: SolvedTracePath
+  traceB: SolvedTracePath
+  pointA: Point
+  pointB: Point
+}
+
+export class TraceSegmentMergeSolver extends BaseSolver {
+  inputProblem: InputProblem
+  inputTraces: SolvedTracePath[]
+  outputTraces: SolvedTracePath[]
+  mergeDistance: number
+  alignmentDistance: number
+  private originalTraceIds: Set<string>
+  private bridgeKeys = new Set<string>()
+  private bridgedTracePairs = new Set<string>()
+
+  constructor(params: {
+    inputProblem: InputProblem
+    traces: SolvedTracePath[]
+    mergeDistance?: number
+    alignmentDistance?: number
+  }) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.inputTraces = params.traces
+    this.outputTraces = [...params.traces]
+    this.mergeDistance = params.mergeDistance ?? 0.25
+    this.alignmentDistance = params.alignmentDistance ?? 0.08
+    this.originalTraceIds = new Set(
+      params.traces.map((trace) => trace.mspPairId),
+    )
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof TraceSegmentMergeSolver
+  >[0] {
+    return {
+      inputProblem: this.inputProblem,
+      traces: this.inputTraces,
+      mergeDistance: this.mergeDistance,
+      alignmentDistance: this.alignmentDistance,
+    }
+  }
+
+  override _step() {
+    const nextBridge = this.findNextBridgeCandidate()
+
+    if (!nextBridge) {
+      this.solved = true
+      return
+    }
+
+    this.addBridgeTrace(nextBridge)
+  }
+
+  private findNextBridgeCandidate(): BridgeCandidate | null {
+    const originalTraces = this.outputTraces.filter((trace) =>
+      this.originalTraceIds.has(trace.mspPairId),
+    )
+
+    for (let i = 0; i < originalTraces.length; i++) {
+      const traceA = originalTraces[i]!
+      for (let j = i + 1; j < originalTraces.length; j++) {
+        const traceB = originalTraces[j]!
+        if (traceA.globalConnNetId !== traceB.globalConnNetId) continue
+        if (this.bridgedTracePairs.has(this.getTracePairKey(traceA, traceB))) {
+          continue
+        }
+
+        const endpointCandidate = this.findEndpointBridge(traceA, traceB)
+        if (endpointCandidate) return endpointCandidate
+
+        const segmentCandidate = this.findParallelSegmentBridge(traceA, traceB)
+        if (segmentCandidate) return segmentCandidate
+      }
+    }
+
+    return null
+  }
+
+  private findEndpointBridge(
+    traceA: SolvedTracePath,
+    traceB: SolvedTracePath,
+  ): BridgeCandidate | null {
+    const endpointsA = this.getEndpoints(traceA)
+    const endpointsB = this.getEndpoints(traceB)
+
+    for (const endpointA of endpointsA) {
+      for (const endpointB of endpointsB) {
+        if (this.areSamePoint(endpointA.point, endpointB.point)) continue
+        if (!this.arePointsBridgeable(endpointA.point, endpointB.point)) {
+          continue
+        }
+        const candidate = {
+          traceA,
+          traceB,
+          pointA: endpointA.point,
+          pointB: endpointB.point,
+        }
+        if (!this.hasBridge(candidate)) return candidate
+      }
+    }
+
+    return null
+  }
+
+  private findParallelSegmentBridge(
+    traceA: SolvedTracePath,
+    traceB: SolvedTracePath,
+  ): BridgeCandidate | null {
+    const segmentsA = this.getOrthogonalSegments(traceA)
+    const segmentsB = this.getOrthogonalSegments(traceB)
+
+    for (const segmentA of segmentsA) {
+      for (const segmentB of segmentsB) {
+        if (segmentA.orientation !== segmentB.orientation) continue
+
+        const bridgePoints = this.getParallelBridgePoints(segmentA, segmentB)
+        if (!bridgePoints) continue
+        if (this.areSamePoint(bridgePoints.pointA, bridgePoints.pointB)) {
+          continue
+        }
+
+        const candidate = {
+          traceA,
+          traceB,
+          pointA: bridgePoints.pointA,
+          pointB: bridgePoints.pointB,
+        }
+        if (!this.hasBridge(candidate)) return candidate
+      }
+    }
+
+    return null
+  }
+
+  private getEndpoints(trace: SolvedTracePath): TraceEndpoint[] {
+    return [
+      { point: trace.tracePath[0]! },
+      {
+        point: trace.tracePath[trace.tracePath.length - 1]!,
+      },
+    ]
+  }
+
+  private getOrthogonalSegments(trace: SolvedTracePath): OrthogonalSegment[] {
+    const segments: OrthogonalSegment[] = []
+
+    for (let i = 0; i < trace.tracePath.length - 1; i++) {
+      const start = trace.tracePath[i]!
+      const end = trace.tracePath[i + 1]!
+      if (Math.abs(start.y - end.y) <= this.alignmentDistance) {
+        segments.push({
+          start,
+          end,
+          orientation: "horizontal",
+        })
+      } else if (Math.abs(start.x - end.x) <= this.alignmentDistance) {
+        segments.push({
+          start,
+          end,
+          orientation: "vertical",
+        })
+      }
+    }
+
+    return segments
+  }
+
+  private getParallelBridgePoints(
+    segmentA: OrthogonalSegment,
+    segmentB: OrthogonalSegment,
+  ): { pointA: Point; pointB: Point } | null {
+    if (segmentA.orientation === "horizontal") {
+      const yA = (segmentA.start.y + segmentA.end.y) / 2
+      const yB = (segmentB.start.y + segmentB.end.y) / 2
+      if (Math.abs(yA - yB) > this.mergeDistance) return null
+
+      const overlap = this.getRangeOverlap(
+        segmentA.start.x,
+        segmentA.end.x,
+        segmentB.start.x,
+        segmentB.end.x,
+      )
+      if (!overlap) return null
+
+      const x = (overlap[0] + overlap[1]) / 2
+      return {
+        pointA: { x, y: yA },
+        pointB: { x, y: yB },
+      }
+    }
+
+    const xA = (segmentA.start.x + segmentA.end.x) / 2
+    const xB = (segmentB.start.x + segmentB.end.x) / 2
+    if (Math.abs(xA - xB) > this.mergeDistance) return null
+
+    const overlap = this.getRangeOverlap(
+      segmentA.start.y,
+      segmentA.end.y,
+      segmentB.start.y,
+      segmentB.end.y,
+    )
+    if (!overlap) return null
+
+    const y = (overlap[0] + overlap[1]) / 2
+    return {
+      pointA: { x: xA, y },
+      pointB: { x: xB, y },
+    }
+  }
+
+  private getRangeOverlap(
+    a1: number,
+    a2: number,
+    b1: number,
+    b2: number,
+  ): [number, number] | null {
+    const minA = Math.min(a1, a2)
+    const maxA = Math.max(a1, a2)
+    const minB = Math.min(b1, b2)
+    const maxB = Math.max(b1, b2)
+    const start = Math.max(minA, minB)
+    const end = Math.min(maxA, maxB)
+    if (start <= end) return [start, end]
+
+    const gap = start - end
+    if (gap <= this.mergeDistance) return [end, start]
+
+    return null
+  }
+
+  private arePointsBridgeable(pointA: Point, pointB: Point): boolean {
+    const dx = Math.abs(pointA.x - pointB.x)
+    const dy = Math.abs(pointA.y - pointB.y)
+
+    if (dx <= this.alignmentDistance && dy <= this.mergeDistance) return true
+    if (dy <= this.alignmentDistance && dx <= this.mergeDistance) return true
+
+    return dx * dx + dy * dy <= this.mergeDistance * this.mergeDistance
+  }
+
+  private addBridgeTrace(candidate: BridgeCandidate) {
+    const bridgeKey = this.getBridgeKey(candidate)
+    this.bridgeKeys.add(bridgeKey)
+    this.bridgedTracePairs.add(
+      this.getTracePairKey(candidate.traceA, candidate.traceB),
+    )
+
+    const bridgeTrace: SolvedTracePath = {
+      ...candidate.traceA,
+      mspPairId: `trace-segment-merge-${this.bridgeKeys.size}-${candidate.traceA.mspPairId}-${candidate.traceB.mspPairId}`,
+      pins: [candidate.traceA.pins[1], candidate.traceB.pins[0]],
+      tracePath: this.buildBridgePath(candidate.pointA, candidate.pointB),
+      mspConnectionPairIds: Array.from(
+        new Set([
+          ...(candidate.traceA.mspConnectionPairIds ?? [
+            candidate.traceA.mspPairId,
+          ]),
+          ...(candidate.traceB.mspConnectionPairIds ?? [
+            candidate.traceB.mspPairId,
+          ]),
+        ]),
+      ),
+      pinIds: Array.from(
+        new Set([...candidate.traceA.pinIds, ...candidate.traceB.pinIds]),
+      ),
+    }
+
+    this.outputTraces.push(bridgeTrace)
+  }
+
+  private buildBridgePath(pointA: Point, pointB: Point): Point[] {
+    if (
+      Math.abs(pointA.x - pointB.x) <= this.alignmentDistance ||
+      Math.abs(pointA.y - pointB.y) <= this.alignmentDistance
+    ) {
+      return this.dedupeConsecutivePoints([pointA, pointB])
+    }
+
+    return this.dedupeConsecutivePoints([
+      pointA,
+      { x: pointB.x, y: pointA.y },
+      pointB,
+    ])
+  }
+
+  private dedupeConsecutivePoints(points: Point[]): Point[] {
+    return points.filter((point, index) => {
+      const previous = points[index - 1]
+      return !previous || !this.areSamePoint(previous, point)
+    })
+  }
+
+  private hasBridge(candidate: BridgeCandidate): boolean {
+    return (
+      this.bridgeKeys.has(this.getBridgeKey(candidate)) ||
+      this.bridgedTracePairs.has(
+        this.getTracePairKey(candidate.traceA, candidate.traceB),
+      )
+    )
+  }
+
+  private getBridgeKey(candidate: BridgeCandidate): string {
+    const pointKeys = [
+      this.getPointKey(candidate.pointA),
+      this.getPointKey(candidate.pointB),
+    ].sort()
+    const traceIds = [candidate.traceA.mspPairId, candidate.traceB.mspPairId]
+      .sort()
+      .join("|")
+    return `${traceIds}:${pointKeys.join("|")}`
+  }
+
+  private getTracePairKey(
+    traceA: SolvedTracePath,
+    traceB: SolvedTracePath,
+  ): string {
+    return [traceA.mspPairId, traceB.mspPairId].sort().join("|")
+  }
+
+  private getPointKey(point: Point): string {
+    return `${point.x.toFixed(4)},${point.y.toFixed(4)}`
+  }
+
+  private areSamePoint(pointA: Point, pointB: Point): boolean {
+    return (
+      Math.abs(pointA.x - pointB.x) <= 1e-6 &&
+      Math.abs(pointA.y - pointB.y) <= 1e-6
+    )
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics = visualizeInputProblem(this.inputProblem, {
+      chipAlpha: 0.1,
+      connectionAlpha: 0.1,
+    })
+
+    for (const trace of this.outputTraces) {
+      graphics.lines!.push({
+        points: trace.tracePath,
+        strokeColor: this.originalTraceIds.has(trace.mspPairId)
+          ? getColorFromString(trace.globalConnNetId)
+          : "green",
+        strokeWidth: this.originalTraceIds.has(trace.mspPairId) ? 0.02 : 0.04,
+      })
+    }
+
+    return graphics
+  }
+}

--- a/lib/solvers/TraceSegmentMergeSolver/index.ts
+++ b/lib/solvers/TraceSegmentMergeSolver/index.ts
@@ -1,0 +1,1 @@
+export { TraceSegmentMergeSolver } from "./TraceSegmentMergeSolver"

--- a/tests/solvers/TraceSegmentMergeSolver/TraceSegmentMergeSolver.test.ts
+++ b/tests/solvers/TraceSegmentMergeSolver/TraceSegmentMergeSolver.test.ts
@@ -115,3 +115,23 @@ test("TraceSegmentMergeSolver does not bridge different nets", () => {
 
   expect(solver.getOutput().traces).toHaveLength(2)
 })
+
+test("TraceSegmentMergeSolver does not create floating bridges between gapped parallel segments", () => {
+  const solver = new TraceSegmentMergeSolver({
+    inputProblem,
+    traces: [
+      makeTrace("a", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("b", [
+        { x: 1.24, y: 0.12 },
+        { x: 2.2, y: 0.12 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().traces).toHaveLength(2)
+})

--- a/tests/solvers/TraceSegmentMergeSolver/TraceSegmentMergeSolver.test.ts
+++ b/tests/solvers/TraceSegmentMergeSolver/TraceSegmentMergeSolver.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test"
+import { TraceSegmentMergeSolver } from "lib/index"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const inputProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+const makeTrace = (
+  mspPairId: string,
+  tracePath: Array<{ x: number; y: number }>,
+  globalConnNetId = "VCC",
+): SolvedTracePath => {
+  const pins = [
+    {
+      pinId: `${mspPairId}.1`,
+      chipId: `${mspPairId}.chip1`,
+      ...tracePath[0]!,
+    },
+    {
+      pinId: `${mspPairId}.2`,
+      chipId: `${mspPairId}.chip2`,
+      ...tracePath[tracePath.length - 1]!,
+    },
+  ] as SolvedTracePath["pins"]
+
+  return {
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    userNetId: globalConnNetId,
+    pins,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: pins.map((pin) => pin.pinId),
+  }
+}
+
+test("TraceSegmentMergeSolver adds a bridge between close same-net endpoints", () => {
+  const solver = new TraceSegmentMergeSolver({
+    inputProblem,
+    traces: [
+      makeTrace("a", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("b", [
+        { x: 1.12, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const output = solver.getOutput().traces
+  expect(output).toHaveLength(3)
+  expect(output[2]!.mspPairId.startsWith("trace-segment-merge-")).toBe(true)
+  expect(output[2]!.tracePath).toEqual([
+    { x: 1, y: 0 },
+    { x: 1.12, y: 0 },
+  ])
+})
+
+test("TraceSegmentMergeSolver bridges close parallel same-net segments", () => {
+  const solver = new TraceSegmentMergeSolver({
+    inputProblem,
+    traces: [
+      makeTrace("a", [
+        { x: 0, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+      makeTrace("b", [
+        { x: 0.5, y: 0.12 },
+        { x: 1.5, y: 0.12 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const bridge = solver
+    .getOutput()
+    .traces.find((trace) => trace.mspPairId.startsWith("trace-segment-merge-"))
+  expect(bridge?.tracePath).toEqual([
+    { x: 1, y: 0 },
+    { x: 1, y: 0.12 },
+  ])
+})
+
+test("TraceSegmentMergeSolver does not bridge different nets", () => {
+  const solver = new TraceSegmentMergeSolver({
+    inputProblem,
+    traces: [
+      makeTrace("a", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace(
+        "b",
+        [
+          { x: 1.12, y: 0 },
+          { x: 2, y: 0 },
+        ],
+        "GND",
+      ),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().traces).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary
- add `TraceSegmentMergeSolver` to bridge close same-net trace endpoints and nearby parallel trace segments
- insert a conservative merge phase after long-distance pair merging and before trace overlap shifting
- export the solver and cover endpoint, parallel-segment, different-net, and gapped parallel-segment behavior with tests
- avoid floating bridge traces when parallel segments are close but their ranges do not overlap

## Tests
- `npx --yes bun@latest test`
- `npx --yes bun@latest run format:check`
- `npx --yes tsc --noEmit`
- CI: Bun Test, Type Check, Format Check, and Vercel are passing on head `875efe1`

## AI assistance disclosure
This PR was prepared with AI assistance from Codex. I reviewed the implementation path and verification results before submission.

Closes #29
/claim #29