### PR TITLE
Prefer net-label detours with fewer crossings

### DIFF
--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/OverlapAvoidanceStepSolver/OverlapAvoidanceStepSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/OverlapAvoidanceStepSolver/OverlapAvoidanceStepSolver.ts
@@ -150,6 +150,9 @@ export class OverlapAvoidanceStepSolver extends BaseSolver {
             problem: this.inputProblem,
             paddingBuffer: this.PADDING_BUFFER,
             detourCount: detourCount,
+            otherTraces: this.allTraces.filter(
+              (trace) => trace.mspPairId !== traceToFix.mspPairId,
+            ),
           })
         } else {
           const overlapId = `${traceToFix.mspPairId}-${labelToAvoid.globalConnNetId}`
@@ -192,6 +195,9 @@ export class OverlapAvoidanceStepSolver extends BaseSolver {
             problem: this.inputProblem,
             paddingBuffer: this.PADDING_BUFFER,
             detourCount: detourCount,
+            otherTraces: this.allTraces.filter(
+              (trace) => trace.mspPairId !== traceToFix.mspPairId,
+            ),
           })
         } else {
           const overlapId = `${traceToFix.mspPairId}-${labelToAvoid.globalConnNetId}`
@@ -211,6 +217,9 @@ export class OverlapAvoidanceStepSolver extends BaseSolver {
         problem: this.inputProblem,
         paddingBuffer: this.PADDING_BUFFER,
         detourCount: detourCount,
+        otherTraces: this.allTraces.filter(
+          (trace) => trace.mspPairId !== traceToFix.mspPairId,
+        ),
       })
     }
   }

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/SingleOverlapSolver/SingleOverlapSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/SingleOverlapSolver/SingleOverlapSolver.ts
@@ -16,9 +16,76 @@ interface SingleOverlapSolverInput {
   problem: InputProblem
   paddingBuffer: number
   detourCount: number
+  otherTraces?: SolvedTracePath[]
 }
 
 const MAX_TRIES = 5
+
+const EPSILON = 1e-9
+
+const isSamePoint = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) < EPSILON && Math.abs(a.y - b.y) < EPSILON
+
+const orientation = (a: Point, b: Point, c: Point) => {
+  const value = (b.y - a.y) * (c.x - b.x) - (b.x - a.x) * (c.y - b.y)
+  if (Math.abs(value) < EPSILON) return 0
+  return value > 0 ? 1 : 2
+}
+
+const isPointOnSegment = (a: Point, b: Point, c: Point) =>
+  b.x <= Math.max(a.x, c.x) + EPSILON &&
+  b.x + EPSILON >= Math.min(a.x, c.x) &&
+  b.y <= Math.max(a.y, c.y) + EPSILON &&
+  b.y + EPSILON >= Math.min(a.y, c.y)
+
+const segmentsIntersect = (a1: Point, a2: Point, b1: Point, b2: Point) => {
+  if (
+    isSamePoint(a1, b1) ||
+    isSamePoint(a1, b2) ||
+    isSamePoint(a2, b1) ||
+    isSamePoint(a2, b2)
+  ) {
+    return false
+  }
+
+  const o1 = orientation(a1, a2, b1)
+  const o2 = orientation(a1, a2, b2)
+  const o3 = orientation(b1, b2, a1)
+  const o4 = orientation(b1, b2, a2)
+
+  if (o1 !== o2 && o3 !== o4) return true
+
+  return (
+    (o1 === 0 && isPointOnSegment(a1, b1, a2)) ||
+    (o2 === 0 && isPointOnSegment(a1, b2, a2)) ||
+    (o3 === 0 && isPointOnSegment(b1, a1, b2)) ||
+    (o4 === 0 && isPointOnSegment(b1, a2, b2))
+  )
+}
+
+const countTraceCrossings = (
+  candidatePath: Point[],
+  otherTraces: SolvedTracePath[],
+) => {
+  let crossings = 0
+  for (let i = 0; i < candidatePath.length - 1; i++) {
+    for (const otherTrace of otherTraces) {
+      for (let j = 0; j < otherTrace.tracePath.length - 1; j++) {
+        if (
+          segmentsIntersect(
+            candidatePath[i],
+            candidatePath[i + 1],
+            otherTrace.tracePath[j],
+            otherTrace.tracePath[j + 1],
+          )
+        ) {
+          crossings++
+        }
+      }
+    }
+  }
+  return crossings
+}
 
 /**
  * This solver attempts to find a valid rerouting for a single trace that is
@@ -60,9 +127,14 @@ export class SingleOverlapSolver extends BaseSolver {
       return len
     }
 
-    this.queuedCandidatePaths = candidates.sort(
-      (a, b) => getPathLength(a) - getPathLength(b),
-    )
+    const otherTraces = solverInput.otherTraces ?? []
+    this.queuedCandidatePaths = candidates.sort((a, b) => {
+      const crossingDelta =
+        countTraceCrossings(a, otherTraces) -
+        countTraceCrossings(b, otherTraces)
+      if (crossingDelta !== 0) return crossingDelta
+      return getPathLength(a) - getPathLength(b)
+    })
     this.obstacles = getObstacleRects(this.problem)
   }
 

--- a/tests/solvers/TraceLabelOverlapAvoidanceSolver/sub-solver/SingleOverlapSolver_crossings.test.ts
+++ b/tests/solvers/TraceLabelOverlapAvoidanceSolver/sub-solver/SingleOverlapSolver_crossings.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import { SingleOverlapSolver } from "lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/SingleOverlapSolver/SingleOverlapSolver"
+
+const traceToReroute = {
+  mspPairId: "vertical-main",
+  dcConnNetId: "net-a",
+  globalConnNetId: "net-a",
+  userNetId: "A",
+  pins: [
+    { pinId: "A.1", x: 0, y: 0, chipId: "chip-a" },
+    { pinId: "A.2", x: 0, y: 10, chipId: "chip-b" },
+  ],
+  tracePath: [
+    { x: 0, y: 0 },
+    { x: 0, y: 10 },
+  ],
+  mspConnectionPairIds: ["vertical-main"],
+  pinIds: ["A.1", "A.2"],
+}
+
+const crossingTrace = {
+  mspPairId: "right-side-crossing",
+  dcConnNetId: "net-b",
+  globalConnNetId: "net-b",
+  userNetId: "B",
+  pins: [
+    { pinId: "B.1", x: 0.2, y: 5, chipId: "chip-c" },
+    { pinId: "B.2", x: 2, y: 5, chipId: "chip-d" },
+  ],
+  tracePath: [
+    { x: 0.2, y: 5 },
+    { x: 2, y: 5 },
+  ],
+  mspConnectionPairIds: ["right-side-crossing"],
+  pinIds: ["B.1", "B.2"],
+}
+
+test("SingleOverlapSolver prefers detours with fewer crossings", () => {
+  const solver = new SingleOverlapSolver({
+    trace: traceToReroute,
+    label: {
+      globalConnNetId: "blocking-label",
+      netId: "LABEL",
+      mspConnectionPairIds: [],
+      pinIds: [],
+      orientation: "x+",
+      anchorPoint: { x: 0, y: 5 },
+      width: 1,
+      height: 1,
+      center: { x: 0, y: 5 },
+    },
+    problem: {
+      chips: [],
+      directConnections: [],
+      netConnections: [],
+      availableNetLabelOrientations: {},
+      maxMspPairDistance: 20,
+    },
+    paddingBuffer: 0.1,
+    detourCount: 0,
+    otherTraces: [crossingTrace],
+  } as any)
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.solvedTracePath?.some((point) => point.x < 0)).toBe(true)
+  expect(solver.solvedTracePath?.some((point) => point.x > 0.5)).toBe(false)
+})


### PR DESCRIPTION
Fixes #83.

This updates trace-label overlap reroute selection so candidate detours are scored by how many existing trace crossings they introduce before falling back to path length.

Why:

When a trace can detour around a blocking net label on either side, both paths can have the same length. The previous ordering could choose the side that crosses another already-routed trace. This makes the lower-crossing detour win.

Changes:

| Area | Change |
|---|---|
| SingleOverlapSolver | Adds optional otherTraces input and scores candidate paths by crossing count before path length |
| OverlapAvoidanceStepSolver | Passes the other current traces into each SingleOverlapSolver |
| Tests | Adds a regression test where the right-side detour crosses another trace and the left-side detour does not |

Verification:

| Command | Result |
|---|---|
| ..\bun-windows-x64\bun.exe test tests\solvers\TraceLabelOverlapAvoidanceSolver\sub-solver\SingleOverlapSolver_crossings.test.ts | 1 pass |
| ..\bun-windows-x64\bun.exe run format:check | passed |
| ..\bun-windows-x64\bun.exe test | 58 pass, 4 skip, 0 fail |
