### PR TITLE
feat: add SameNetTraceAlignSolver to merge close same-net trace segments

### DIFF
--- a/lib/solvers/SameNetTraceAlignSolver/SameNetTraceAlignSolver.ts
+++ b/lib/solvers/SameNetTraceAlignSolver/SameNetTraceAlignSolver.ts
@@ -44,18 +44,21 @@ export class SameNetTraceAlignSolver extends BaseSolver {
   private netsToProcess: string[] = []
   private tracesByNet: Map<string, SolvedTracePath[]>
   private outputTraces: SolvedTracePath[]
-  private pendingAlignments: Map<string, { orientation: "h" | "v"; alignTo: number }[]>
+  private pendingAlignments: Map<
+    string,
+    { orientation: "h" | "v"; alignTo: number }[]
+  >
 
-  constructor(
-    traces: SolvedTracePath[],
-    proximityThreshold = 0.19
-  ) {
+  constructor(traces: SolvedTracePath[], proximityThreshold = 0.19) {
     super()
     this.traces = traces
     this.proximityThreshold = proximityThreshold
     this.tracesByNet = this._groupTracesByNet(traces)
     this.netsToProcess = Array.from(this.tracesByNet.keys())
-    this.outputTraces = traces.map((t) => ({ ...t, tracePath: t.tracePath.map((p) => ({ ...p })) }))
+    this.outputTraces = traces.map((t) => ({
+      ...t,
+      tracePath: t.tracePath.map((p) => ({ ...p })),
+    }))
     this.pendingAlignments = new Map()
   }
 
@@ -74,7 +77,7 @@ export class SameNetTraceAlignSolver extends BaseSolver {
   }
 
   private _groupTracesByNet(
-    traces: SolvedTracePath[]
+    traces: SolvedTracePath[],
   ): Map<string, SolvedTracePath[]> {
     const groups = new Map<string, SolvedTracePath[]>()
     for (const trace of traces) {
@@ -85,9 +88,7 @@ export class SameNetTraceAlignSolver extends BaseSolver {
     return groups
   }
 
-  private _extractSegments(
-    traces: SolvedTracePath[]
-  ): TraceSegment[] {
+  private _extractSegments(traces: SolvedTracePath[]): TraceSegment[] {
     const segments: TraceSegment[] = []
     for (const trace of traces) {
       for (let i = 0; i < trace.tracePath.length - 1; i++) {
@@ -109,7 +110,7 @@ export class SameNetTraceAlignSolver extends BaseSolver {
 
   private _clusterSegments(
     segments: TraceSegment[],
-    getCoord: (s: TraceSegment) => number
+    getCoord: (s: TraceSegment) => number,
   ): string[][] {
     if (segments.length === 0) return []
     // Stable IDs: unique per call using original array index
@@ -155,7 +156,10 @@ export class SameNetTraceAlignSolver extends BaseSolver {
     const vSegments = segments.filter((s) => !s.isHorizontal)
 
     // Build cluster map: segmentId → cluster
-    const segmentClusterMap = new Map<string, { orient: "h" | "v"; alignTo: number }>()
+    const segmentClusterMap = new Map<
+      string,
+      { orient: "h" | "v"; alignTo: number }
+    >()
 
     const hClusters = this._clusterSegments(hSegments, (s) => s.fixedCoord)
     for (const cluster of hClusters) {
@@ -187,7 +191,9 @@ export class SameNetTraceAlignSolver extends BaseSolver {
       const align = segmentClusterMap.get(segId)
       if (!align) continue
 
-      const outTrace = this.outputTraces.find((t) => t.mspPairId === seg.traceId)
+      const outTrace = this.outputTraces.find(
+        (t) => t.mspPairId === seg.traceId,
+      )
       if (!outTrace) continue
 
       for (const pt of outTrace.tracePath) {

--- a/lib/solvers/SameNetTraceAlignSolver/SameNetTraceAlignSolver.ts
+++ b/lib/solvers/SameNetTraceAlignSolver/SameNetTraceAlignSolver.ts
@@ -1,0 +1,214 @@
+import type { Point } from "@tscircuit/math-utils"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+interface TraceSegment {
+  traceId: string
+  netId: string
+  startPoint: Point
+  endPoint: Point
+  isHorizontal: boolean
+  /** The segment's fixed coordinate: Y for horizontal, X for vertical */
+  fixedCoord: number
+}
+
+interface AlignCluster {
+  orientation: "h" | "v"
+  alignTo: number
+  segmentIds: string[]
+}
+
+/**
+ * SameNetTraceAlignSolver
+ *
+ * Issue #34: "Merge same-net trace lines that are close together
+ * (make at the same Y or same X)"
+ *
+ * Reduces visual clutter by snapping same-net trace segments that are
+ * close together to share the same Y coordinate (for horizontal) or
+ * X coordinate (for vertical).
+ *
+ * Algorithm:
+ * 1. Groups traces by globalConnNetId
+ * 2. Extracts all trace segments from each net
+ * 3. Uses single-linkage clustering on the fixed coordinate
+ *   (Y for horizontal segments, X for vertical segments)
+ *   to find groups that should share a coordinate
+ * 4. Computes average coordinate per cluster and snaps all
+ *   segments to that average
+ */
+export class SameNetTraceAlignSolver extends BaseSolver {
+  private traces: SolvedTracePath[]
+  private proximityThreshold: number
+  private _stepCount = 0
+  private netsToProcess: string[] = []
+  private tracesByNet: Map<string, SolvedTracePath[]>
+  private outputTraces: SolvedTracePath[]
+  private pendingAlignments: Map<string, { orientation: "h" | "v"; alignTo: number }[]>
+
+  constructor(
+    traces: SolvedTracePath[],
+    proximityThreshold = 0.19
+  ) {
+    super()
+    this.traces = traces
+    this.proximityThreshold = proximityThreshold
+    this.tracesByNet = this._groupTracesByNet(traces)
+    this.netsToProcess = Array.from(this.tracesByNet.keys())
+    this.outputTraces = traces.map((t) => ({ ...t, tracePath: t.tracePath.map((p) => ({ ...p })) }))
+    this.pendingAlignments = new Map()
+  }
+
+  override _step() {
+    this._stepCount++
+
+    if (this.netsToProcess.length === 0) {
+      this.solved = true
+      return
+    }
+
+    const netId = this.netsToProcess[0]
+    const traces = this.tracesByNet.get(netId) || []
+    this._computeAndApplyAlignments(netId, traces)
+    this.netsToProcess.shift()
+  }
+
+  private _groupTracesByNet(
+    traces: SolvedTracePath[]
+  ): Map<string, SolvedTracePath[]> {
+    const groups = new Map<string, SolvedTracePath[]>()
+    for (const trace of traces) {
+      const netId = trace.globalConnNetId
+      if (!groups.has(netId)) groups.set(netId, [])
+      groups.get(netId)!.push(trace)
+    }
+    return groups
+  }
+
+  private _extractSegments(
+    traces: SolvedTracePath[]
+  ): TraceSegment[] {
+    const segments: TraceSegment[] = []
+    for (const trace of traces) {
+      for (let i = 0; i < trace.tracePath.length - 1; i++) {
+        const start = trace.tracePath[i]
+        const end = trace.tracePath[i + 1]
+        const isHorizontal = Math.abs(end.y - start.y) < 0.001
+        segments.push({
+          traceId: trace.mspPairId,
+          netId: trace.globalConnNetId,
+          startPoint: start,
+          endPoint: end,
+          isHorizontal,
+          fixedCoord: isHorizontal ? end.y : end.x,
+        })
+      }
+    }
+    return segments
+  }
+
+  private _clusterSegments(
+    segments: TraceSegment[],
+    getCoord: (s: TraceSegment) => number
+  ): string[][] {
+    if (segments.length === 0) return []
+    // Stable IDs: unique per call using original array index
+    const ids = segments.map((_s, i) => String(i))
+    const parent = ids.map((_, i) => i)
+    const coords = segments.map(getCoord)
+
+    const find = (i: number): number => {
+      if (parent[i] !== i) parent[i] = find(parent[i])
+      return parent[i]
+    }
+
+    const union = (i: number, j: number) => {
+      const ri = find(i)
+      const rj = find(j)
+      if (ri !== rj) parent[ri] = rj
+    }
+
+    for (let i = 0; i < segments.length; i++) {
+      for (let j = i + 1; j < segments.length; j++) {
+        if (Math.abs(coords[i] - coords[j]) <= this.proximityThreshold) {
+          union(i, j)
+        }
+      }
+    }
+
+    const clusterMap = new Map<number, string[]>()
+    for (let i = 0; i < segments.length; i++) {
+      const root = find(i)
+      if (!clusterMap.has(root)) clusterMap.set(root, [])
+      clusterMap.get(root)!.push(ids[i])
+    }
+
+    const result = Array.from(clusterMap.values())
+    return result
+  }
+
+  private _computeAndApplyAlignments(netId: string, traces: SolvedTracePath[]) {
+    const segments = this._extractSegments(traces)
+    if (segments.length === 0) return
+
+    const hSegments = segments.filter((s) => s.isHorizontal)
+    const vSegments = segments.filter((s) => !s.isHorizontal)
+
+    // Build cluster map: segmentId → cluster
+    const segmentClusterMap = new Map<string, { orient: "h" | "v"; alignTo: number }>()
+
+    const hClusters = this._clusterSegments(hSegments, (s) => s.fixedCoord)
+    for (const cluster of hClusters) {
+      if (cluster.length < 2) continue
+      const segs = cluster.map((id) => hSegments[parseInt(id)])
+      const avgY = segs.reduce((sum, s) => sum + s.fixedCoord, 0) / segs.length
+      for (const id of cluster) {
+        segmentClusterMap.set(id, { orient: "h", alignTo: avgY })
+      }
+    }
+
+    const vClusters = this._clusterSegments(vSegments, (s) => s.fixedCoord)
+    for (const cluster of vClusters) {
+      if (cluster.length < 2) continue
+      const segs = cluster.map((id) => vSegments[parseInt(id)])
+      const avgX = segs.reduce((sum, s) => sum + s.fixedCoord, 0) / segs.length
+      for (const id of cluster) {
+        segmentClusterMap.set(id, { orient: "v", alignTo: avgX })
+      }
+    }
+
+    if (segmentClusterMap.size === 0) return
+
+    // Apply to output traces
+    const allSegs = this._extractSegments(traces)
+    for (const seg of allSegs) {
+      const segIdx = allSegs.indexOf(seg)
+      const segId = String(segIdx)
+      const align = segmentClusterMap.get(segId)
+      if (!align) continue
+
+      const outTrace = this.outputTraces.find((t) => t.mspPairId === seg.traceId)
+      if (!outTrace) continue
+
+      for (const pt of outTrace.tracePath) {
+        const atStart =
+          Math.abs(pt.x - seg.startPoint.x) < 0.001 &&
+          Math.abs(pt.y - seg.startPoint.y) < 0.001
+        const atEnd =
+          Math.abs(pt.x - seg.endPoint.x) < 0.001 &&
+          Math.abs(pt.y - seg.endPoint.y) < 0.001
+        if (!atStart && !atEnd) continue
+
+        if (align.orient === "h") {
+          pt.y = align.alignTo
+        } else {
+          pt.x = align.alignTo
+        }
+      }
+    }
+  }
+
+  getOutput(): { traces: SolvedTracePath[] } {
+    return { traces: this.outputTraces }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceAlignSolver } from "../SameNetTraceAlignSolver/SameNetTraceAlignSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -80,6 +81,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
   traceAnchoredNetLabelOverlapSolver?: TraceAnchoredNetLabelOverlapSolver
   netLabelTraceCollisionSolver?: NetLabelTraceCollisionSolver
+  sameNetTraceAlignSolver?: SameNetTraceAlignSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -217,6 +219,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
         },
       ]
     }),
+    // Issue #34: align same-net traces that are close together to same X or Y
+    definePipelineStep(
+      "sameNetTraceAlignSolver",
+      SameNetTraceAlignSolver,
+      (instance) => {
+        const traces =
+          instance.traceCleanupSolver?.getOutput().traces ??
+          instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
+        return [traces]
+      },
+      {
+        onSolved: (_solver) => {},
+      },
+    ),
     definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,

--- a/tests/solvers/SameNetTraceAlignSolver/same-net-trace-align-solver.test.ts
+++ b/tests/solvers/SameNetTraceAlignSolver/same-net-trace-align-solver.test.ts
@@ -5,7 +5,7 @@ import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/Sche
 function makeTrace(
   mspPairId: string,
   globalConnNetId: string,
-  path: { x: number; y: number }[]
+  path: { x: number; y: number }[],
 ): SolvedTracePath {
   return {
     mspPairId,

--- a/tests/solvers/SameNetTraceAlignSolver/same-net-trace-align-solver.test.ts
+++ b/tests/solvers/SameNetTraceAlignSolver/same-net-trace-align-solver.test.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "bun:test"
+import { SameNetTraceAlignSolver } from "../../../lib/solvers/SameNetTraceAlignSolver/SameNetTraceAlignSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+function makeTrace(
+  mspPairId: string,
+  globalConnNetId: string,
+  path: { x: number; y: number }[]
+): SolvedTracePath {
+  return {
+    mspPairId,
+    globalConnNetId,
+    tracePath: path,
+    inputProblem: { chips: [], pins: [], ports: [] },
+  } as any
+}
+
+test("SameNetTraceAlignSolver aligns two horizontal segments close in Y", () => {
+  // Two simple horizontal traces in same net, endpoints at Y=1.0 and Y=1.1 (diff=0.1, within threshold 0.19)
+  const traces: SolvedTracePath[] = [
+    makeTrace("trace-a", "net-1", [
+      { x: 0, y: 1.0 },
+      { x: 5, y: 1.0 },
+    ]),
+    makeTrace("trace-b", "net-1", [
+      { x: 10, y: 1.1 },
+      { x: 15, y: 1.1 },
+    ]),
+  ]
+
+  const solver = new SameNetTraceAlignSolver(traces, 0.19)
+  while (!solver.solved) solver.step()
+
+  const output = solver.getOutput()
+  const y0 = output.traces[0].tracePath[0].y
+  const y1 = output.traces[1].tracePath[0].y
+
+  // Both should align to average ≈ 1.05
+  expect(Math.abs(y0 - y1)).toBeLessThan(0.01)
+  expect(Math.abs(y0 - 1.05)).toBeLessThan(0.01)
+})
+
+test("SameNetTraceAlignSolver aligns two vertical segments close in X", () => {
+  // Two simple vertical traces in same net, endpoints at X=2.0 and X=2.08 (diff=0.08, within threshold 0.19)
+  const traces: SolvedTracePath[] = [
+    makeTrace("trace-a", "net-1", [
+      { x: 2.0, y: 0 },
+      { x: 2.0, y: 5 },
+    ]),
+    makeTrace("trace-b", "net-1", [
+      { x: 2.08, y: 10 },
+      { x: 2.08, y: 15 },
+    ]),
+  ]
+
+  const solver = new SameNetTraceAlignSolver(traces, 0.19)
+  while (!solver.solved) solver.step()
+
+  const output = solver.getOutput()
+  const x0 = output.traces[0].tracePath[0].x
+  const x1 = output.traces[1].tracePath[0].x
+
+  // Both should align to average ≈ 2.04
+  expect(Math.abs(x0 - x1)).toBeLessThan(0.01)
+  expect(Math.abs(x0 - 2.04)).toBeLessThan(0.01)
+})
+
+test("SameNetTraceAlignSolver does NOT align segments far apart", () => {
+  // Two horizontal traces at Y=1.0 and Y=5.0 (diff=4.0, OUTSIDE threshold)
+  const traces: SolvedTracePath[] = [
+    makeTrace("trace-a", "net-1", [
+      { x: 0, y: 1.0 },
+      { x: 5, y: 1.0 },
+    ]),
+    makeTrace("trace-b", "net-1", [
+      { x: 10, y: 5.0 },
+      { x: 15, y: 5.0 },
+    ]),
+  ]
+
+  const solver = new SameNetTraceAlignSolver(traces, 0.19)
+  while (!solver.solved) solver.step()
+
+  const output = solver.getOutput()
+  const y0 = output.traces[0].tracePath[0].y
+  const y1 = output.traces[1].tracePath[0].y
+
+  // Should NOT be aligned (difference should be ~4.0)
+  expect(Math.abs(y0 - y1)).toBeGreaterThan(1.0)
+})
+
+test("SameNetTraceAlignSolver does not touch different nets", () => {
+  // Two horizontal traces in DIFFERENT nets at Y=1.0 and Y=1.1 (close but different nets)
+  const traces: SolvedTracePath[] = [
+    makeTrace("trace-a", "net-1", [
+      { x: 0, y: 1.0 },
+      { x: 5, y: 1.0 },
+    ]),
+    makeTrace("trace-b", "net-2", [
+      { x: 10, y: 1.1 },
+      { x: 15, y: 1.1 },
+    ]),
+  ]
+
+  const solver = new SameNetTraceAlignSolver(traces, 0.19)
+  while (!solver.solved) solver.step()
+
+  const output = solver.getOutput()
+  const y0 = output.traces[0].tracePath[0].y
+  const y1 = output.traces[1].tracePath[0].y
+
+  // Should NOT be aligned because different nets
+  expect(Math.abs(y0 - y1)).toBeGreaterThan(0.01)
+})


### PR DESCRIPTION
Closes #34

---

This PR implements SameNetTraceAlignSolver that aligns same-net trace segments which are close together.

## Algorithm
- Groups traces by `globalConnNetId`
- Extracts horizontal and vertical segments per net
- Single-linkage clustering by fixed coordinate (Y for horizontal, X for vertical)
- Computes average coordinate per cluster and snaps all segments to that average

## Effect
Reduces visual zig-zag in schematics by aligning nearby same-net trace segments.

## Testing
- 4 new tests added, all pass
- Full test suite: 61 pass, 4 skip, 0 fail

## Pipeline Integration
Added to `SchematicTracePipelineSolver` after `traceCleanupSolver`.