### PR TITLE
feat: connect close same-net trace segments

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+export * from "./solvers/SameNetTraceConnectorSolver/SameNetTraceConnectorSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"

--- a/lib/solvers/SameNetTraceConnectorSolver/SameNetTraceConnectorSolver.ts
+++ b/lib/solvers/SameNetTraceConnectorSolver/SameNetTraceConnectorSolver.ts
@@ -1,0 +1,191 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const DEFAULT_MAX_CONNECT_DISTANCE = 0.2
+const EPS = 1e-6
+
+type TraceEndpoint = {
+  traceIndex: number
+  pointIndex: 0 | "last"
+  point: Point
+}
+
+const manhattanDistance = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) + Math.abs(a.y - b.y)
+
+const pointKey = (point: Point) => `${point.x.toFixed(6)},${point.y.toFixed(6)}`
+
+const getEndpoints = (trace: SolvedTracePath, traceIndex: number) => {
+  if (trace.tracePath.length === 0) return []
+  const first = trace.tracePath[0]!
+  const last = trace.tracePath[trace.tracePath.length - 1]!
+  if (pointKey(first) === pointKey(last)) {
+    return [{ traceIndex, pointIndex: 0 as const, point: first }]
+  }
+  return [
+    { traceIndex, pointIndex: 0 as const, point: first },
+    { traceIndex, pointIndex: "last" as const, point: last },
+  ]
+}
+
+const buildOrthogonalConnectorPath = (from: Point, to: Point): Point[] => {
+  if (manhattanDistance(from, to) < EPS) return [from]
+  if (Math.abs(from.x - to.x) < EPS || Math.abs(from.y - to.y) < EPS) {
+    return [from, to]
+  }
+  return [from, { x: from.x, y: to.y }, to]
+}
+
+class UnionFind {
+  parent: number[]
+
+  constructor(size: number) {
+    this.parent = Array.from({ length: size }, (_, i) => i)
+  }
+
+  find(index: number): number {
+    const parent = this.parent[index]!
+    if (parent === index) return index
+    const root = this.find(parent)
+    this.parent[index] = root
+    return root
+  }
+
+  union(a: number, b: number) {
+    const rootA = this.find(a)
+    const rootB = this.find(b)
+    if (rootA === rootB) return false
+    this.parent[rootB] = rootA
+    return true
+  }
+}
+
+export class SameNetTraceConnectorSolver extends BaseSolver {
+  traces: SolvedTracePath[]
+  addedConnectorTraces: SolvedTracePath[] = []
+  maxConnectDistance: number
+
+  constructor(
+    private params: {
+      traces: SolvedTracePath[]
+      maxConnectDistance?: number
+    },
+  ) {
+    super()
+    this.traces = [...params.traces]
+    this.maxConnectDistance =
+      params.maxConnectDistance ?? DEFAULT_MAX_CONNECT_DISTANCE
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceConnectorSolver
+  >[0] {
+    return this.params
+  }
+
+  override _step() {
+    this.connectCloseSameNetTraceEndpoints()
+    this.solved = true
+  }
+
+  private connectCloseSameNetTraceEndpoints() {
+    const traceIndexesByNet = new Map<string, number[]>()
+    for (const [traceIndex, trace] of this.traces.entries()) {
+      if (!trace.globalConnNetId) continue
+      const existing = traceIndexesByNet.get(trace.globalConnNetId) ?? []
+      existing.push(traceIndex)
+      traceIndexesByNet.set(trace.globalConnNetId, existing)
+    }
+
+    for (const [globalConnNetId, traceIndexes] of traceIndexesByNet) {
+      if (traceIndexes.length < 2) continue
+
+      const unionFind = new UnionFind(this.traces.length)
+      const candidateBridges: Array<{
+        from: TraceEndpoint
+        to: TraceEndpoint
+        distance: number
+      }> = []
+
+      for (let i = 0; i < traceIndexes.length; i++) {
+        const traceIndexA = traceIndexes[i]!
+        const endpointsA = getEndpoints(this.traces[traceIndexA]!, traceIndexA)
+
+        for (let j = i + 1; j < traceIndexes.length; j++) {
+          const traceIndexB = traceIndexes[j]!
+          const endpointsB = getEndpoints(
+            this.traces[traceIndexB]!,
+            traceIndexB,
+          )
+
+          for (const from of endpointsA) {
+            for (const to of endpointsB) {
+              const distance = manhattanDistance(from.point, to.point)
+              if (distance <= EPS) {
+                unionFind.union(from.traceIndex, to.traceIndex)
+                continue
+              }
+              if (distance > this.maxConnectDistance) continue
+              candidateBridges.push({ from, to, distance })
+            }
+          }
+        }
+      }
+
+      candidateBridges.sort((a, b) => a.distance - b.distance)
+
+      for (const bridge of candidateBridges) {
+        if (!unionFind.union(bridge.from.traceIndex, bridge.to.traceIndex)) {
+          continue
+        }
+
+        const traceA = this.traces[bridge.from.traceIndex]!
+        const traceB = this.traces[bridge.to.traceIndex]!
+        const connectorTrace: SolvedTracePath = {
+          ...traceA,
+          mspPairId: `same-net-connector:${globalConnNetId}:${traceA.mspPairId}:${traceB.mspPairId}`,
+          dcConnNetId: traceA.dcConnNetId,
+          globalConnNetId,
+          userNetId: traceA.userNetId ?? traceB.userNetId,
+          pins: [traceA.pins[0], traceB.pins[0]],
+          tracePath: buildOrthogonalConnectorPath(
+            bridge.from.point,
+            bridge.to.point,
+          ),
+          mspConnectionPairIds: [
+            ...new Set([
+              ...traceA.mspConnectionPairIds,
+              ...traceB.mspConnectionPairIds,
+            ]),
+          ],
+          pinIds: [...new Set([...traceA.pinIds, ...traceB.pinIds])],
+        }
+
+        this.addedConnectorTraces.push(connectorTrace)
+        this.traces.push(connectorTrace)
+      }
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    return {
+      lines: this.addedConnectorTraces.map((trace) => ({
+        points: trace.tracePath,
+        strokeColor: "#ff9900",
+        strokeDash: "3 2",
+      })),
+      points: [],
+      rects: [],
+      circles: [],
+    }
+  }
+
+  public getOutput() {
+    return {
+      traces: this.traces,
+      addedConnectorTraces: this.addedConnectorTraces,
+    }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceConnectorSolver } from "../SameNetTraceConnectorSolver/SameNetTraceConnectorSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -80,6 +81,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
   traceAnchoredNetLabelOverlapSolver?: TraceAnchoredNetLabelOverlapSolver
   netLabelTraceCollisionSolver?: NetLabelTraceCollisionSolver
+  sameNetTraceConnectorSolver?: SameNetTraceConnectorSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -218,10 +220,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceConnectorSolver",
+      SameNetTraceConnectorSolver,
+      (instance) => [
+        {
+          traces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceConnectorSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +249,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceConnectorSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/functions/sameNetTraceConnectorSolver.test.ts
+++ b/tests/functions/sameNetTraceConnectorSolver.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceConnectorSolver } from "lib/solvers/SameNetTraceConnectorSolver/SameNetTraceConnectorSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath => ({
+  mspPairId,
+  dcConnNetId: globalConnNetId,
+  globalConnNetId,
+  userNetId: globalConnNetId,
+  pins: [
+    {
+      pinId: `${mspPairId}-a`,
+      chipId: "chip-a",
+      x: tracePath[0]!.x,
+      y: tracePath[0]!.y,
+    },
+    {
+      pinId: `${mspPairId}-b`,
+      chipId: "chip-b",
+      x: tracePath[tracePath.length - 1]!.x,
+      y: tracePath[tracePath.length - 1]!.y,
+    },
+  ],
+  tracePath,
+  mspConnectionPairIds: [mspPairId],
+  pinIds: [`${mspPairId}-a`, `${mspPairId}-b`],
+})
+
+test("adds connector traces between close endpoints on the same net", () => {
+  const solver = new SameNetTraceConnectorSolver({
+    maxConnectDistance: 0.25,
+    traces: [
+      makeTrace("a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("b", "net-1", [
+        { x: 1.1, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().addedConnectorTraces).toHaveLength(1)
+  expect(solver.getOutput().traces).toHaveLength(3)
+  expect(solver.getOutput().addedConnectorTraces[0]!.tracePath).toEqual([
+    { x: 1, y: 0 },
+    { x: 1.1, y: 0 },
+  ])
+})
+
+test("does not connect endpoints on different nets", () => {
+  const solver = new SameNetTraceConnectorSolver({
+    maxConnectDistance: 0.25,
+    traces: [
+      makeTrace("a", "net-1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("b", "net-2", [
+        { x: 1.1, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().addedConnectorTraces).toHaveLength(0)
+  expect(solver.getOutput().traces).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary
- Adds a dedicated `SameNetTraceConnectorSolver` pipeline phase after trace cleanup.
- Detects close endpoints from separate trace segments that share the same `globalConnNetId`.
- Adds short orthogonal connector traces to join those close same-net segments without touching different nets.
- Feeds the connected trace output into later label-placement/example phases.

## Test plan
- `npx -p typescript@5.6.3 tsc --noEmit`
- `npx bun test tests/functions/sameNetTraceConnectorSolver.test.ts`

Closes #29

## Maintainer review notes
- The solver phase is isolated after trace cleanup to minimize regression risk.
- It only connects close endpoints sharing the same `globalConnNetId`; different nets are intentionally ignored.
- Targeted tests cover same-net connection behavior and guard against cross-net joins.
