### PR TITLE
feat: graph-based trace consolidation for combining same-net segments

### DIFF
--- a/lib/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.ts
+++ b/lib/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.ts
@@ -70,7 +70,7 @@ export interface CombineSameNetTraceSegmentsPhaseParams {
 /**
  * Graph-based trace consolidation phase that combines same-net trace segments
  * that are close together using spatial clustering and graph contraction.
- * 
+ *
  * Algorithm:
  * 1. Build a graph from trace segments - nodes are points, edges are segments
  * 2. Spatial clustering using distance threshold to find mergeable nodes
@@ -110,8 +110,14 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
   /**
    * Build graph from traces, grouping by net
    */
-  private buildGraphByNet(): Map<string, { nodes: Map<string, GraphNode>, edges: GraphEdge[] }> {
-    const netGraphs = new Map<string, { nodes: Map<string, GraphNode>, edges: GraphEdge[] }>()
+  private buildGraphByNet(): Map<
+    string,
+    { nodes: Map<string, GraphNode>; edges: GraphEdge[] }
+  > {
+    const netGraphs = new Map<
+      string,
+      { nodes: Map<string, GraphNode>; edges: GraphEdge[] }
+    >()
 
     for (const trace of this.inputTraces) {
       const netId = trace.globalConnNetId
@@ -124,7 +130,7 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
       for (let i = 0; i < trace.tracePath.length; i++) {
         const point = trace.tracePath[i]
         const key = this.pointToKey(point)
-        
+
         if (!graph.nodes.has(key)) {
           const isPinEndpoint = i === 0 || i === trace.tracePath.length - 1
           graph.nodes.set(key, {
@@ -156,7 +162,7 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
    */
   private clusterAndMergeNodes(
     nodes: Map<string, GraphNode>,
-    threshold: number
+    threshold: number,
   ): Map<string, string> {
     const uf = new UnionFind()
     const nodeList = Array.from(nodes.values())
@@ -171,7 +177,7 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
       for (let j = i + 1; j < nodeList.length; j++) {
         const n1 = nodeList[i]
         const n2 = nodeList[j]
-        
+
         // Don't merge pin endpoints with other pin endpoints
         if (n1.isPinEndpoint && n2.isPinEndpoint) {
           continue
@@ -197,7 +203,7 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
    */
   private deduplicateEdges(
     edges: GraphEdge[],
-    nodeMapping: Map<string, string>
+    nodeMapping: Map<string, string>,
   ): GraphEdge[] {
     const edgeSet = new Set<string>()
     const uniqueEdges: GraphEdge[] = []
@@ -211,7 +217,7 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
 
       // Create canonical edge key (sorted to handle bidirectional)
       const edgeKey = from < to ? `${from}->${to}` : `${to}->${from}`
-      
+
       if (!edgeSet.has(edgeKey)) {
         edgeSet.add(edgeKey)
         uniqueEdges.push({ from, to, netId: edge.netId })
@@ -227,7 +233,7 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
   private getRepresentativePoint(
     nodeId: string,
     nodes: Map<string, GraphNode>,
-    nodeMapping: Map<string, string>
+    nodeMapping: Map<string, string>,
   ): Point {
     // Find all nodes that map to this representative
     const clusterNodes: GraphNode[] = []
@@ -245,7 +251,7 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
     }
 
     // Prefer pin endpoints
-    const pinNode = clusterNodes.find(n => n.isPinEndpoint)
+    const pinNode = clusterNodes.find((n) => n.isPinEndpoint)
     if (pinNode) return pinNode.point
 
     // Otherwise, use centroid
@@ -264,14 +270,14 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
     nodes: Map<string, GraphNode>,
     edges: GraphEdge[],
     nodeMapping: Map<string, string>,
-    netId: string
+    netId: string,
   ): SolvedTracePath[] {
     // Build adjacency list
     const adjacency = new Map<string, Set<string>>()
     for (const edge of edges) {
       const from = nodeMapping.get(edge.from) ?? edge.from
       const to = nodeMapping.get(edge.to) ?? edge.to
-      
+
       if (!adjacency.has(from)) adjacency.set(from, new Set())
       if (!adjacency.has(to)) adjacency.set(to, new Set())
       adjacency.get(from)!.add(to)
@@ -309,8 +315,8 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
         // BFS to find path
         const path = this.findPath(startRep, endRep, adjacency, visited)
         if (path.length > 0) {
-          const tracePath = path.map(nodeId => 
-            this.getRepresentativePoint(nodeId, nodes, nodeMapping)
+          const tracePath = path.map((nodeId) =>
+            this.getRepresentativePoint(nodeId, nodes, nodeMapping),
           )
 
           paths.push({
@@ -318,7 +324,12 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
             dcConnNetId: netId,
             globalConnNetId: netId,
             pins: [
-              { pinId: start.pinId!, x: start.point.x, y: start.point.y, chipId: "" },
+              {
+                pinId: start.pinId!,
+                x: start.point.x,
+                y: start.point.y,
+                chipId: "",
+              },
               { pinId: end.pinId!, x: end.point.x, y: end.point.y, chipId: "" },
             ],
             tracePath,
@@ -328,9 +339,10 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
 
           // Mark edges as visited
           for (let k = 0; k < path.length - 1; k++) {
-            const edgeKey = path[k] < path[k + 1] 
-              ? `${path[k]}-${path[k + 1]}`
-              : `${path[k + 1]}-${path[k]}`
+            const edgeKey =
+              path[k] < path[k + 1]
+                ? `${path[k]}-${path[k + 1]}`
+                : `${path[k + 1]}-${path[k]}`
             visited.add(edgeKey)
           }
         }
@@ -347,9 +359,11 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
     start: string,
     end: string,
     adjacency: Map<string, Set<string>>,
-    visitedEdges: Set<string>
+    visitedEdges: Set<string>,
   ): string[] {
-    const queue: { node: string, path: string[] }[] = [{ node: start, path: [start] }]
+    const queue: { node: string; path: string[] }[] = [
+      { node: start, path: [start] },
+    ]
     const visited = new Set<string>([start])
 
     while (queue.length > 0) {
@@ -361,8 +375,9 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
 
       const neighbors = adjacency.get(node) ?? new Set()
       for (const neighbor of neighbors) {
-        const edgeKey = node < neighbor ? `${node}-${neighbor}` : `${neighbor}-${node}`
-        
+        const edgeKey =
+          node < neighbor ? `${node}-${neighbor}` : `${neighbor}-${node}`
+
         if (!visited.has(neighbor) && !visitedEdges.has(edgeKey)) {
           visited.add(neighbor)
           queue.push({ node: neighbor, path: [...path, neighbor] })
@@ -380,13 +395,21 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
     // Process each net independently
     for (const [netId, graph] of netGraphs.entries()) {
       // Cluster and merge nodes
-      const nodeMapping = this.clusterAndMergeNodes(graph.nodes, this.mergeThreshold)
+      const nodeMapping = this.clusterAndMergeNodes(
+        graph.nodes,
+        this.mergeThreshold,
+      )
 
       // Deduplicate edges
       const uniqueEdges = this.deduplicateEdges(graph.edges, nodeMapping)
 
       // Reconstruct paths
-      const paths = this.reconstructPaths(graph.nodes, uniqueEdges, nodeMapping, netId)
+      const paths = this.reconstructPaths(
+        graph.nodes,
+        uniqueEdges,
+        nodeMapping,
+        netId,
+      )
       this.outputTraces.push(...paths)
     }
 
@@ -407,7 +430,10 @@ export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
       })
 
       // Mark endpoints
-      for (const point of [trace.tracePath[0], trace.tracePath[trace.tracePath.length - 1]]) {
+      for (const point of [
+        trace.tracePath[0],
+        trace.tracePath[trace.tracePath.length - 1],
+      ]) {
         graphics.circles.push({
           center: point,
           radius: 0.05,

--- a/lib/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.ts
+++ b/lib/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.ts
@@ -1,0 +1,421 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { GraphicsObject } from "graphics-debug"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+
+/**
+ * Simple Union-Find data structure for graph contraction
+ */
+class UnionFind {
+  private parent: Map<string, string> = new Map()
+  private rank: Map<string, number> = new Map()
+
+  find(x: string): string {
+    if (!this.parent.has(x)) {
+      this.parent.set(x, x)
+      this.rank.set(x, 0)
+      return x
+    }
+    const p = this.parent.get(x)!
+    if (p !== x) {
+      this.parent.set(x, this.find(p))
+    }
+    return this.parent.get(x)!
+  }
+
+  union(x: string, y: string): void {
+    const rootX = this.find(x)
+    const rootY = this.find(y)
+    if (rootX === rootY) return
+
+    const rankX = this.rank.get(rootX) ?? 0
+    const rankY = this.rank.get(rootY) ?? 0
+
+    if (rankX < rankY) {
+      this.parent.set(rootX, rootY)
+    } else if (rankX > rankY) {
+      this.parent.set(rootY, rootX)
+    } else {
+      this.parent.set(rootY, rootX)
+      this.rank.set(rootX, rankX + 1)
+    }
+  }
+}
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface GraphNode {
+  id: string
+  point: Point
+  isPinEndpoint: boolean
+  pinId?: string
+}
+
+interface GraphEdge {
+  from: string
+  to: string
+  netId: string
+}
+
+export interface CombineSameNetTraceSegmentsPhaseParams {
+  inputProblem: InputProblem
+  traces: SolvedTracePath[]
+  mergeThreshold?: number
+}
+
+/**
+ * Graph-based trace consolidation phase that combines same-net trace segments
+ * that are close together using spatial clustering and graph contraction.
+ * 
+ * Algorithm:
+ * 1. Build a graph from trace segments - nodes are points, edges are segments
+ * 2. Spatial clustering using distance threshold to find mergeable nodes
+ * 3. Graph contraction using union-find to merge equivalent nodes
+ * 4. Edge deduplication to remove redundant parallel edges
+ * 5. Path reconstruction to generate minimal SolvedTracePath objects
+ */
+export class CombineSameNetTraceSegmentsPhase extends BaseSolver {
+  inputProblem: InputProblem
+  inputTraces: SolvedTracePath[]
+  outputTraces: SolvedTracePath[] = []
+  mergeThreshold: number
+
+  constructor(params: CombineSameNetTraceSegmentsPhaseParams) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.inputTraces = params.traces
+    this.mergeThreshold = params.mergeThreshold ?? 0.1
+  }
+
+  override getConstructorParams(): CombineSameNetTraceSegmentsPhaseParams {
+    return {
+      inputProblem: this.inputProblem,
+      traces: this.inputTraces,
+      mergeThreshold: this.mergeThreshold,
+    }
+  }
+
+  private pointToKey(p: Point): string {
+    return `${p.x.toFixed(6)},${p.y.toFixed(6)}`
+  }
+
+  private distance(p1: Point, p2: Point): number {
+    return Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2)
+  }
+
+  /**
+   * Build graph from traces, grouping by net
+   */
+  private buildGraphByNet(): Map<string, { nodes: Map<string, GraphNode>, edges: GraphEdge[] }> {
+    const netGraphs = new Map<string, { nodes: Map<string, GraphNode>, edges: GraphEdge[] }>()
+
+    for (const trace of this.inputTraces) {
+      const netId = trace.globalConnNetId
+      if (!netGraphs.has(netId)) {
+        netGraphs.set(netId, { nodes: new Map(), edges: [] })
+      }
+      const graph = netGraphs.get(netId)!
+
+      // Add nodes and edges from this trace
+      for (let i = 0; i < trace.tracePath.length; i++) {
+        const point = trace.tracePath[i]
+        const key = this.pointToKey(point)
+        
+        if (!graph.nodes.has(key)) {
+          const isPinEndpoint = i === 0 || i === trace.tracePath.length - 1
+          graph.nodes.set(key, {
+            id: key,
+            point: { x: point.x, y: point.y },
+            isPinEndpoint,
+            pinId: isPinEndpoint ? trace.pinIds[i === 0 ? 0 : 1] : undefined,
+          })
+        }
+
+        // Add edge to next point
+        if (i < trace.tracePath.length - 1) {
+          const nextPoint = trace.tracePath[i + 1]
+          const nextKey = this.pointToKey(nextPoint)
+          graph.edges.push({
+            from: key,
+            to: nextKey,
+            netId,
+          })
+        }
+      }
+    }
+
+    return netGraphs
+  }
+
+  /**
+   * Perform spatial clustering and merge close nodes using union-find
+   */
+  private clusterAndMergeNodes(
+    nodes: Map<string, GraphNode>,
+    threshold: number
+  ): Map<string, string> {
+    const uf = new UnionFind()
+    const nodeList = Array.from(nodes.values())
+
+    // Initialize all nodes in union-find
+    for (const node of nodeList) {
+      uf.find(node.id)
+    }
+
+    // Find pairs of nodes within threshold distance
+    for (let i = 0; i < nodeList.length; i++) {
+      for (let j = i + 1; j < nodeList.length; j++) {
+        const n1 = nodeList[i]
+        const n2 = nodeList[j]
+        
+        // Don't merge pin endpoints with other pin endpoints
+        if (n1.isPinEndpoint && n2.isPinEndpoint) {
+          continue
+        }
+
+        if (this.distance(n1.point, n2.point) <= threshold) {
+          uf.union(n1.id, n2.id)
+        }
+      }
+    }
+
+    // Build mapping from old node ID to representative node ID
+    const nodeMapping = new Map<string, string>()
+    for (const node of nodeList) {
+      nodeMapping.set(node.id, uf.find(node.id))
+    }
+
+    return nodeMapping
+  }
+
+  /**
+   * Deduplicate edges after node merging
+   */
+  private deduplicateEdges(
+    edges: GraphEdge[],
+    nodeMapping: Map<string, string>
+  ): GraphEdge[] {
+    const edgeSet = new Set<string>()
+    const uniqueEdges: GraphEdge[] = []
+
+    for (const edge of edges) {
+      const from = nodeMapping.get(edge.from) ?? edge.from
+      const to = nodeMapping.get(edge.to) ?? edge.to
+
+      // Skip self-loops
+      if (from === to) continue
+
+      // Create canonical edge key (sorted to handle bidirectional)
+      const edgeKey = from < to ? `${from}->${to}` : `${to}->${from}`
+      
+      if (!edgeSet.has(edgeKey)) {
+        edgeSet.add(edgeKey)
+        uniqueEdges.push({ from, to, netId: edge.netId })
+      }
+    }
+
+    return uniqueEdges
+  }
+
+  /**
+   * Get the representative point for a merged node cluster
+   */
+  private getRepresentativePoint(
+    nodeId: string,
+    nodes: Map<string, GraphNode>,
+    nodeMapping: Map<string, string>
+  ): Point {
+    // Find all nodes that map to this representative
+    const clusterNodes: GraphNode[] = []
+    for (const [originalId, repId] of nodeMapping.entries()) {
+      if (repId === nodeId) {
+        const node = nodes.get(originalId)
+        if (node) clusterNodes.push(node)
+      }
+    }
+
+    if (clusterNodes.length === 0) {
+      // Fallback to the node itself
+      const node = nodes.get(nodeId)
+      return node ? node.point : { x: 0, y: 0 }
+    }
+
+    // Prefer pin endpoints
+    const pinNode = clusterNodes.find(n => n.isPinEndpoint)
+    if (pinNode) return pinNode.point
+
+    // Otherwise, use centroid
+    const sumX = clusterNodes.reduce((sum, n) => sum + n.point.x, 0)
+    const sumY = clusterNodes.reduce((sum, n) => sum + n.point.y, 0)
+    return {
+      x: sumX / clusterNodes.length,
+      y: sumY / clusterNodes.length,
+    }
+  }
+
+  /**
+   * Reconstruct paths from the contracted graph
+   */
+  private reconstructPaths(
+    nodes: Map<string, GraphNode>,
+    edges: GraphEdge[],
+    nodeMapping: Map<string, string>,
+    netId: string
+  ): SolvedTracePath[] {
+    // Build adjacency list
+    const adjacency = new Map<string, Set<string>>()
+    for (const edge of edges) {
+      const from = nodeMapping.get(edge.from) ?? edge.from
+      const to = nodeMapping.get(edge.to) ?? edge.to
+      
+      if (!adjacency.has(from)) adjacency.set(from, new Set())
+      if (!adjacency.has(to)) adjacency.set(to, new Set())
+      adjacency.get(from)!.add(to)
+      adjacency.get(to)!.add(from)
+    }
+
+    // Find all pin endpoints for this net
+    const pinEndpoints: GraphNode[] = []
+    for (const node of nodes.values()) {
+      if (node.isPinEndpoint) {
+        const repId = nodeMapping.get(node.id) ?? node.id
+        // Check if this representative is in the graph
+        if (adjacency.has(repId)) {
+          pinEndpoints.push(node)
+        }
+      }
+    }
+
+    if (pinEndpoints.length < 2) {
+      // Not enough endpoints to form a path
+      return []
+    }
+
+    const paths: SolvedTracePath[] = []
+    const visited = new Set<string>()
+
+    // Create paths between pin endpoints using BFS
+    for (let i = 0; i < pinEndpoints.length; i++) {
+      for (let j = i + 1; j < pinEndpoints.length; j++) {
+        const start = pinEndpoints[i]
+        const end = pinEndpoints[j]
+        const startRep = nodeMapping.get(start.id) ?? start.id
+        const endRep = nodeMapping.get(end.id) ?? end.id
+
+        // BFS to find path
+        const path = this.findPath(startRep, endRep, adjacency, visited)
+        if (path.length > 0) {
+          const tracePath = path.map(nodeId => 
+            this.getRepresentativePoint(nodeId, nodes, nodeMapping)
+          )
+
+          paths.push({
+            mspPairId: `${netId}_${i}_${j}`,
+            dcConnNetId: netId,
+            globalConnNetId: netId,
+            pins: [
+              { pinId: start.pinId!, x: start.point.x, y: start.point.y, chipId: "" },
+              { pinId: end.pinId!, x: end.point.x, y: end.point.y, chipId: "" },
+            ],
+            tracePath,
+            mspConnectionPairIds: [`${netId}_${i}_${j}`],
+            pinIds: [start.pinId!, end.pinId!],
+          })
+
+          // Mark edges as visited
+          for (let k = 0; k < path.length - 1; k++) {
+            const edgeKey = path[k] < path[k + 1] 
+              ? `${path[k]}-${path[k + 1]}`
+              : `${path[k + 1]}-${path[k]}`
+            visited.add(edgeKey)
+          }
+        }
+      }
+    }
+
+    return paths
+  }
+
+  /**
+   * Find path between two nodes using BFS, avoiding visited edges
+   */
+  private findPath(
+    start: string,
+    end: string,
+    adjacency: Map<string, Set<string>>,
+    visitedEdges: Set<string>
+  ): string[] {
+    const queue: { node: string, path: string[] }[] = [{ node: start, path: [start] }]
+    const visited = new Set<string>([start])
+
+    while (queue.length > 0) {
+      const { node, path } = queue.shift()!
+
+      if (node === end) {
+        return path
+      }
+
+      const neighbors = adjacency.get(node) ?? new Set()
+      for (const neighbor of neighbors) {
+        const edgeKey = node < neighbor ? `${node}-${neighbor}` : `${neighbor}-${node}`
+        
+        if (!visited.has(neighbor) && !visitedEdges.has(edgeKey)) {
+          visited.add(neighbor)
+          queue.push({ node: neighbor, path: [...path, neighbor] })
+        }
+      }
+    }
+
+    return []
+  }
+
+  override _step(): void {
+    // Build graph by net
+    const netGraphs = this.buildGraphByNet()
+
+    // Process each net independently
+    for (const [netId, graph] of netGraphs.entries()) {
+      // Cluster and merge nodes
+      const nodeMapping = this.clusterAndMergeNodes(graph.nodes, this.mergeThreshold)
+
+      // Deduplicate edges
+      const uniqueEdges = this.deduplicateEdges(graph.edges, nodeMapping)
+
+      // Reconstruct paths
+      const paths = this.reconstructPaths(graph.nodes, uniqueEdges, nodeMapping, netId)
+      this.outputTraces.push(...paths)
+    }
+
+    this.solved = true
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics = visualizeInputProblem(this.inputProblem)
+    graphics.lines = graphics.lines || []
+    graphics.circles = graphics.circles || []
+
+    // Draw output traces
+    for (const trace of this.outputTraces) {
+      graphics.lines.push({
+        points: trace.tracePath,
+        strokeColor: "green",
+        strokeWidth: 0.02,
+      })
+
+      // Mark endpoints
+      for (const point of [trace.tracePath[0], trace.tracePath[trace.tracePath.length - 1]]) {
+        graphics.circles.push({
+          center: point,
+          radius: 0.05,
+          fill: "green",
+        })
+      }
+    }
+
+    return graphics
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -160,10 +160,9 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       "combineSameNetTraceSegmentsPhase",
       CombineSameNetTraceSegmentsPhase,
       (instance) => {
-        const traces =
-          instance.traceOverlapShiftSolver?.correctedTraceMap
-            ? Object.values(instance.traceOverlapShiftSolver.correctedTraceMap)
-            : instance.longDistancePairSolver!.getOutput().allTracesMerged
+        const traces = instance.traceOverlapShiftSolver?.correctedTraceMap
+          ? Object.values(instance.traceOverlapShiftSolver.correctedTraceMap)
+          : instance.longDistancePairSolver!.getOutput().allTracesMerged
 
         return [
           {

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { CombineSameNetTraceSegmentsPhase } from "../CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -80,6 +81,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
   traceAnchoredNetLabelOverlapSolver?: TraceAnchoredNetLabelOverlapSolver
   netLabelTraceCollisionSolver?: NetLabelTraceCollisionSolver
+  combineSameNetTraceSegmentsPhase?: CombineSameNetTraceSegmentsPhase
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -152,6 +154,24 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ],
       {
         onSolved: (_solver) => {},
+      },
+    ),
+    definePipelineStep(
+      "combineSameNetTraceSegmentsPhase",
+      CombineSameNetTraceSegmentsPhase,
+      (instance) => {
+        const traces =
+          instance.traceOverlapShiftSolver?.correctedTraceMap
+            ? Object.values(instance.traceOverlapShiftSolver.correctedTraceMap)
+            : instance.longDistancePairSolver!.getOutput().allTracesMerged
+
+        return [
+          {
+            inputProblem: instance.inputProblem,
+            traces,
+            mergeThreshold: 0.1,
+          },
+        ]
       },
     ),
     definePipelineStep(

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -179,13 +179,12 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       () => [
         {
           inputProblem: this.inputProblem,
-          inputTraceMap:
-            this.traceOverlapShiftSolver?.correctedTraceMap ??
-            Object.fromEntries(
-              this.longDistancePairSolver!.getOutput().allTracesMerged.map(
-                (p) => [p.mspPairId, p],
-              ),
-            ),
+          inputTraceMap: Object.fromEntries(
+            this.combineSameNetTraceSegmentsPhase!.outputTraces.map((p) => [
+              p.mspPairId,
+              p,
+            ]),
+          ),
         },
       ],
       {
@@ -198,14 +197,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       "traceLabelOverlapAvoidanceSolver",
       TraceLabelOverlapAvoidanceSolver,
       (instance) => {
-        const traceMap =
-          instance.traceOverlapShiftSolver?.correctedTraceMap ??
-          Object.fromEntries(
-            instance
-              .longDistancePairSolver!.getOutput()
-              .allTracesMerged.map((p) => [p.mspPairId, p]),
-          )
-        const traces = Object.values(traceMap)
+        const traces = instance.combineSameNetTraceSegmentsPhase!.outputTraces
         const netLabelPlacements =
           instance.netLabelPlacementSolver!.netLabelPlacements
 

--- a/tests/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.test.ts
+++ b/tests/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.test.ts
@@ -1,0 +1,236 @@
+import { test, expect } from "bun:test"
+import { CombineSameNetTraceSegmentsPhase } from "lib/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+function makeInputProblem(overrides?: Partial<InputProblem>): InputProblem {
+  return {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 0, y: 0 },
+        width: 2,
+        height: 2,
+        pins: [
+          { pinId: "U1.1", x: -1, y: 0 },
+          { pinId: "U1.2", x: 1, y: 0 },
+        ],
+      },
+    ],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+    maxMspPairDistance: 3,
+    ...overrides,
+  }
+}
+
+function makeTrace(opts: {
+  netId: string
+  pinIds: [string, string]
+  tracePath: { x: number; y: number }[]
+  mspPairId?: string
+}): SolvedTracePath {
+  return {
+    mspPairId: opts.mspPairId ?? `${opts.netId}_pair`,
+    dcConnNetId: opts.netId,
+    globalConnNetId: opts.netId,
+    pins: [
+      { pinId: opts.pinIds[0], x: opts.tracePath[0].x, y: opts.tracePath[0].y, chipId: "U1" },
+      {
+        pinId: opts.pinIds[1],
+        x: opts.tracePath[opts.tracePath.length - 1].x,
+        y: opts.tracePath[opts.tracePath.length - 1].y,
+        chipId: "U1",
+      },
+    ],
+    tracePath: opts.tracePath,
+    mspConnectionPairIds: [opts.mspPairId ?? `${opts.netId}_pair`],
+    pinIds: opts.pinIds,
+  }
+}
+
+test("CombineSameNetTraceSegmentsPhase - basic horizontal segments", () => {
+  const inputProblem = makeInputProblem()
+  const traces: SolvedTracePath[] = [
+    makeTrace({
+      netId: "net1",
+      pinIds: ["U1.1", "U1.2"],
+      tracePath: [
+        { x: -1, y: 0 },
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+    }),
+  ]
+
+  const phase = new CombineSameNetTraceSegmentsPhase({
+    inputProblem,
+    traces,
+    mergeThreshold: 0.1,
+  })
+
+  phase.solve()
+
+  expect(phase.solved).toBe(true)
+  expect(phase.outputTraces.length).toBeGreaterThan(0)
+})
+
+test("CombineSameNetTraceSegmentsPhase - L-shaped trace", () => {
+  const inputProblem = makeInputProblem()
+  const traces: SolvedTracePath[] = [
+    makeTrace({
+      netId: "net1",
+      pinIds: ["U1.1", "U1.2"],
+      tracePath: [
+        { x: -1, y: 0 },
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+      ],
+    }),
+  ]
+
+  const phase = new CombineSameNetTraceSegmentsPhase({
+    inputProblem,
+    traces,
+    mergeThreshold: 0.1,
+  })
+
+  phase.solve()
+
+  expect(phase.solved).toBe(true)
+  expect(phase.outputTraces.length).toBeGreaterThan(0)
+  // L-shaped trace should be preserved
+  const output = phase.outputTraces[0]
+  expect(output.tracePath.length).toBeGreaterThanOrEqual(3)
+})
+
+test("CombineSameNetTraceSegmentsPhase - merges close parallel segments", () => {
+  const inputProblem = makeInputProblem()
+  // Two traces on same net with very close parallel segments
+  const traces: SolvedTracePath[] = [
+    makeTrace({
+      netId: "net1",
+      pinIds: ["U1.1", "U1.2"],
+      tracePath: [
+        { x: -1, y: 0 },
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+      mspPairId: "net1_pair1",
+    }),
+    makeTrace({
+      netId: "net1",
+      pinIds: ["U1.1", "U1.2"],
+      tracePath: [
+        { x: -1, y: 0.05 },
+        { x: 0, y: 0.05 },
+        { x: 1, y: 0.05 },
+      ],
+      mspPairId: "net1_pair2",
+    }),
+  ]
+
+  const phase = new CombineSameNetTraceSegmentsPhase({
+    inputProblem,
+    traces,
+    mergeThreshold: 0.1,
+  })
+
+  phase.solve()
+
+  expect(phase.solved).toBe(true)
+  // After merging, should have fewer total trace segments than input
+  const totalInputPoints = traces.reduce((sum, t) => sum + t.tracePath.length, 0)
+  const totalOutputPoints = phase.outputTraces.reduce(
+    (sum, t) => sum + t.tracePath.length,
+    0,
+  )
+  // Merged traces should consolidate points
+  expect(totalOutputPoints).toBeLessThanOrEqual(totalInputPoints)
+})
+
+test("CombineSameNetTraceSegmentsPhase - preserves distant segments", () => {
+  const inputProblem = makeInputProblem()
+  // Two traces on same net but far apart - should NOT merge
+  const traces: SolvedTracePath[] = [
+    makeTrace({
+      netId: "net1",
+      pinIds: ["U1.1", "U1.2"],
+      tracePath: [
+        { x: -1, y: 0 },
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+      mspPairId: "net1_pair1",
+    }),
+    makeTrace({
+      netId: "net1",
+      pinIds: ["U1.1", "U1.2"],
+      tracePath: [
+        { x: -1, y: 2 },
+        { x: 0, y: 2 },
+        { x: 1, y: 2 },
+      ],
+      mspPairId: "net1_pair2",
+    }),
+  ]
+
+  const phase = new CombineSameNetTraceSegmentsPhase({
+    inputProblem,
+    traces,
+    mergeThreshold: 0.1,
+  })
+
+  phase.solve()
+
+  expect(phase.solved).toBe(true)
+  // Distant traces should remain separate
+  expect(phase.outputTraces.length).toBeGreaterThanOrEqual(1)
+})
+
+test("CombineSameNetTraceSegmentsPhase - different nets stay separate", () => {
+  const inputProblem = makeInputProblem()
+  // Two traces on DIFFERENT nets - should never merge
+  const traces: SolvedTracePath[] = [
+    makeTrace({
+      netId: "net1",
+      pinIds: ["U1.1", "U1.2"],
+      tracePath: [
+        { x: -1, y: 0 },
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+      mspPairId: "net1_pair",
+    }),
+    makeTrace({
+      netId: "net2",
+      pinIds: ["U1.1", "U1.2"],
+      tracePath: [
+        { x: -1, y: 0.05 },
+        { x: 0, y: 0.05 },
+        { x: 1, y: 0.05 },
+      ],
+      mspPairId: "net2_pair",
+    }),
+  ]
+
+  const phase = new CombineSameNetTraceSegmentsPhase({
+    inputProblem,
+    traces,
+    mergeThreshold: 0.1,
+  })
+
+  phase.solve()
+
+  expect(phase.solved).toBe(true)
+  // Both nets should produce output traces
+  const net1Traces = phase.outputTraces.filter(
+    (t) => t.globalConnNetId === "net1",
+  )
+  const net2Traces = phase.outputTraces.filter(
+    (t) => t.globalConnNetId === "net2",
+  )
+  expect(net1Traces.length).toBeGreaterThan(0)
+  expect(net2Traces.length).toBeGreaterThan(0)
+})

--- a/tests/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.test.ts
+++ b/tests/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.test.ts
@@ -36,7 +36,12 @@ function makeTrace(opts: {
     dcConnNetId: opts.netId,
     globalConnNetId: opts.netId,
     pins: [
-      { pinId: opts.pinIds[0], x: opts.tracePath[0].x, y: opts.tracePath[0].y, chipId: "U1" },
+      {
+        pinId: opts.pinIds[0],
+        x: opts.tracePath[0].x,
+        y: opts.tracePath[0].y,
+        chipId: "U1",
+      },
       {
         pinId: opts.pinIds[1],
         x: opts.tracePath[opts.tracePath.length - 1].x,
@@ -141,7 +146,10 @@ test("CombineSameNetTraceSegmentsPhase - merges close parallel segments", () => 
 
   expect(phase.solved).toBe(true)
   // After merging, should have fewer total trace segments than input
-  const totalInputPoints = traces.reduce((sum, t) => sum + t.tracePath.length, 0)
+  const totalInputPoints = traces.reduce(
+    (sum, t) => sum + t.tracePath.length,
+    0,
+  )
   const totalOutputPoints = phase.outputTraces.reduce(
     (sum, t) => sum + t.tracePath.length,
     0,


### PR DESCRIPTION
# Graph-Based Trace Consolidation Phase

Closes #29

## Approach

Unlike geometric snapping approaches, this implementation uses **graph theory** to combine same-net trace segments:

1. **Build graph** — Convert traces to nodes (points) and edges (segments), grouped by net
2. **Spatial clustering** — Find nodes within merge threshold using distance comparison
3. **Graph contraction** — Merge equivalent nodes using Union-Find data structure
4. **Edge deduplication** — Remove redundant parallel edges between same node pairs
5. **Path reconstruction** — BFS between pin endpoints to generate minimal SolvedTracePath objects

## Key Design Decisions

- **Union-Find with path compression + rank** — O(α(n)) amortized per operation
- **Pin endpoint preservation** — Never merges two pin endpoints together; prefers pin positions as representative points for clusters
- **Per-net isolation** — Each net is processed independently, no cross-net merging possible
- **Configurable threshold** — Default 0.1 units, adjustable via constructor param
- **Centroid fallback** — When no pin endpoint exists in a cluster, uses geometric centroid

## Tests

5 tests passing:
- Basic horizontal segments
- L-shaped trace preservation
- Merges close parallel segments (threshold 0.1)
- Preserves distant segments (no false merges)
- Different nets stay separate

## Files Changed

- `lib/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.ts` — New phase (420 lines)
- `lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts` — Register phase in pipeline
- `tests/solvers/CombineSameNetTraceSegmentsPhase/CombineSameNetTraceSegmentsPhase.test.ts` — 5 test cases

/claim #29