### PR TITLE
feat: new pipeline phase to combine close same-net trace segments

### DIFF
--- a/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
+++ b/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
@@ -1,0 +1,240 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { GraphicsObject } from "graphics-debug"
+import type { Point } from "@tscircuit/math-utils"
+
+const EPS = 1e-6
+
+interface CombineCloseTraceSegmentsSolverInput {
+  inputProblem: InputProblem
+  allTraces: SolvedTracePath[]
+  closenessTolerance?: number
+}
+
+interface SegmentPair {
+  traceIdx1: number
+  segIdx1: number
+  traceIdx2: number
+  segIdx2: number
+  isVertical: boolean
+  sharedMin: number
+  sharedMax: number
+  coord1: number
+  coord2: number
+}
+
+/**
+ * Combines same-net trace segments that are close together.
+ *
+ * When two traces on the same net have parallel segments that are near each
+ * other (within `closenessTolerance`), this solver shifts them onto the same
+ * axis so they share a single visual line instead of two nearly-overlapping
+ * ones. This reduces visual clutter in schematic layouts.
+ *
+ * Only operates within the same globalConnNetId — never merges across nets.
+ */
+export class CombineCloseTraceSegmentsSolver extends BaseSolver {
+  private input: CombineCloseTraceSegmentsSolverInput
+  private outputTraces: SolvedTracePath[]
+  private closenessTolerance: number
+  private netIds: string[]
+  private currentNetIdx: number = 0
+  private tracesByNet: Record<string, SolvedTracePath[]> = {}
+
+  constructor(solverInput: CombineCloseTraceSegmentsSolverInput) {
+    super()
+    this.input = solverInput
+    this.closenessTolerance = solverInput.closenessTolerance ?? 0.15
+    this.outputTraces = solverInput.allTraces.map((t) => ({
+      ...t,
+      tracePath: [...t.tracePath],
+    }))
+
+    // Group traces by net
+    for (const trace of this.outputTraces) {
+      const netId = trace.globalConnNetId
+      if (!this.tracesByNet[netId]) this.tracesByNet[netId] = []
+      this.tracesByNet[netId].push(trace)
+    }
+
+    this.netIds = Object.keys(this.tracesByNet).filter(
+      (netId) => (this.tracesByNet[netId]?.length ?? 0) > 1,
+    )
+  }
+
+  override getConstructorParams() {
+    return this.input
+  }
+
+  /**
+   * Find two parallel segments from different traces on the same net that
+   * are close together (within tolerance) and overlap in the parallel axis.
+   */
+  private findCloseSegmentPair(
+    traces: SolvedTracePath[],
+  ): SegmentPair | null {
+    const tol = this.closenessTolerance
+
+    for (let i = 0; i < traces.length; i++) {
+      const path1 = traces[i]!.tracePath
+      for (let si = 0; si < path1.length - 1; si++) {
+        const a1 = path1[si]!
+        const a2 = path1[si + 1]!
+        const aVert = Math.abs(a1.x - a2.x) < EPS
+        const aHorz = Math.abs(a1.y - a2.y) < EPS
+        if (!aVert && !aHorz) continue
+
+        for (let j = i + 1; j < traces.length; j++) {
+          const path2 = traces[j]!.tracePath
+          for (let sj = 0; sj < path2.length - 1; sj++) {
+            const b1 = path2[sj]!
+            const b2 = path2[sj + 1]!
+            const bVert = Math.abs(b1.x - b2.x) < EPS
+            const bHorz = Math.abs(b1.y - b2.y) < EPS
+            if (!bVert && !bHorz) continue
+
+            if (aVert && bVert) {
+              const dist = Math.abs(a1.x - b1.x)
+              if (dist > EPS && dist < tol) {
+                const overlapMin = Math.max(
+                  Math.min(a1.y, a2.y),
+                  Math.min(b1.y, b2.y),
+                )
+                const overlapMax = Math.min(
+                  Math.max(a1.y, a2.y),
+                  Math.max(b1.y, b2.y),
+                )
+                if (overlapMax - overlapMin > EPS) {
+                  return {
+                    traceIdx1: i,
+                    segIdx1: si,
+                    traceIdx2: j,
+                    segIdx2: sj,
+                    isVertical: true,
+                    sharedMin: overlapMin,
+                    sharedMax: overlapMax,
+                    coord1: a1.x,
+                    coord2: b1.x,
+                  }
+                }
+              }
+            } else if (aHorz && bHorz) {
+              const dist = Math.abs(a1.y - b1.y)
+              if (dist > EPS && dist < tol) {
+                const overlapMin = Math.max(
+                  Math.min(a1.x, a2.x),
+                  Math.min(b1.x, b2.x),
+                )
+                const overlapMax = Math.min(
+                  Math.max(a1.x, a2.x),
+                  Math.max(b1.x, b2.x),
+                )
+                if (overlapMax - overlapMin > EPS) {
+                  return {
+                    traceIdx1: i,
+                    segIdx1: si,
+                    traceIdx2: j,
+                    segIdx2: sj,
+                    isVertical: false,
+                    sharedMin: overlapMin,
+                    sharedMax: overlapMax,
+                    coord1: a1.y,
+                    coord2: b1.y,
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return null
+  }
+
+  /**
+   * Shift the second trace's segment to align with the first trace's
+   * coordinate, adjusting adjacent points to maintain orthogonal routing.
+   */
+  private alignSegment(
+    tracePath: Point[],
+    segIdx: number,
+    isVertical: boolean,
+    targetCoord: number,
+  ): void {
+    const p1 = tracePath[segIdx]!
+    const p2 = tracePath[segIdx + 1]!
+
+    if (isVertical) {
+      // Shift X of both endpoints to target
+      p1.x = targetCoord
+      p2.x = targetCoord
+    } else {
+      // Shift Y of both endpoints to target
+      p1.y = targetCoord
+      p2.y = targetCoord
+    }
+  }
+
+  override _step() {
+    if (this.currentNetIdx >= this.netIds.length) {
+      this.solved = true
+      return
+    }
+
+    const netId = this.netIds[this.currentNetIdx]!
+    const traces = this.tracesByNet[netId]!
+
+    const pair = this.findCloseSegmentPair(traces)
+
+    if (!pair) {
+      // No more close segments in this net, move to next
+      this.currentNetIdx++
+      return
+    }
+
+    // Average the two coordinates for the merge target
+    const targetCoord = (pair.coord1 + pair.coord2) / 2
+
+    // Align the second trace's segment to the target
+    this.alignSegment(
+      traces[pair.traceIdx2]!.tracePath,
+      pair.segIdx2,
+      pair.isVertical,
+      targetCoord,
+    )
+
+    // Also align the first trace's segment to the target
+    this.alignSegment(
+      traces[pair.traceIdx1]!.tracePath,
+      pair.segIdx1,
+      pair.isVertical,
+      targetCoord,
+    )
+
+    // Don't advance currentNetIdx — re-check this net for more close segments
+  }
+
+  getOutput() {
+    return { traces: this.outputTraces }
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics = visualizeInputProblem(this.input.inputProblem, {
+      chipAlpha: 0.1,
+      connectionAlpha: 0.1,
+    })
+
+    if (!graphics.lines) graphics.lines = []
+
+    for (const trace of this.outputTraces) {
+      graphics.lines.push({
+        points: trace.tracePath.map((p) => ({ x: p.x, y: p.y })),
+        strokeColor: "blue",
+      })
+    }
+
+    return graphics
+  }
+}

--- a/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
+++ b/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
@@ -210,12 +210,8 @@ export class CombineCloseTraceSegmentsSolver extends BaseSolver {
         if (!isVertical && !qHorz) continue
         const qCoord = isVertical ? q1.x : q1.y
         if (Math.abs(qCoord - targetCoord) > EPS) continue
-        const qMin = isVertical
-          ? Math.min(q1.y, q2.y)
-          : Math.min(q1.x, q2.x)
-        const qMax = isVertical
-          ? Math.max(q1.y, q2.y)
-          : Math.max(q1.x, q2.x)
+        const qMin = isVertical ? Math.min(q1.y, q2.y) : Math.min(q1.x, q2.x)
+        const qMax = isVertical ? Math.max(q1.y, q2.y) : Math.max(q1.x, q2.x)
         const overlapStart = Math.max(qMin, sharedMin)
         const overlapEnd = Math.min(qMax, sharedMax)
         if (overlapEnd - overlapStart > EPS) return true

--- a/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
+++ b/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
@@ -71,9 +71,14 @@ export class CombineCloseTraceSegmentsSolver extends BaseSolver {
   /**
    * Find two parallel segments from different traces on the same net that
    * are close together (within tolerance) and overlap in the parallel axis.
+   *
+   * Rejects candidates whose merged target axis would land on a different-net
+   * trace segment in the same parallel range — that would introduce a
+   * cross-net short. See `wouldCollideWithDifferentNet`.
    */
   private findCloseSegmentPair(traces: SolvedTracePath[]): SegmentPair | null {
     const tol = this.closenessTolerance
+    const netId = traces[0]?.globalConnNetId ?? ""
 
     for (let i = 0; i < traces.length; i++) {
       const path1 = traces[i]!.tracePath
@@ -105,6 +110,18 @@ export class CombineCloseTraceSegmentsSolver extends BaseSolver {
                   Math.max(b1.y, b2.y),
                 )
                 if (overlapMax - overlapMin > EPS) {
+                  const targetCoord = (a1.x + b1.x) / 2
+                  if (
+                    this.wouldCollideWithDifferentNet(
+                      targetCoord,
+                      overlapMin,
+                      overlapMax,
+                      true,
+                      netId,
+                    )
+                  ) {
+                    continue
+                  }
                   return {
                     traceIdx1: i,
                     segIdx1: si,
@@ -130,6 +147,18 @@ export class CombineCloseTraceSegmentsSolver extends BaseSolver {
                   Math.max(b1.x, b2.x),
                 )
                 if (overlapMax - overlapMin > EPS) {
+                  const targetCoord = (a1.y + b1.y) / 2
+                  if (
+                    this.wouldCollideWithDifferentNet(
+                      targetCoord,
+                      overlapMin,
+                      overlapMax,
+                      false,
+                      netId,
+                    )
+                  ) {
+                    continue
+                  }
                   return {
                     traceIdx1: i,
                     segIdx1: si,
@@ -149,6 +178,50 @@ export class CombineCloseTraceSegmentsSolver extends BaseSolver {
       }
     }
     return null
+  }
+
+  /**
+   * Returns true if moving both candidate segments onto `targetCoord` (with
+   * shared perpendicular range [sharedMin, sharedMax]) would place them on top
+   * of a parallel segment from a different net. This is the check that
+   * prevents same-net merges from accidentally introducing a cross-net short.
+   *
+   * Two segments collide when:
+   *   - they share orientation (both vertical or both horizontal),
+   *   - their parallel-axis coordinates are equal (within EPS) at targetCoord,
+   *   - their perpendicular ranges overlap beyond EPS.
+   */
+  private wouldCollideWithDifferentNet(
+    targetCoord: number,
+    sharedMin: number,
+    sharedMax: number,
+    isVertical: boolean,
+    currentNetId: string,
+  ): boolean {
+    for (const trace of this.outputTraces) {
+      if (trace.globalConnNetId === currentNetId) continue
+      const path = trace.tracePath
+      for (let k = 0; k < path.length - 1; k++) {
+        const q1 = path[k]!
+        const q2 = path[k + 1]!
+        const qVert = Math.abs(q1.x - q2.x) < EPS
+        const qHorz = Math.abs(q1.y - q2.y) < EPS
+        if (isVertical && !qVert) continue
+        if (!isVertical && !qHorz) continue
+        const qCoord = isVertical ? q1.x : q1.y
+        if (Math.abs(qCoord - targetCoord) > EPS) continue
+        const qMin = isVertical
+          ? Math.min(q1.y, q2.y)
+          : Math.min(q1.x, q2.x)
+        const qMax = isVertical
+          ? Math.max(q1.y, q2.y)
+          : Math.max(q1.x, q2.x)
+        const overlapStart = Math.max(qMin, sharedMin)
+        const overlapEnd = Math.min(qMax, sharedMax)
+        if (overlapEnd - overlapStart > EPS) return true
+      }
+    }
+    return false
   }
 
   /**

--- a/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
+++ b/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
@@ -49,7 +49,7 @@ export class CombineCloseTraceSegmentsSolver extends BaseSolver {
     this.closenessTolerance = solverInput.closenessTolerance ?? 0.15
     this.outputTraces = solverInput.allTraces.map((t) => ({
       ...t,
-      tracePath: [...t.tracePath],
+      tracePath: t.tracePath.map((p) => ({ ...p })),
     }))
 
     // Group traces by net

--- a/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
+++ b/lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts
@@ -72,9 +72,7 @@ export class CombineCloseTraceSegmentsSolver extends BaseSolver {
    * Find two parallel segments from different traces on the same net that
    * are close together (within tolerance) and overlap in the parallel axis.
    */
-  private findCloseSegmentPair(
-    traces: SolvedTracePath[],
-  ): SegmentPair | null {
+  private findCloseSegmentPair(traces: SolvedTracePath[]): SegmentPair | null {
     const tol = this.closenessTolerance
 
     for (let i = 0; i < traces.length; i++) {

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -21,6 +21,7 @@ import { expandChipsToFitPins } from "./expandChipsToFitPins"
 import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import { CombineCloseTraceSegmentsSolver } from "../CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver"
 import { Example28Solver } from "../Example28Solver/Example28Solver"
 import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
@@ -75,6 +76,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  combineCloseTraceSegmentsSolver?: CombineCloseTraceSegmentsSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -218,10 +220,27 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "combineCloseTraceSegmentsSolver",
+      CombineCloseTraceSegmentsSolver,
+      (instance) => {
+        const traces =
+          instance.traceCleanupSolver?.getOutput().traces ??
+          instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
+
+        return [
+          {
+            inputProblem: instance.inputProblem,
+            allTraces: traces,
+          },
+        ]
+      },
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.combineCloseTraceSegmentsSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +256,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.combineCloseTraceSegmentsSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/site/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.page.tsx
+++ b/site/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.page.tsx
@@ -1,0 +1,12 @@
+import { useMemo } from "react"
+import { GenericSolverDebugger } from "site/components/GenericSolverDebugger"
+import { CombineCloseTraceSegmentsSolver } from "lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver"
+import inputData from "../../tests/assets/CombineCloseTraceSegmentsSolver.test.input.json"
+
+export default () => {
+  const solver = useMemo(
+    () => new CombineCloseTraceSegmentsSolver(inputData as any),
+    [],
+  )
+  return <GenericSolverDebugger solver={solver} />
+}

--- a/tests/assets/CombineCloseTraceSegmentsSolver.test.input.json
+++ b/tests/assets/CombineCloseTraceSegmentsSolver.test.input.json
@@ -41,8 +41,20 @@
       "globalConnNetId": "net1_global",
       "userNetId": "NET1",
       "pins": [
-        { "pinId": "U1.3", "x": 1.0, "y": 0.2, "chipId": "U1", "_facingDirection": "x+" },
-        { "pinId": "U2.1", "x": 4.0, "y": 0.2, "chipId": "U2", "_facingDirection": "x-" }
+        {
+          "pinId": "U1.3",
+          "x": 1.0,
+          "y": 0.2,
+          "chipId": "U1",
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U2.1",
+          "x": 4.0,
+          "y": 0.2,
+          "chipId": "U2",
+          "_facingDirection": "x-"
+        }
       ],
       "tracePath": [
         { "x": 1.0, "y": 0.2 },
@@ -60,8 +72,20 @@
       "globalConnNetId": "net1_global",
       "userNetId": "NET1",
       "pins": [
-        { "pinId": "U1.4", "x": 1.0, "y": -0.2, "chipId": "U1", "_facingDirection": "x+" },
-        { "pinId": "U2.2", "x": 4.0, "y": -0.2, "chipId": "U2", "_facingDirection": "x-" }
+        {
+          "pinId": "U1.4",
+          "x": 1.0,
+          "y": -0.2,
+          "chipId": "U1",
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U2.2",
+          "x": 4.0,
+          "y": -0.2,
+          "chipId": "U2",
+          "_facingDirection": "x-"
+        }
       ],
       "tracePath": [
         { "x": 1.0, "y": -0.2 },

--- a/tests/assets/CombineCloseTraceSegmentsSolver.test.input.json
+++ b/tests/assets/CombineCloseTraceSegmentsSolver.test.input.json
@@ -1,0 +1,77 @@
+{
+  "inputProblem": {
+    "chips": [
+      {
+        "chipId": "U1",
+        "center": { "x": 0, "y": 0 },
+        "width": 2.0,
+        "height": 1.0,
+        "pins": [
+          { "pinId": "U1.1", "x": -1.0, "y": 0.2 },
+          { "pinId": "U1.2", "x": -1.0, "y": -0.2 },
+          { "pinId": "U1.3", "x": 1.0, "y": 0.2 },
+          { "pinId": "U1.4", "x": 1.0, "y": -0.2 }
+        ]
+      },
+      {
+        "chipId": "U2",
+        "center": { "x": 5, "y": 0 },
+        "width": 2.0,
+        "height": 1.0,
+        "pins": [
+          { "pinId": "U2.1", "x": 4.0, "y": 0.2 },
+          { "pinId": "U2.2", "x": 4.0, "y": -0.2 },
+          { "pinId": "U2.3", "x": 6.0, "y": 0.2 },
+          { "pinId": "U2.4", "x": 6.0, "y": -0.2 }
+        ]
+      }
+    ],
+    "directConnections": [],
+    "netConnections": [
+      { "netId": "NET1", "pinIds": ["U1.3", "U2.1"] },
+      { "netId": "NET1", "pinIds": ["U1.4", "U2.2"] }
+    ],
+    "availableNetLabelOrientations": {},
+    "maxMspPairDistance": 5
+  },
+  "allTraces": [
+    {
+      "mspPairId": "U1.3-U2.1",
+      "dcConnNetId": "net1_dc",
+      "globalConnNetId": "net1_global",
+      "userNetId": "NET1",
+      "pins": [
+        { "pinId": "U1.3", "x": 1.0, "y": 0.2, "chipId": "U1", "_facingDirection": "x+" },
+        { "pinId": "U2.1", "x": 4.0, "y": 0.2, "chipId": "U2", "_facingDirection": "x-" }
+      ],
+      "tracePath": [
+        { "x": 1.0, "y": 0.2 },
+        { "x": 2.5, "y": 0.2 },
+        { "x": 2.5, "y": 0.8 },
+        { "x": 4.0, "y": 0.8 },
+        { "x": 4.0, "y": 0.2 }
+      ],
+      "mspConnectionPairIds": ["U1.3-U2.1"],
+      "pinIds": ["U1.3", "U2.1"]
+    },
+    {
+      "mspPairId": "U1.4-U2.2",
+      "dcConnNetId": "net1_dc",
+      "globalConnNetId": "net1_global",
+      "userNetId": "NET1",
+      "pins": [
+        { "pinId": "U1.4", "x": 1.0, "y": -0.2, "chipId": "U1", "_facingDirection": "x+" },
+        { "pinId": "U2.2", "x": 4.0, "y": -0.2, "chipId": "U2", "_facingDirection": "x-" }
+      ],
+      "tracePath": [
+        { "x": 1.0, "y": -0.2 },
+        { "x": 2.6, "y": -0.2 },
+        { "x": 2.6, "y": 0.7 },
+        { "x": 4.0, "y": 0.7 },
+        { "x": 4.0, "y": -0.2 }
+      ],
+      "mspConnectionPairIds": ["U1.4-U2.2"],
+      "pinIds": ["U1.4", "U2.2"]
+    }
+  ]
+}

--- a/tests/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.test.ts
+++ b/tests/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test"
+import inputData from "../../assets/CombineCloseTraceSegmentsSolver.test.input.json"
+import { CombineCloseTraceSegmentsSolver } from "lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver"
+
+test("CombineCloseTraceSegmentsSolver snapshot", () => {
+  const solver = new CombineCloseTraceSegmentsSolver(inputData as any)
+  solver.solve()
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})
+
+test("CombineCloseTraceSegmentsSolver merges close vertical segments", () => {
+  const solver = new CombineCloseTraceSegmentsSolver(inputData as any)
+  solver.solve()
+
+  const output = solver.getOutput()
+  expect(output.traces).toHaveLength(2)
+
+  // After merging, the two vertical segments (at x=2.5 and x=2.6) should
+  // be at the same x coordinate (averaged to x=2.55)
+  const trace1 = output.traces[0]!
+  const trace2 = output.traces[1]!
+
+  // Find vertical segments in each trace
+  const getVerticalX = (path: { x: number; y: number }[]) => {
+    for (let i = 0; i < path.length - 1; i++) {
+      if (Math.abs(path[i]!.x - path[i + 1]!.x) < 1e-6 && path[i]!.x > 1.5) {
+        return path[i]!.x
+      }
+    }
+    return null
+  }
+
+  const x1 = getVerticalX(trace1.tracePath)
+  const x2 = getVerticalX(trace2.tracePath)
+
+  // Both vertical segments should now be at the same x coordinate
+  expect(x1).not.toBeNull()
+  expect(x2).not.toBeNull()
+  if (x1 !== null && x2 !== null) {
+    expect(Math.abs(x1 - x2)).toBeLessThan(1e-6)
+  }
+})
+
+test("CombineCloseTraceSegmentsSolver does not merge distant segments", () => {
+  const input = {
+    ...inputData,
+    allTraces: inputData.allTraces.map((t: any, i: number) => ({
+      ...t,
+      // Put the vertical segments far apart (x=2.0 and x=3.5)
+      tracePath: t.tracePath.map((p: any) => ({
+        ...p,
+        x: p.x === 2.5 ? 2.0 : p.x === 2.6 ? 3.5 : p.x,
+      })),
+    })),
+  }
+
+  const solver = new CombineCloseTraceSegmentsSolver(input as any)
+  solver.solve()
+
+  const output = solver.getOutput()
+  const trace1 = output.traces[0]!
+  const trace2 = output.traces[1]!
+
+  // Vertical segments should remain at different x coordinates
+  const getVerticalX = (path: { x: number; y: number }[]) => {
+    for (let i = 0; i < path.length - 1; i++) {
+      if (Math.abs(path[i]!.x - path[i + 1]!.x) < 1e-6 && path[i]!.x > 1.5) {
+        return path[i]!.x
+      }
+    }
+    return null
+  }
+
+  const x1 = getVerticalX(trace1.tracePath)
+  const x2 = getVerticalX(trace2.tracePath)
+  expect(x1).not.toBeNull()
+  expect(x2).not.toBeNull()
+  if (x1 !== null && x2 !== null) {
+    expect(Math.abs(x1 - x2)).toBeGreaterThan(1.0)
+  }
+})
+
+test("CombineCloseTraceSegmentsSolver skips different nets", () => {
+  const input = {
+    ...inputData,
+    allTraces: inputData.allTraces.map((t: any, i: number) => ({
+      ...t,
+      // Give each trace a different globalConnNetId
+      globalConnNetId: `net_${i}`,
+    })),
+  }
+
+  const solver = new CombineCloseTraceSegmentsSolver(input as any)
+  solver.solve()
+
+  const output = solver.getOutput()
+  const trace1 = output.traces[0]!
+  const trace2 = output.traces[1]!
+
+  // Vertical segments should NOT be merged (different nets)
+  const getVerticalX = (path: { x: number; y: number }[]) => {
+    for (let i = 0; i < path.length - 1; i++) {
+      if (Math.abs(path[i]!.x - path[i + 1]!.x) < 1e-6 && path[i]!.x > 1.5) {
+        return path[i]!.x
+      }
+    }
+    return null
+  }
+
+  const x1 = getVerticalX(trace1.tracePath)
+  const x2 = getVerticalX(trace2.tracePath)
+  expect(x1).not.toBeNull()
+  expect(x2).not.toBeNull()
+  if (x1 !== null && x2 !== null) {
+    expect(Math.abs(x1 - x2)).toBeGreaterThan(0.05)
+  }
+})

--- a/tests/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.test.ts
+++ b/tests/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.test.ts
@@ -42,16 +42,13 @@ test("CombineCloseTraceSegmentsSolver merges close vertical segments", () => {
 })
 
 test("CombineCloseTraceSegmentsSolver does not merge distant segments", () => {
-  const input = {
-    ...inputData,
-    allTraces: inputData.allTraces.map((t: any, i: number) => ({
-      ...t,
-      // Put the vertical segments far apart (x=2.0 and x=3.5)
-      tracePath: t.tracePath.map((p: any) => ({
-        ...p,
-        x: p.x === 2.5 ? 2.0 : p.x === 2.6 ? 3.5 : p.x,
-      })),
-    })),
+  const input = JSON.parse(JSON.stringify(inputData))
+  // Put the vertical segments far apart (x=2.0 and x=3.5)
+  for (const trace of input.allTraces) {
+    for (const p of trace.tracePath) {
+      if (p.x === 2.5) p.x = 2.0
+      if (p.x === 2.6) p.x = 3.5
+    }
   }
 
   const solver = new CombineCloseTraceSegmentsSolver(input as any)
@@ -81,14 +78,11 @@ test("CombineCloseTraceSegmentsSolver does not merge distant segments", () => {
 })
 
 test("CombineCloseTraceSegmentsSolver skips different nets", () => {
-  const input = {
-    ...inputData,
-    allTraces: inputData.allTraces.map((t: any, i: number) => ({
-      ...t,
-      // Give each trace a different globalConnNetId
-      globalConnNetId: `net_${i}`,
-    })),
-  }
+  const input = JSON.parse(JSON.stringify(inputData))
+  // Give each trace a different globalConnNetId
+  input.allTraces.forEach((t: any, i: number) => {
+    t.globalConnNetId = `net_${i}`
+  })
 
   const solver = new CombineCloseTraceSegmentsSolver(input as any)
   solver.solve()

--- a/tests/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.test.ts
+++ b/tests/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.test.ts
@@ -77,6 +77,67 @@ test("CombineCloseTraceSegmentsSolver does not merge distant segments", () => {
   }
 })
 
+test("CombineCloseTraceSegmentsSolver does not merge onto a different-net segment", () => {
+  // Regression test for the case raised in review:
+  //   net1: vertical segment at x=2.5
+  //   net1: vertical segment at x=2.6
+  //   net2: vertical segment at x=2.55  (right where the average would be)
+  // The naive merge would average the two net1 segments to x=2.55, placing
+  // them exactly on top of the net2 segment — a cross-net short. The solver
+  // must reject this merge.
+  const input = JSON.parse(JSON.stringify(inputData))
+
+  // Build a third trace on a different net, with a vertical segment at the
+  // midpoint of the two existing net1 vertical segments (x=2.55), spanning
+  // the same y range so it overlaps in parallel.
+  const decoyTrace = {
+    mspPairId: "decoy",
+    dcConnNetId: "net2_dc",
+    globalConnNetId: "net2_global",
+    userNetId: "NET2",
+    pins: [],
+    tracePath: [
+      { x: 1.0, y: -0.2 },
+      { x: 2.55, y: -0.2 },
+      { x: 2.55, y: 0.8 },
+      { x: 4.0, y: 0.8 },
+    ],
+    mspConnectionPairIds: ["decoy"],
+    pinIds: [],
+  }
+  input.allTraces.push(decoyTrace)
+
+  const solver = new CombineCloseTraceSegmentsSolver(input as any)
+  solver.solve()
+
+  const output = solver.getOutput()
+
+  // The two net1 traces should NOT both have ended up at x=2.55, which would
+  // overlap the net2 segment.
+  const net1Vertical: number[] = []
+  let net2Vertical: number | null = null
+  for (const trace of output.traces) {
+    for (let i = 0; i < trace.tracePath.length - 1; i++) {
+      const p1 = trace.tracePath[i]!
+      const p2 = trace.tracePath[i + 1]!
+      if (Math.abs(p1.x - p2.x) < 1e-6 && p1.x > 1.5 && p1.x < 3.5) {
+        if (trace.globalConnNetId === "net2_global") {
+          net2Vertical = p1.x
+        } else {
+          net1Vertical.push(p1.x)
+        }
+        break
+      }
+    }
+  }
+
+  expect(net2Vertical).not.toBeNull()
+  // Neither net1 segment should sit on top of the net2 segment.
+  for (const x of net1Vertical) {
+    expect(Math.abs(x - (net2Vertical ?? -999))).toBeGreaterThan(1e-6)
+  }
+})
+
 test("CombineCloseTraceSegmentsSolver skips different nets", () => {
   const input = JSON.parse(JSON.stringify(inputData))
   // Give each trace a different globalConnNetId


### PR DESCRIPTION
## Summary

Adds a new `CombineCloseTraceSegmentsSolver` pipeline phase that merges same-net trace segments which are close together, reducing visual clutter in schematic layouts.

- When two traces on the same `globalConnNetId` have parallel segments within a configurable tolerance (default 0.15), they are shifted onto a shared axis
- Runs after `TraceCleanupSolver` in the pipeline, before the second `NetLabelPlacementSolver`
- Only operates within same-net trace groups — never merges across different nets

## Changes

- **New**: `lib/solvers/CombineCloseTraceSegmentsSolver/CombineCloseTraceSegmentsSolver.ts` — the solver (240 lines)
- **Modified**: `SchematicTracePipelineSolver.ts` — pipeline registration (+20 lines)
- **New**: 4 tests (snapshot, merge verification, distance check, cross-net safety)
- **New**: React Cosmos debug page at `site/CombineCloseTraceSegmentsSolver/`

## How it works

1. Groups traces by `globalConnNetId`
2. For nets with 2+ traces, finds parallel segments within tolerance
3. Averages their coordinates so both merge onto one line
4. Iterates until no more close segments remain per net

## Test plan

- [ ] `bun test tests/solvers/CombineCloseTraceSegmentsSolver/` passes
- [ ] Existing pipeline snapshot tests still pass
- [ ] Visual inspection via Cosmos debug page looks correct
- [ ] Type check passes (`bunx tsc --noEmit`)

Addresses #29