### PR TITLE
feat: merge nearby same-net trace segments

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+export * from "./solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"

--- a/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
+++ b/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
@@ -37,6 +37,15 @@ function setAxisValue(
   else point.y = value
 }
 
+function setFixedValue(
+  point: { x: number; y: number },
+  orientation: "horizontal" | "vertical",
+  value: number,
+) {
+  if (orientation === "horizontal") point.y = value
+  else point.x = value
+}
+
 function getSegments(trace: SolvedTracePath, traceIndex: number): Segment[] {
   const segments: Segment[] = []
 
@@ -93,6 +102,24 @@ function endpointCandidate(
   return null
 }
 
+function overlappingParallelCandidate(
+  first: Segment,
+  second: Segment,
+  gapThreshold: number,
+) {
+  if (first.traceIndex === second.traceIndex) return null
+  if (first.orientation !== second.orientation) return null
+
+  const fixedDistance = Math.abs(first.fixed - second.fixed)
+  if (fixedDistance <= EPSILON || fixedDistance > gapThreshold) return null
+
+  const overlapMin = Math.max(first.min, second.min)
+  const overlapMax = Math.min(first.max, second.max)
+  if (overlapMax - overlapMin <= EPSILON) return null
+
+  return { mergedFixed: (first.fixed + second.fixed) / 2 }
+}
+
 function moveSegmentEndpoint(
   trace: SolvedTracePath,
   segment: Segment,
@@ -106,6 +133,24 @@ function moveSegmentEndpoint(
       setAxisValue(point, segment.orientation, replacementAxisValue)
     }
   }
+}
+
+function moveSegmentFixed(
+  trace: SolvedTracePath,
+  segment: Segment,
+  replacementFixedValue: number,
+) {
+  const points = trace.tracePath
+  setFixedValue(
+    points[segment.startIndex]!,
+    segment.orientation,
+    replacementFixedValue,
+  )
+  setFixedValue(
+    points[segment.endIndex]!,
+    segment.orientation,
+    replacementFixedValue,
+  )
 }
 
 export function mergeSameNetTraceSegments({
@@ -136,19 +181,37 @@ export function mergeSameNetTraceSegments({
 
         if (firstTrace.globalConnNetId !== secondTrace.globalConnNetId) continue
 
-        const candidate = endpointCandidate(first, second, gapThreshold)
-        if (!candidate) continue
+        const endpointMerge = endpointCandidate(first, second, gapThreshold)
+        if (endpointMerge) {
+          const mergedAxis =
+            (endpointMerge.firstAxis + endpointMerge.secondAxis) / 2
+          moveSegmentEndpoint(
+            firstTrace,
+            first,
+            endpointMerge.firstAxis,
+            mergedAxis,
+          )
+          moveSegmentEndpoint(
+            secondTrace,
+            second,
+            endpointMerge.secondAxis,
+            mergedAxis,
+          )
+          changed = true
+          break outer
+        }
 
-        const mergedAxis = (candidate.firstAxis + candidate.secondAxis) / 2
-        moveSegmentEndpoint(firstTrace, first, candidate.firstAxis, mergedAxis)
-        moveSegmentEndpoint(
-          secondTrace,
+        const parallelMerge = overlappingParallelCandidate(
+          first,
           second,
-          candidate.secondAxis,
-          mergedAxis,
+          gapThreshold,
         )
-        changed = true
-        break outer
+        if (parallelMerge) {
+          moveSegmentFixed(firstTrace, first, parallelMerge.mergedFixed)
+          moveSegmentFixed(secondTrace, second, parallelMerge.mergedFixed)
+          changed = true
+          break outer
+        }
       }
     }
   }

--- a/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
+++ b/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
@@ -1,0 +1,186 @@
+import type { GraphicsObject, Line } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+export interface SameNetTraceMergeSolverInput {
+  traces: SolvedTracePath[]
+  gapThreshold?: number
+}
+
+type Segment = {
+  traceIndex: number
+  startIndex: number
+  endIndex: number
+  orientation: "horizontal" | "vertical"
+  fixed: number
+  min: number
+  max: number
+}
+
+const DEFAULT_GAP_THRESHOLD = 0.15
+const EPSILON = 1e-9
+
+function almostEqual(a: number, b: number) {
+  return Math.abs(a - b) <= EPSILON
+}
+
+function getAxisValue(segment: Segment, point: { x: number; y: number }) {
+  return segment.orientation === "horizontal" ? point.x : point.y
+}
+
+function setAxisValue(
+  point: { x: number; y: number },
+  orientation: "horizontal" | "vertical",
+  value: number,
+) {
+  if (orientation === "horizontal") point.x = value
+  else point.y = value
+}
+
+function getSegments(trace: SolvedTracePath, traceIndex: number): Segment[] {
+  const segments: Segment[] = []
+
+  for (let i = 0; i < trace.tracePath.length - 1; i++) {
+    const start = trace.tracePath[i]!
+    const end = trace.tracePath[i + 1]!
+
+    if (almostEqual(start.y, end.y) && !almostEqual(start.x, end.x)) {
+      segments.push({
+        traceIndex,
+        startIndex: i,
+        endIndex: i + 1,
+        orientation: "horizontal",
+        fixed: start.y,
+        min: Math.min(start.x, end.x),
+        max: Math.max(start.x, end.x),
+      })
+    } else if (almostEqual(start.x, end.x) && !almostEqual(start.y, end.y)) {
+      segments.push({
+        traceIndex,
+        startIndex: i,
+        endIndex: i + 1,
+        orientation: "vertical",
+        fixed: start.x,
+        min: Math.min(start.y, end.y),
+        max: Math.max(start.y, end.y),
+      })
+    }
+  }
+
+  return segments
+}
+
+function endpointCandidate(
+  first: Segment,
+  second: Segment,
+  gapThreshold: number,
+) {
+  if (first.traceIndex === second.traceIndex) return null
+  if (first.orientation !== second.orientation) return null
+  if (!almostEqual(first.fixed, second.fixed)) return null
+
+  const gapForward = second.min - first.max
+  const gapBackward = first.min - second.max
+
+  if (gapForward > EPSILON && gapForward <= gapThreshold) {
+    return { firstAxis: first.max, secondAxis: second.min }
+  }
+
+  if (gapBackward > EPSILON && gapBackward <= gapThreshold) {
+    return { firstAxis: first.min, secondAxis: second.max }
+  }
+
+  return null
+}
+
+function moveSegmentEndpoint(
+  trace: SolvedTracePath,
+  segment: Segment,
+  axisValue: number,
+  replacementAxisValue: number,
+) {
+  const points = trace.tracePath
+  for (const index of [segment.startIndex, segment.endIndex]) {
+    const point = points[index]!
+    if (almostEqual(getAxisValue(segment, point), axisValue)) {
+      setAxisValue(point, segment.orientation, replacementAxisValue)
+    }
+  }
+}
+
+export function mergeSameNetTraceSegments({
+  traces,
+  gapThreshold = DEFAULT_GAP_THRESHOLD,
+}: SameNetTraceMergeSolverInput): SolvedTracePath[] {
+  const mergedTraces: SolvedTracePath[] = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  let changed = true
+  let safetyCounter = 0
+
+  while (changed && safetyCounter++ < 20) {
+    changed = false
+    const segments = mergedTraces.flatMap((trace, traceIndex) =>
+      getSegments(trace, traceIndex),
+    )
+
+    outer: for (let i = 0; i < segments.length; i++) {
+      const first = segments[i]!
+      const firstTrace = mergedTraces[first.traceIndex]!
+
+      for (let j = i + 1; j < segments.length; j++) {
+        const second = segments[j]!
+        const secondTrace = mergedTraces[second.traceIndex]!
+
+        if (firstTrace.globalConnNetId !== secondTrace.globalConnNetId) continue
+
+        const candidate = endpointCandidate(first, second, gapThreshold)
+        if (!candidate) continue
+
+        const mergedAxis = (candidate.firstAxis + candidate.secondAxis) / 2
+        moveSegmentEndpoint(firstTrace, first, candidate.firstAxis, mergedAxis)
+        moveSegmentEndpoint(
+          secondTrace,
+          second,
+          candidate.secondAxis,
+          mergedAxis,
+        )
+        changed = true
+        break outer
+      }
+    }
+  }
+
+  return mergedTraces
+}
+
+export class SameNetTraceMergeSolver extends BaseSolver {
+  private input: SameNetTraceMergeSolverInput
+  private outputTraces: SolvedTracePath[]
+
+  constructor(input: SameNetTraceMergeSolverInput) {
+    super()
+    this.input = input
+    this.outputTraces = input.traces
+  }
+
+  override _step() {
+    this.outputTraces = mergeSameNetTraceSegments(this.input)
+    this.solved = true
+  }
+
+  getOutput() {
+    return { traces: this.outputTraces }
+  }
+
+  override visualize(): GraphicsObject {
+    const lines: Line[] = this.outputTraces.map((trace) => ({
+      points: trace.tracePath,
+      strokeColor: "blue",
+    }))
+
+    return { lines }
+  }
+}

--- a/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
+++ b/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
@@ -117,7 +117,120 @@ function overlappingParallelCandidate(
   const overlapMax = Math.min(first.max, second.max)
   if (overlapMax - overlapMin <= EPSILON) return null
 
-  return { mergedFixed: (first.fixed + second.fixed) / 2 }
+  return true
+}
+
+function isInternalSegment(trace: SolvedTracePath, segment: Segment) {
+  return segment.startIndex > 0 && segment.endIndex < trace.tracePath.length - 1
+}
+
+function getSnappedFixedValue(
+  firstTrace: SolvedTracePath,
+  first: Segment,
+  secondTrace: SolvedTracePath,
+  second: Segment,
+) {
+  const canMoveFirst = isInternalSegment(firstTrace, first)
+  const canMoveSecond = isInternalSegment(secondTrace, second)
+
+  if (canMoveFirst && canMoveSecond) return (first.fixed + second.fixed) / 2
+  if (canMoveFirst) return second.fixed
+  if (canMoveSecond) return first.fixed
+
+  return null
+}
+
+function cloneTraces(traces: SolvedTracePath[]) {
+  return traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+}
+
+function rangesOverlap(
+  firstMin: number,
+  firstMax: number,
+  secondMin: number,
+  secondMax: number,
+) {
+  return (
+    Math.min(firstMax, secondMax) - Math.max(firstMin, secondMin) >= -EPSILON
+  )
+}
+
+function axisAlignedSegmentsIntersect(
+  firstTrace: SolvedTracePath,
+  first: Segment,
+  secondTrace: SolvedTracePath,
+  second: Segment,
+) {
+  if (first.orientation === second.orientation) {
+    return (
+      almostEqual(first.fixed, second.fixed) &&
+      rangesOverlap(first.min, first.max, second.min, second.max)
+    )
+  }
+
+  const horizontal = first.orientation === "horizontal" ? first : second
+  const vertical = first.orientation === "vertical" ? first : second
+  return (
+    vertical.fixed >= horizontal.min - EPSILON &&
+    vertical.fixed <= horizontal.max + EPSILON &&
+    horizontal.fixed >= vertical.min - EPSILON &&
+    horizontal.fixed <= vertical.max + EPSILON
+  )
+}
+
+function countDifferentNetIntersections(traces: SolvedTracePath[]) {
+  const segments = traces.flatMap((trace, traceIndex) =>
+    getSegments(trace, traceIndex),
+  )
+  let intersections = 0
+
+  for (let i = 0; i < segments.length; i++) {
+    const first = segments[i]!
+    const firstTrace = traces[first.traceIndex]!
+    for (let j = i + 1; j < segments.length; j++) {
+      const second = segments[j]!
+      const secondTrace = traces[second.traceIndex]!
+      if (firstTrace.globalConnNetId === secondTrace.globalConnNetId) continue
+      if (
+        axisAlignedSegmentsIntersect(firstTrace, first, secondTrace, second)
+      ) {
+        intersections++
+      }
+    }
+  }
+
+  return intersections
+}
+
+function moveParallelSegmentsSafely(
+  traces: SolvedTracePath[],
+  first: Segment,
+  second: Segment,
+  snappedFixed: number,
+) {
+  const candidateTraces = cloneTraces(traces)
+  const candidateFirstTrace = candidateTraces[first.traceIndex]!
+  const candidateSecondTrace = candidateTraces[second.traceIndex]!
+
+  if (isInternalSegment(candidateFirstTrace, first)) {
+    moveSegmentFixed(candidateFirstTrace, first, snappedFixed)
+  }
+  if (isInternalSegment(candidateSecondTrace, second)) {
+    moveSegmentFixed(candidateSecondTrace, second, snappedFixed)
+  }
+
+  if (
+    countDifferentNetIntersections(candidateTraces) >
+    countDifferentNetIntersections(traces)
+  ) {
+    return false
+  }
+
+  traces.splice(0, traces.length, ...candidateTraces)
+  return true
 }
 
 function moveSegmentEndpoint(
@@ -207,8 +320,24 @@ export function mergeSameNetTraceSegments({
           gapThreshold,
         )
         if (parallelMerge) {
-          moveSegmentFixed(firstTrace, first, parallelMerge.mergedFixed)
-          moveSegmentFixed(secondTrace, second, parallelMerge.mergedFixed)
+          const snappedFixed = getSnappedFixedValue(
+            firstTrace,
+            first,
+            secondTrace,
+            second,
+          )
+          if (snappedFixed === null) continue
+
+          if (
+            !moveParallelSegmentsSafely(
+              mergedTraces,
+              first,
+              second,
+              snappedFixed,
+            )
+          ) {
+            continue
+          }
           changed = true
           break outer
         }

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceMergeSolver } from "../SameNetTraceMergeSolver/SameNetTraceMergeSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -75,6 +76,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetTraceMergeSolver?: SameNetTraceMergeSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -218,10 +220,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceMergeSolver",
+      SameNetTraceMergeSolver,
+      (instance) => [
+        {
+          traces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceMergeSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +249,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceMergeSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
+++ b/tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
@@ -74,53 +74,69 @@ test("does not merge same-net endpoints beyond the gap threshold", () => {
   expect(traces[1]!.tracePath[0]).toEqual({ x: 1.3, y: 0 })
 })
 
-test("snaps close overlapping same-net parallel horizontal segments onto a shared y axis", () => {
+test("snaps close overlapping same-net internal horizontal segments onto a shared y axis", () => {
   const traces = mergeSameNetTraceSegments({
     traces: [
       makeTrace("a", "net1", [
+        { x: 0, y: -1 },
         { x: 0, y: 0 },
         { x: 3, y: 0 },
+        { x: 3, y: -1 },
       ]),
       makeTrace("b", "net1", [
+        { x: 1, y: 1 },
         { x: 1, y: 0.08 },
         { x: 4, y: 0.08 },
+        { x: 4, y: 1 },
       ]),
     ],
     gapThreshold: 0.15,
   })
 
   expect(traces[0]!.tracePath).toEqual([
+    { x: 0, y: -1 },
     { x: 0, y: 0.04 },
     { x: 3, y: 0.04 },
+    { x: 3, y: -1 },
   ])
   expect(traces[1]!.tracePath).toEqual([
+    { x: 1, y: 1 },
     { x: 1, y: 0.04 },
     { x: 4, y: 0.04 },
+    { x: 4, y: 1 },
   ])
 })
 
-test("snaps close overlapping same-net parallel vertical segments onto a shared x axis", () => {
+test("snaps close overlapping same-net internal vertical segments onto a shared x axis", () => {
   const traces = mergeSameNetTraceSegments({
     traces: [
       makeTrace("a", "net1", [
+        { x: -1, y: 0 },
         { x: 0, y: 0 },
         { x: 0, y: 3 },
+        { x: -1, y: 3 },
       ]),
       makeTrace("b", "net1", [
+        { x: 1, y: 1 },
         { x: 0.08, y: 1 },
         { x: 0.08, y: 4 },
+        { x: 1, y: 4 },
       ]),
     ],
     gapThreshold: 0.15,
   })
 
   expect(traces[0]!.tracePath).toEqual([
+    { x: -1, y: 0 },
     { x: 0.04, y: 0 },
     { x: 0.04, y: 3 },
+    { x: -1, y: 3 },
   ])
   expect(traces[1]!.tracePath).toEqual([
+    { x: 1, y: 1 },
     { x: 0.04, y: 1 },
     { x: 0.04, y: 4 },
+    { x: 1, y: 4 },
   ])
 })
 
@@ -146,5 +162,42 @@ test("does not snap close parallel segments unless their spans overlap", () => {
   expect(traces[1]!.tracePath).toEqual([
     { x: 1.1, y: 0.08 },
     { x: 2, y: 0.08 },
+  ])
+})
+
+test("does not snap close parallel segments when that would add a different-net crossing", () => {
+  const traces = mergeSameNetTraceSegments({
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: -1 },
+        { x: 0, y: 0 },
+        { x: 3, y: 0 },
+        { x: 3, y: -1 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 1, y: 1 },
+        { x: 1, y: 0.08 },
+        { x: 4, y: 0.08 },
+        { x: 4, y: 1 },
+      ]),
+      makeTrace("c", "net2", [
+        { x: 2, y: 0.02 },
+        { x: 2, y: 0.06 },
+      ]),
+    ],
+    gapThreshold: 0.15,
+  })
+
+  expect(traces[0]!.tracePath).toEqual([
+    { x: 0, y: -1 },
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: -1 },
+  ])
+  expect(traces[1]!.tracePath).toEqual([
+    { x: 1, y: 1 },
+    { x: 1, y: 0.08 },
+    { x: 4, y: 0.08 },
+    { x: 4, y: 1 },
   ])
 })

--- a/tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
+++ b/tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
@@ -73,3 +73,78 @@ test("does not merge same-net endpoints beyond the gap threshold", () => {
   expect(traces[0]!.tracePath[1]).toEqual({ x: 1, y: 0 })
   expect(traces[1]!.tracePath[0]).toEqual({ x: 1.3, y: 0 })
 })
+
+test("snaps close overlapping same-net parallel horizontal segments onto a shared y axis", () => {
+  const traces = mergeSameNetTraceSegments({
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 3, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 1, y: 0.08 },
+        { x: 4, y: 0.08 },
+      ]),
+    ],
+    gapThreshold: 0.15,
+  })
+
+  expect(traces[0]!.tracePath).toEqual([
+    { x: 0, y: 0.04 },
+    { x: 3, y: 0.04 },
+  ])
+  expect(traces[1]!.tracePath).toEqual([
+    { x: 1, y: 0.04 },
+    { x: 4, y: 0.04 },
+  ])
+})
+
+test("snaps close overlapping same-net parallel vertical segments onto a shared x axis", () => {
+  const traces = mergeSameNetTraceSegments({
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 3 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 0.08, y: 1 },
+        { x: 0.08, y: 4 },
+      ]),
+    ],
+    gapThreshold: 0.15,
+  })
+
+  expect(traces[0]!.tracePath).toEqual([
+    { x: 0.04, y: 0 },
+    { x: 0.04, y: 3 },
+  ])
+  expect(traces[1]!.tracePath).toEqual([
+    { x: 0.04, y: 1 },
+    { x: 0.04, y: 4 },
+  ])
+})
+
+test("does not snap close parallel segments unless their spans overlap", () => {
+  const traces = mergeSameNetTraceSegments({
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 1.1, y: 0.08 },
+        { x: 2, y: 0.08 },
+      ]),
+    ],
+    gapThreshold: 0.15,
+  })
+
+  expect(traces[0]!.tracePath).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ])
+  expect(traces[1]!.tracePath).toEqual([
+    { x: 1.1, y: 0.08 },
+    { x: 2, y: 0.08 },
+  ])
+})

--- a/tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
+++ b/tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import { mergeSameNetTraceSegments } from "lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  id: string,
+  netId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [] as any,
+    tracePath,
+    mspConnectionPairIds: [id],
+    pinIds: [],
+  }) as SolvedTracePath
+
+test("merges close collinear same-net trace segment endpoints", () => {
+  const traces = mergeSameNetTraceSegments({
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 1.1, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+    gapThreshold: 0.15,
+  })
+
+  expect(traces[0]!.tracePath[1]).toEqual({ x: 1.05, y: 0 })
+  expect(traces[1]!.tracePath[0]).toEqual({ x: 1.05, y: 0 })
+})
+
+test("does not merge close endpoints from different nets", () => {
+  const traces = mergeSameNetTraceSegments({
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("b", "net2", [
+        { x: 1.1, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+    gapThreshold: 0.15,
+  })
+
+  expect(traces[0]!.tracePath[1]).toEqual({ x: 1, y: 0 })
+  expect(traces[1]!.tracePath[0]).toEqual({ x: 1.1, y: 0 })
+})
+
+test("does not merge same-net endpoints beyond the gap threshold", () => {
+  const traces = mergeSameNetTraceSegments({
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 1.3, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+    gapThreshold: 0.15,
+  })
+
+  expect(traces[0]!.tracePath[1]).toEqual({ x: 1, y: 0 })
+  expect(traces[1]!.tracePath[0]).toEqual({ x: 1.3, y: 0 })
+})


### PR DESCRIPTION
## Summary
- add a `SameNetTraceMergeSolver` post-cleanup phase to conservatively join nearby collinear trace segment endpoints on the same global net
- keep different nets and gaps beyond the threshold untouched
- add focused unit coverage for merge/no-merge behavior

/claim #29

## Testing
- `bunx biome format .`
- `bunx tsc --noEmit`
- `bun test`
