### PR TITLE
feat: merge close same-net trace segments

### DIFF
--- a/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
+++ b/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
@@ -1,0 +1,299 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject, Line } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+import type { InputProblem } from "lib/types/InputProblem"
+
+type MergeAxis = "x" | "y"
+
+interface SameNetTraceMergeSolverInput {
+  inputProblem: InputProblem
+  traces: SolvedTracePath[]
+  mergeDistance?: number
+  minOverlap?: number
+}
+
+interface TraceSegment {
+  traceIndex: number
+  segmentIndex: number
+  globalConnNetId: string
+  axis: MergeAxis
+  constantCoord: number
+  start: number
+  end: number
+}
+
+const EPS = 2e-3
+const DEFAULT_MERGE_DISTANCE = 0.15
+const DEFAULT_MIN_OVERLAP = 0.05
+
+const clonePoint = (point: Point): Point => ({ x: point.x, y: point.y })
+
+const cloneTrace = (trace: SolvedTracePath): SolvedTracePath => ({
+  ...trace,
+  tracePath: trace.tracePath.map(clonePoint),
+})
+
+const rangesOverlap = (
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number,
+) => Math.min(aEnd, bEnd) - Math.max(aStart, bStart)
+
+const isHorizontal = (p1: Point, p2: Point) => Math.abs(p1.y - p2.y) < EPS
+const isVertical = (p1: Point, p2: Point) => Math.abs(p1.x - p2.x) < EPS
+
+const canMoveSegment = (
+  points: Point[],
+  segmentIndex: number,
+  axis: MergeAxis,
+) => {
+  if (segmentIndex === 0 || segmentIndex >= points.length - 2) return false
+
+  const p1 = points[segmentIndex]!
+  const p2 = points[segmentIndex + 1]!
+  const prev = points[segmentIndex - 1]
+  const next = points[segmentIndex + 2]
+
+  if (axis === "y") {
+    if (prev && Math.abs(prev.x - p1.x) >= EPS) return false
+    if (next && Math.abs(next.x - p2.x) >= EPS) return false
+  } else {
+    if (prev && Math.abs(prev.y - p1.y) >= EPS) return false
+    if (next && Math.abs(next.y - p2.y) >= EPS) return false
+  }
+
+  return true
+}
+
+const getMergeableSegments = (traces: SolvedTracePath[]): TraceSegment[] => {
+  const segments: TraceSegment[] = []
+
+  for (let traceIndex = 0; traceIndex < traces.length; traceIndex++) {
+    const trace = traces[traceIndex]!
+    const points = trace.tracePath
+
+    for (
+      let segmentIndex = 0;
+      segmentIndex < points.length - 1;
+      segmentIndex++
+    ) {
+      const p1 = points[segmentIndex]!
+      const p2 = points[segmentIndex + 1]!
+      const horizontal = isHorizontal(p1, p2)
+      const vertical = isVertical(p1, p2)
+
+      if (!horizontal && !vertical) continue
+
+      const axis: MergeAxis = horizontal ? "y" : "x"
+      if (!canMoveSegment(points, segmentIndex, axis)) continue
+
+      segments.push({
+        traceIndex,
+        segmentIndex,
+        globalConnNetId: trace.globalConnNetId,
+        axis,
+        constantCoord: horizontal ? p1.y : p1.x,
+        start: horizontal ? Math.min(p1.x, p2.x) : Math.min(p1.y, p2.y),
+        end: horizontal ? Math.max(p1.x, p2.x) : Math.max(p1.y, p2.y),
+      })
+    }
+  }
+
+  return segments
+}
+
+const hasDifferentNetBetweenSegments = (
+  a: TraceSegment,
+  b: TraceSegment,
+  allSegments: TraceSegment[],
+  minOverlap: number,
+) => {
+  const lowerCoord = Math.min(a.constantCoord, b.constantCoord)
+  const upperCoord = Math.max(a.constantCoord, b.constantCoord)
+
+  return allSegments.some((candidate) => {
+    if (candidate.globalConnNetId === a.globalConnNetId) return false
+    if (candidate.axis !== a.axis) return false
+    if (candidate.constantCoord <= lowerCoord + EPS) return false
+    if (candidate.constantCoord >= upperCoord - EPS) return false
+
+    return (
+      rangesOverlap(a.start, a.end, candidate.start, candidate.end) >=
+        minOverlap &&
+      rangesOverlap(b.start, b.end, candidate.start, candidate.end) >=
+        minOverlap
+    )
+  })
+}
+
+const shouldMergeSegments = (
+  a: TraceSegment,
+  b: TraceSegment,
+  allSegments: TraceSegment[],
+  mergeDistance: number,
+  minOverlap: number,
+) => {
+  if (a.traceIndex === b.traceIndex) return false
+  if (a.globalConnNetId !== b.globalConnNetId) return false
+  if (a.axis !== b.axis) return false
+  if (Math.abs(a.constantCoord - b.constantCoord) > mergeDistance) return false
+  if (rangesOverlap(a.start, a.end, b.start, b.end) < minOverlap) return false
+  if (hasDifferentNetBetweenSegments(a, b, allSegments, minOverlap))
+    return false
+
+  return true
+}
+
+const getMergeComponents = (
+  segments: TraceSegment[],
+  mergeDistance: number,
+  minOverlap: number,
+) => {
+  const visited = new Set<number>()
+  const components: TraceSegment[][] = []
+
+  for (let i = 0; i < segments.length; i++) {
+    if (visited.has(i)) continue
+
+    const queue = [i]
+    const component: TraceSegment[] = []
+    visited.add(i)
+
+    while (queue.length > 0) {
+      const currentIndex = queue.shift()!
+      const current = segments[currentIndex]!
+      component.push(current)
+
+      for (let j = 0; j < segments.length; j++) {
+        if (visited.has(j)) continue
+
+        if (
+          shouldMergeSegments(
+            current,
+            segments[j]!,
+            segments,
+            mergeDistance,
+            minOverlap,
+          )
+        ) {
+          visited.add(j)
+          queue.push(j)
+        }
+      }
+    }
+
+    if (component.length > 1) {
+      components.push(component)
+    }
+  }
+
+  return components
+}
+
+const moveSegmentToCoord = (
+  points: Point[],
+  segmentIndex: number,
+  axis: MergeAxis,
+  coord: number,
+) => {
+  const p1 = points[segmentIndex]!
+  const p2 = points[segmentIndex + 1]!
+
+  if (axis === "y") {
+    p1.y = coord
+    p2.y = coord
+  } else {
+    p1.x = coord
+    p2.x = coord
+  }
+}
+
+export const mergeSameNetTraceSegments = (
+  traces: SolvedTracePath[],
+  opts: {
+    mergeDistance?: number
+    minOverlap?: number
+  } = {},
+) => {
+  const mergeDistance = opts.mergeDistance ?? DEFAULT_MERGE_DISTANCE
+  const minOverlap = opts.minOverlap ?? DEFAULT_MIN_OVERLAP
+  const outputTraces = traces.map(cloneTrace)
+  const segments = getMergeableSegments(outputTraces)
+  const components = getMergeComponents(segments, mergeDistance, minOverlap)
+
+  for (const component of components) {
+    const targetCoord =
+      component.reduce((sum, segment) => sum + segment.constantCoord, 0) /
+      component.length
+
+    for (const segment of component) {
+      moveSegmentToCoord(
+        outputTraces[segment.traceIndex]!.tracePath,
+        segment.segmentIndex,
+        segment.axis,
+        targetCoord,
+      )
+    }
+  }
+
+  return {
+    traces: outputTraces.map((trace) => ({
+      ...trace,
+      tracePath: simplifyPath(trace.tracePath),
+    })),
+    mergeCount: components.length,
+  }
+}
+
+export class SameNetTraceMergeSolver extends BaseSolver {
+  private input: SameNetTraceMergeSolverInput
+  outputTraces: SolvedTracePath[]
+  mergeCount = 0
+
+  constructor(input: SameNetTraceMergeSolverInput) {
+    super()
+    this.input = input
+    this.outputTraces = input.traces.map(cloneTrace)
+  }
+
+  override _step() {
+    const output = mergeSameNetTraceSegments(this.outputTraces, {
+      mergeDistance: this.input.mergeDistance,
+      minOverlap: this.input.minOverlap,
+    })
+
+    this.outputTraces = output.traces
+    this.mergeCount = output.mergeCount
+    this.solved = true
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+      mergeCount: this.mergeCount,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics = visualizeInputProblem(this.input.inputProblem, {
+      chipAlpha: 0.1,
+      connectionAlpha: 0.1,
+    })
+
+    graphics.lines = graphics.lines ?? []
+
+    for (const trace of this.outputTraces) {
+      const line: Line = {
+        points: trace.tracePath,
+        strokeColor: "purple",
+      }
+      graphics.lines.push(line)
+    }
+
+    return graphics
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceMergeSolver } from "../SameNetTraceMergeSolver/SameNetTraceMergeSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -80,6 +81,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
   traceAnchoredNetLabelOverlapSolver?: TraceAnchoredNetLabelOverlapSolver
   netLabelTraceCollisionSolver?: NetLabelTraceCollisionSolver
+  sameNetTraceMergeSolver?: SameNetTraceMergeSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -218,10 +220,21 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceMergeSolver",
+      SameNetTraceMergeSolver,
+      (instance) => [
+        {
+          inputProblem: instance.inputProblem,
+          traces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceMergeSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +250,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceMergeSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/site/SameNetTraceMergeSolver/SameNetTraceMergeSolver01.page.tsx
+++ b/site/SameNetTraceMergeSolver/SameNetTraceMergeSolver01.page.tsx
@@ -1,0 +1,55 @@
+import { SameNetTraceMergeSolver } from "lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { useMemo } from "react"
+import { GenericSolverDebugger } from "site/components/GenericSolverDebugger"
+
+const pin = (pinId: string, x: number, y: number) => ({
+  pinId,
+  chipId: "U1",
+  x,
+  y,
+})
+
+const trace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  yOffset: number,
+): SolvedTracePath => ({
+  mspPairId,
+  dcConnNetId: globalConnNetId,
+  globalConnNetId,
+  mspConnectionPairIds: [mspPairId],
+  pinIds: [`${mspPairId}-start`, `${mspPairId}-end`],
+  pins: [
+    pin(`${mspPairId}-start`, 0, yOffset),
+    pin(`${mspPairId}-end`, 2, yOffset),
+  ],
+  tracePath: [
+    { x: 0, y: yOffset },
+    { x: 0, y: 1 + yOffset },
+    { x: 2, y: 1 + yOffset },
+    { x: 2, y: yOffset },
+  ],
+})
+
+export default () => {
+  const solver = useMemo(() => {
+    const solver = new SameNetTraceMergeSolver({
+      inputProblem: {
+        chips: [],
+        directConnections: [],
+        netConnections: [],
+        availableNetLabelOrientations: {},
+      },
+      traces: [
+        trace("same-net-a", "net-1", 0),
+        trace("same-net-b", "net-1", 0.08),
+        trace("different-net", "net-2", 0.35),
+      ],
+    })
+    solver.solve()
+    return solver
+  }, [])
+
+  return <GenericSolverDebugger solver={solver} />
+}

--- a/tests/functions/merge-same-net-trace-segments.test.ts
+++ b/tests/functions/merge-same-net-trace-segments.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+import {
+  mergeSameNetTraceSegments,
+  SameNetTraceMergeSolver,
+} from "lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const pin = (pinId: string, x: number, y: number) => ({
+  pinId,
+  chipId: "U1",
+  x,
+  y,
+})
+
+const trace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  yOffset: number,
+): SolvedTracePath => ({
+  mspPairId,
+  dcConnNetId: globalConnNetId,
+  globalConnNetId,
+  mspConnectionPairIds: [mspPairId],
+  pinIds: [`${mspPairId}-start`, `${mspPairId}-end`],
+  pins: [
+    pin(`${mspPairId}-start`, 0, yOffset),
+    pin(`${mspPairId}-end`, 2, yOffset),
+  ],
+  tracePath: [
+    { x: 0, y: yOffset },
+    { x: 0, y: 1 + yOffset },
+    { x: 2, y: 1 + yOffset },
+    { x: 2, y: yOffset },
+  ],
+})
+
+const getMiddleSegmentY = (trace: SolvedTracePath) => trace.tracePath[1]!.y
+
+test("mergeSameNetTraceSegments aligns close overlapping same-net segments", () => {
+  const traceA = trace("a", "net-1", 0)
+  const traceB = trace("b", "net-1", 0.08)
+
+  const result = mergeSameNetTraceSegments([traceA, traceB])
+
+  expect(result.mergeCount).toBe(1)
+  expect(getMiddleSegmentY(result.traces[0]!)).toBeCloseTo(1.04)
+  expect(getMiddleSegmentY(result.traces[1]!)).toBeCloseTo(1.04)
+  expect(result.traces[0]!.tracePath[0]).toEqual({ x: 0, y: 0 })
+  expect(result.traces[1]!.tracePath[0]).toEqual({ x: 0, y: 0.08 })
+})
+
+test("mergeSameNetTraceSegments leaves different-net segments alone", () => {
+  const traceA = trace("a", "net-1", 0)
+  const traceB = trace("b", "net-2", 0.08)
+
+  const result = mergeSameNetTraceSegments([traceA, traceB])
+
+  expect(result.mergeCount).toBe(0)
+  expect(getMiddleSegmentY(result.traces[0]!)).toBe(1)
+  expect(getMiddleSegmentY(result.traces[1]!)).toBe(1.08)
+})
+
+test("mergeSameNetTraceSegments leaves same-net segments outside threshold alone", () => {
+  const traceA = trace("a", "net-1", 0)
+  const traceB = trace("b", "net-1", 0.3)
+
+  const result = mergeSameNetTraceSegments([traceA, traceB])
+
+  expect(result.mergeCount).toBe(0)
+  expect(getMiddleSegmentY(result.traces[0]!)).toBe(1)
+  expect(getMiddleSegmentY(result.traces[1]!)).toBe(1.3)
+})
+
+test("SameNetTraceMergeSolver exposes merged traces through getOutput", () => {
+  const solver = new SameNetTraceMergeSolver({
+    inputProblem: {
+      chips: [],
+      directConnections: [],
+      netConnections: [],
+      availableNetLabelOrientations: {},
+    },
+    traces: [trace("a", "net-1", 0), trace("b", "net-1", 0.08)],
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput().mergeCount).toBe(1)
+  expect(getMiddleSegmentY(solver.getOutput().traces[0]!)).toBeCloseTo(1.04)
+})


### PR DESCRIPTION
## Issue
Closes #29

/claim #29

## Summary
- Adds `SameNetTraceMergeSolver` after trace cleanup to merge close overlapping same-net orthogonal trace segments onto a shared axis.
- Leaves different-net traces and same-net traces outside the merge threshold untouched.
- Adds a Cosmos debug page for `SameNetTraceMergeSolver01`.

## Verification
- `npx bun test`
- `npx biome format .`
- `npx -y -p typescript@5 tsc --noEmit`
- `git diff --check`