### PR TITLE
feat: merge nearby parallel same-net traces (#34)

### DIFF
--- a/lib/solvers/MergeParallelTracesSolver/MergeParallelTracesSolver.ts
+++ b/lib/solvers/MergeParallelTracesSolver/MergeParallelTracesSolver.ts
@@ -26,7 +26,12 @@ export class MergeParallelTracesSolver extends BaseSolver {
     this.mergeDistance = params.mergeDistance ?? DEFAULT_MERGE_DISTANCE
 
     for (const tracePath of this.inputTracePaths) {
-      this.correctedTraceMap[tracePath.mspPairId] = tracePath
+      this.correctedTraceMap[tracePath.mspPairId] = {
+        ...tracePath,
+        tracePath: tracePath.tracePath.map((point) => ({ ...point })),
+        mspConnectionPairIds: [...tracePath.mspConnectionPairIds],
+        pinIds: [...tracePath.pinIds],
+      }
     }
   }
 

--- a/lib/solvers/MergeParallelTracesSolver/MergeParallelTracesSolver.ts
+++ b/lib/solvers/MergeParallelTracesSolver/MergeParallelTracesSolver.ts
@@ -1,0 +1,72 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { MspConnectionPairId } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
+import {
+  DEFAULT_MERGE_DISTANCE,
+  mergeParallelTraceSegments,
+} from "./mergeParallelTraceSegments"
+
+export class MergeParallelTracesSolver extends BaseSolver {
+  inputProblem: InputProblem
+  inputTracePaths: SolvedTracePath[]
+  mergeDistance: number
+
+  correctedTraceMap: Record<MspConnectionPairId, SolvedTracePath> = {}
+
+  constructor(params: {
+    inputProblem: InputProblem
+    inputTracePaths: SolvedTracePath[]
+    mergeDistance?: number
+  }) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.inputTracePaths = params.inputTracePaths
+    this.mergeDistance = params.mergeDistance ?? DEFAULT_MERGE_DISTANCE
+
+    for (const tracePath of this.inputTracePaths) {
+      this.correctedTraceMap[tracePath.mspPairId] = tracePath
+    }
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof MergeParallelTracesSolver
+  >[0] {
+    return {
+      inputProblem: this.inputProblem,
+      inputTracePaths: this.inputTracePaths,
+      mergeDistance: this.mergeDistance,
+    }
+  }
+
+  override _step() {
+    const merged = mergeParallelTraceSegments(
+      this.inputTracePaths,
+      this.mergeDistance,
+    )
+
+    this.correctedTraceMap = Object.fromEntries(
+      merged.map((trace) => [trace.mspPairId, trace]),
+    )
+    this.solved = true
+  }
+
+  getOutput(): { traces: SolvedTracePath[] } {
+    return { traces: Object.values(this.correctedTraceMap) }
+  }
+
+  override visualize() {
+    const graphics = visualizeInputProblem(this.inputProblem)
+    graphics.lines = graphics.lines || []
+
+    for (const trace of Object.values(this.correctedTraceMap)) {
+      graphics.lines.push({
+        points: trace.tracePath,
+        strokeColor: "teal",
+      })
+    }
+
+    return graphics
+  }
+}

--- a/lib/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments.ts
+++ b/lib/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments.ts
@@ -131,7 +131,8 @@ const findConsolidatableSegmentPair = (
   if (!segmentA || !segmentB) return null
   if (segmentA.orientation !== segmentB.orientation) return null
   if (
-    Math.abs(segmentA.fixedCoordinate - segmentB.fixedCoordinate) > mergeDistance
+    Math.abs(segmentA.fixedCoordinate - segmentB.fixedCoordinate) >
+    mergeDistance
   ) {
     return null
   }
@@ -189,7 +190,9 @@ const consolidateRedundantParallelTraces = (
 
     outer: for (let indexA = 0; indexA < result.length; indexA++) {
       for (let indexB = indexA + 1; indexB < result.length; indexB++) {
-        if (result[indexA]!.globalConnNetId !== result[indexB]!.globalConnNetId) {
+        if (
+          result[indexA]!.globalConnNetId !== result[indexB]!.globalConnNetId
+        ) {
           continue
         }
 

--- a/lib/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments.ts
+++ b/lib/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments.ts
@@ -1,0 +1,322 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+const EPS = 1e-6
+export const DEFAULT_MERGE_DISTANCE = 0.15
+
+type Orientation = "horizontal" | "vertical"
+
+interface SegmentRef {
+  traceIndex: number
+  segmentIndex: number
+  orientation: Orientation
+  fixedCoordinate: number
+  rangeStart: number
+  rangeEnd: number
+}
+
+const getSegmentRef = (
+  traceIndex: number,
+  segmentIndex: number,
+  start: Point,
+  end: Point,
+): SegmentRef | null => {
+  if (Math.abs(start.y - end.y) < EPS) {
+    return {
+      traceIndex,
+      segmentIndex,
+      orientation: "horizontal",
+      fixedCoordinate: start.y,
+      rangeStart: Math.min(start.x, end.x),
+      rangeEnd: Math.max(start.x, end.x),
+    }
+  }
+
+  if (Math.abs(start.x - end.x) < EPS) {
+    return {
+      traceIndex,
+      segmentIndex,
+      orientation: "vertical",
+      fixedCoordinate: start.x,
+      rangeStart: Math.min(start.y, end.y),
+      rangeEnd: Math.max(start.y, end.y),
+    }
+  }
+
+  return null
+}
+
+const getSegments = (
+  traces: SolvedTracePath[],
+  traceIndex: number,
+  options: { includeTerminals: boolean },
+): SegmentRef[] => {
+  const trace = traces[traceIndex]!
+  const refs: SegmentRef[] = []
+  const startIndex = options.includeTerminals ? 0 : 1
+  const endIndex = options.includeTerminals
+    ? trace.tracePath.length - 1
+    : trace.tracePath.length - 2
+
+  for (let segmentIndex = startIndex; segmentIndex < endIndex; segmentIndex++) {
+    const start = trace.tracePath[segmentIndex]!
+    const end = trace.tracePath[segmentIndex + 1]!
+    const ref = getSegmentRef(traceIndex, segmentIndex, start, end)
+    if (ref) refs.push(ref)
+  }
+
+  return refs
+}
+
+const rangesOverlap = (a: SegmentRef, b: SegmentRef) =>
+  Math.min(a.rangeEnd, b.rangeEnd) - Math.max(a.rangeStart, b.rangeStart) > EPS
+
+const wouldOverlapDifferentNet = (
+  traces: SolvedTracePath[],
+  source: SegmentRef,
+  fixedCoordinate: number,
+) => {
+  for (let traceIndex = 0; traceIndex < traces.length; traceIndex++) {
+    const trace = traces[traceIndex]!
+    if (trace.globalConnNetId === traces[source.traceIndex]!.globalConnNetId) {
+      continue
+    }
+
+    for (
+      let segmentIndex = 0;
+      segmentIndex < trace.tracePath.length - 1;
+      segmentIndex++
+    ) {
+      const ref = getSegmentRef(
+        traceIndex,
+        segmentIndex,
+        trace.tracePath[segmentIndex]!,
+        trace.tracePath[segmentIndex + 1]!,
+      )
+      if (!ref) continue
+      if (ref.orientation !== source.orientation) continue
+      if (Math.abs(ref.fixedCoordinate - fixedCoordinate) > EPS) continue
+      if (rangesOverlap(source, ref)) return true
+    }
+  }
+
+  return false
+}
+
+const findConsolidatableSegmentPair = (
+  traces: SolvedTracePath[],
+  indexA: number,
+  indexB: number,
+  mergeDistance: number,
+): SegmentRef | null => {
+  const traceA = traces[indexA]!
+  const traceB = traces[indexB]!
+  if (traceA.tracePath.length !== 2 || traceB.tracePath.length !== 2) {
+    return null
+  }
+
+  const segmentA = getSegmentRef(
+    indexA,
+    0,
+    traceA.tracePath[0]!,
+    traceA.tracePath[1]!,
+  )
+  const segmentB = getSegmentRef(
+    indexB,
+    0,
+    traceB.tracePath[0]!,
+    traceB.tracePath[1]!,
+  )
+  if (!segmentA || !segmentB) return null
+  if (segmentA.orientation !== segmentB.orientation) return null
+  if (
+    Math.abs(segmentA.fixedCoordinate - segmentB.fixedCoordinate) > mergeDistance
+  ) {
+    return null
+  }
+  if (!rangesOverlap(segmentA, segmentB)) return null
+
+  return segmentA
+}
+
+const mergeTracePair = (
+  kept: SolvedTracePath,
+  removed: SolvedTracePath,
+  canonical: SegmentRef,
+): SolvedTracePath => {
+  const tracePath = kept.tracePath.map((point) => {
+    const p = { ...point }
+    if (canonical.orientation === "horizontal") {
+      p.y = canonical.fixedCoordinate
+    } else {
+      p.x = canonical.fixedCoordinate
+    }
+    return p
+  })
+
+  const pinIds = [...new Set([...kept.pinIds, ...removed.pinIds])]
+  const pinsById = new Map(
+    [...kept.pins, ...removed.pins].map((pin) => [pin.pinId, pin]),
+  )
+
+  return {
+    ...kept,
+    tracePath: simplifyPath(tracePath),
+    mspConnectionPairIds: [
+      ...new Set([
+        ...kept.mspConnectionPairIds,
+        ...removed.mspConnectionPairIds,
+      ]),
+    ],
+    pinIds,
+    pins: pinIds.map((pinId) => pinsById.get(pinId)!),
+  }
+}
+
+const consolidateRedundantParallelTraces = (
+  traces: SolvedTracePath[],
+  mergeDistance: number,
+): SolvedTracePath[] => {
+  const result = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  let changed = true
+  while (changed) {
+    changed = false
+
+    outer: for (let indexA = 0; indexA < result.length; indexA++) {
+      for (let indexB = indexA + 1; indexB < result.length; indexB++) {
+        if (result[indexA]!.globalConnNetId !== result[indexB]!.globalConnNetId) {
+          continue
+        }
+
+        const canonical = findConsolidatableSegmentPair(
+          result,
+          indexA,
+          indexB,
+          mergeDistance,
+        )
+        if (!canonical) continue
+        if (
+          wouldOverlapDifferentNet(result, canonical, canonical.fixedCoordinate)
+        ) {
+          continue
+        }
+
+        result[indexA] = mergeTracePair(
+          result[indexA]!,
+          result[indexB]!,
+          canonical,
+        )
+        result.splice(indexB, 1)
+        changed = true
+        break outer
+      }
+    }
+  }
+
+  return result
+}
+
+const snapSegmentFixedCoordinate = (
+  trace: SolvedTracePath,
+  segmentIndex: number,
+  orientation: Orientation,
+  fixedCoordinate: number,
+) => {
+  const tracePath = trace.tracePath.map((point) => ({ ...point }))
+  const start = tracePath[segmentIndex]!
+  const end = tracePath[segmentIndex + 1]!
+
+  if (orientation === "horizontal") {
+    start.y = fixedCoordinate
+    end.y = fixedCoordinate
+  } else {
+    start.x = fixedCoordinate
+    end.x = fixedCoordinate
+  }
+
+  return {
+    ...trace,
+    tracePath: simplifyPath(tracePath),
+  }
+}
+
+/**
+ * Snaps nearby parallel same-net trace segments onto a shared X or Y axis.
+ * Internal segments align to overlapping segments on sibling traces in the net.
+ */
+export const mergeParallelTraceSegments = (
+  traces: SolvedTracePath[],
+  mergeDistance = DEFAULT_MERGE_DISTANCE,
+): SolvedTracePath[] => {
+  const mergedTraces = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  const traceIndexesByNet = new Map<string, number[]>()
+  for (let traceIndex = 0; traceIndex < mergedTraces.length; traceIndex++) {
+    const netId = mergedTraces[traceIndex]!.globalConnNetId
+    const traceIndexes = traceIndexesByNet.get(netId) ?? []
+    traceIndexes.push(traceIndex)
+    traceIndexesByNet.set(netId, traceIndexes)
+  }
+
+  for (const traceIndexes of traceIndexesByNet.values()) {
+    if (traceIndexes.length < 2) continue
+
+    let changed = true
+    while (changed) {
+      changed = false
+
+      for (const traceIndex of traceIndexes.slice(1)) {
+        const candidates = getSegments(mergedTraces, traceIndex, {
+          includeTerminals: false,
+        })
+
+        for (const candidate of candidates) {
+          const target = traceIndexes
+            .filter((targetTraceIndex) => targetTraceIndex !== traceIndex)
+            .flatMap((targetTraceIndex) =>
+              getSegments(mergedTraces, targetTraceIndex, {
+                includeTerminals: true,
+              }),
+            )
+            .find(
+              (other) =>
+                other.orientation === candidate.orientation &&
+                Math.abs(other.fixedCoordinate - candidate.fixedCoordinate) <=
+                  mergeDistance &&
+                Math.abs(other.fixedCoordinate - candidate.fixedCoordinate) >
+                  EPS &&
+                rangesOverlap(candidate, other) &&
+                !wouldOverlapDifferentNet(
+                  mergedTraces,
+                  candidate,
+                  other.fixedCoordinate,
+                ),
+            )
+
+          if (!target) continue
+
+          mergedTraces[traceIndex] = snapSegmentFixedCoordinate(
+            mergedTraces[traceIndex]!,
+            candidate.segmentIndex,
+            candidate.orientation,
+            target.fixedCoordinate,
+          )
+          changed = true
+          break
+        }
+
+        if (changed) break
+      }
+    }
+  }
+
+  return consolidateRedundantParallelTraces(mergedTraces, mergeDistance)
+}

--- a/lib/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments.ts
+++ b/lib/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments.ts
@@ -156,11 +156,6 @@ const mergeTracePair = (
     return p
   })
 
-  const pinIds = [...new Set([...kept.pinIds, ...removed.pinIds])]
-  const pinsById = new Map(
-    [...kept.pins, ...removed.pins].map((pin) => [pin.pinId, pin]),
-  )
-
   return {
     ...kept,
     tracePath: simplifyPath(tracePath),
@@ -170,8 +165,7 @@ const mergeTracePair = (
         ...removed.mspConnectionPairIds,
       ]),
     ],
-    pinIds,
-    pins: pinIds.map((pinId) => pinsById.get(pinId)!),
+    pinIds: [...new Set([...kept.pinIds, ...removed.pinIds])],
   }
 }
 

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -12,6 +12,7 @@ import {
   type SolvedTracePath,
 } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
+import { MergeParallelTracesSolver } from "../MergeParallelTracesSolver/MergeParallelTracesSolver"
 import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
 import { visualizeInputProblem } from "./visualizeInputProblem"
@@ -71,6 +72,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   schematicTraceLinesSolver?: SchematicTraceLinesSolver
   longDistancePairSolver?: LongDistancePairSolver
   traceOverlapShiftSolver?: TraceOverlapShiftSolver
+  mergeParallelTracesSolver?: MergeParallelTracesSolver
   netLabelPlacementSolver?: NetLabelPlacementSolver
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
@@ -155,18 +157,24 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       },
     ),
     definePipelineStep(
+      "mergeParallelTracesSolver",
+      MergeParallelTracesSolver,
+      () => [
+        {
+          inputProblem: this.inputProblem,
+          inputTracePaths: Object.values(
+            this.traceOverlapShiftSolver!.correctedTraceMap,
+          ),
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       () => [
         {
           inputProblem: this.inputProblem,
-          inputTraceMap:
-            this.traceOverlapShiftSolver?.correctedTraceMap ??
-            Object.fromEntries(
-              this.longDistancePairSolver!.getOutput().allTracesMerged.map(
-                (p) => [p.mspPairId, p],
-              ),
-            ),
+          inputTraceMap: this.getRoutedTraceMap(),
         },
       ],
       {
@@ -179,13 +187,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       "traceLabelOverlapAvoidanceSolver",
       TraceLabelOverlapAvoidanceSolver,
       (instance) => {
-        const traceMap =
-          instance.traceOverlapShiftSolver?.correctedTraceMap ??
-          Object.fromEntries(
-            instance
-              .longDistancePairSolver!.getOutput()
-              .allTracesMerged.map((p) => [p.mspPairId, p]),
-          )
+        const traceMap = instance.getRoutedTraceMap()
         const traces = Object.values(traceMap)
         const netLabelPlacements =
           instance.netLabelPlacementSolver!.netLabelPlacements
@@ -319,6 +321,21 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   }
 
   currentPipelineStepIndex = 0
+
+  getRoutedTraceMap(): Record<string, SolvedTracePath> {
+    if (this.mergeParallelTracesSolver) {
+      return this.mergeParallelTracesSolver.correctedTraceMap
+    }
+    if (this.traceOverlapShiftSolver) {
+      return this.traceOverlapShiftSolver.correctedTraceMap
+    }
+    return Object.fromEntries(
+      this.longDistancePairSolver!.getOutput().allTracesMerged.map((p) => [
+        p.mspPairId,
+        p,
+      ]),
+    )
+  }
 
   private cloneAndCorrectInputProblem(original: InputProblem): InputProblem {
     const cloned: InputProblem = structuredClone({

--- a/site/examples/example35.page.tsx
+++ b/site/examples/example35.page.tsx
@@ -1,0 +1,6 @@
+import { PipelineDebugger } from "site/components/PipelineDebugger"
+import inputProblem from "../../tests/assets/example35.json"
+
+export { inputProblem }
+
+export default () => <PipelineDebugger inputProblem={inputProblem as any} />

--- a/tests/assets/example35-pre-merge-traces.json
+++ b/tests/assets/example35-pre-merge-traces.json
@@ -1,0 +1,24 @@
+[
+  {
+    "mspPairId": "trace-a",
+    "dcConnNetId": "GND",
+    "globalConnNetId": "GND",
+    "tracePath": [
+      { "x": 0, "y": 1 },
+      { "x": 4, "y": 1 }
+    ],
+    "mspConnectionPairIds": ["trace-a"],
+    "pinIds": ["U1.1", "U2.1"]
+  },
+  {
+    "mspPairId": "trace-b",
+    "dcConnNetId": "GND",
+    "globalConnNetId": "GND",
+    "tracePath": [
+      { "x": 0, "y": 1.1 },
+      { "x": 4, "y": 1.1 }
+    ],
+    "mspConnectionPairIds": ["trace-b"],
+    "pinIds": ["U1.2", "U2.2"]
+  }
+]

--- a/tests/assets/example35-pre-merge-traces.json
+++ b/tests/assets/example35-pre-merge-traces.json
@@ -1,24 +1,28 @@
 [
   {
     "mspPairId": "trace-a",
-    "dcConnNetId": "GND",
-    "globalConnNetId": "GND",
+    "dcConnNetId": "V3_3",
+    "globalConnNetId": "V3_3",
     "tracePath": [
+      { "x": 0, "y": 0 },
       { "x": 0, "y": 1 },
-      { "x": 4, "y": 1 }
+      { "x": 4, "y": 1 },
+      { "x": 4, "y": 0 }
     ],
     "mspConnectionPairIds": ["trace-a"],
-    "pinIds": ["U1.1", "U2.1"]
+    "pinIds": ["C14.1", "C15.1"]
   },
   {
     "mspPairId": "trace-b",
-    "dcConnNetId": "GND",
-    "globalConnNetId": "GND",
+    "dcConnNetId": "V3_3",
+    "globalConnNetId": "V3_3",
     "tracePath": [
-      { "x": 0, "y": 1.1 },
-      { "x": 4, "y": 1.1 }
+      { "x": 0, "y": 0.12 },
+      { "x": 0, "y": 1.12 },
+      { "x": 4, "y": 1.12 },
+      { "x": 4, "y": 0.12 }
     ],
     "mspConnectionPairIds": ["trace-b"],
-    "pinIds": ["U1.2", "U2.2"]
+    "pinIds": ["C14.2", "C15.2"]
   }
 ]

--- a/tests/assets/example35.json
+++ b/tests/assets/example35.json
@@ -1,50 +1,35 @@
 {
   "chips": [
     {
-      "chipId": "JP6",
-      "center": { "x": -3, "y": 0 },
-      "width": 1,
-      "height": 1.2,
+      "chipId": "U1",
+      "center": { "x": 0, "y": 1.05 },
+      "width": 0.5,
+      "height": 0.3,
       "pins": [
-        { "pinId": "JP6.VOUT", "x": -3, "y": 0.3 },
-        { "pinId": "JP6.GND", "x": -3, "y": -0.3 }
+        { "pinId": "U1.1", "x": 0, "y": 1 },
+        { "pinId": "U1.2", "x": 0, "y": 1.1 }
       ]
     },
     {
-      "chipId": "R1",
-      "center": { "x": 0, "y": 0 },
-      "width": 1.5,
-      "height": 0.5,
+      "chipId": "U2",
+      "center": { "x": 4, "y": 1.05 },
+      "width": 0.5,
+      "height": 0.3,
       "pins": [
-        { "pinId": "R1.1", "x": -0.6, "y": 0 },
-        { "pinId": "R1.2", "x": 0.6, "y": 0 }
-      ]
-    },
-    {
-      "chipId": "SJ2",
-      "center": { "x": 3, "y": 0 },
-      "width": 0.8,
-      "height": 0.8,
-      "pins": [
-        { "pinId": "SJ2.1", "x": 3, "y": 0.2 },
-        { "pinId": "SJ2.2", "x": 3, "y": -0.2 }
+        { "pinId": "U2.1", "x": 4, "y": 1 },
+        { "pinId": "U2.2", "x": 4, "y": 1.1 }
       ]
     }
   ],
   "directConnections": [],
   "netConnections": [
     {
-      "pinIds": ["JP6.GND", "R1.1", "SJ2.2"],
+      "pinIds": ["U1.1", "U1.2", "U2.1", "U2.2"],
       "netId": "GND"
-    },
-    {
-      "pinIds": ["JP6.VOUT", "R1.2", "SJ2.1"],
-      "netId": "VOUT"
     }
   ],
   "availableNetLabelOrientations": {
-    "GND": ["y-"],
-    "VOUT": ["x+"]
+    "GND": ["x+"]
   },
-  "maxMspPairDistance": 8
+  "maxMspPairDistance": 10
 }

--- a/tests/assets/example35.json
+++ b/tests/assets/example35.json
@@ -1,35 +1,35 @@
 {
   "chips": [
     {
-      "chipId": "U1",
-      "center": { "x": 0, "y": 1.05 },
-      "width": 0.5,
-      "height": 0.3,
+      "chipId": "C14",
+      "center": { "x": 0, "y": 0.5 },
+      "width": 0.4,
+      "height": 1.2,
       "pins": [
-        { "pinId": "U1.1", "x": 0, "y": 1 },
-        { "pinId": "U1.2", "x": 0, "y": 1.1 }
+        { "pinId": "C14.1", "x": 0, "y": 0 },
+        { "pinId": "C14.2", "x": 0, "y": 0.12 }
       ]
     },
     {
-      "chipId": "U2",
-      "center": { "x": 4, "y": 1.05 },
-      "width": 0.5,
-      "height": 0.3,
+      "chipId": "C15",
+      "center": { "x": 4, "y": 0.5 },
+      "width": 0.4,
+      "height": 1.2,
       "pins": [
-        { "pinId": "U2.1", "x": 4, "y": 1 },
-        { "pinId": "U2.2", "x": 4, "y": 1.1 }
+        { "pinId": "C15.1", "x": 4, "y": 0 },
+        { "pinId": "C15.2", "x": 4, "y": 0.12 }
       ]
     }
   ],
   "directConnections": [],
   "netConnections": [
     {
-      "pinIds": ["U1.1", "U1.2", "U2.1", "U2.2"],
-      "netId": "GND"
+      "pinIds": ["C14.1", "C14.2", "C15.1", "C15.2"],
+      "netId": "V3_3"
     }
   ],
   "availableNetLabelOrientations": {
-    "GND": ["x+"]
+    "V3_3": ["x+", "y+"]
   },
   "maxMspPairDistance": 10
 }

--- a/tests/assets/example35.json
+++ b/tests/assets/example35.json
@@ -1,0 +1,50 @@
+{
+  "chips": [
+    {
+      "chipId": "JP6",
+      "center": { "x": -3, "y": 0 },
+      "width": 1,
+      "height": 1.2,
+      "pins": [
+        { "pinId": "JP6.VOUT", "x": -3, "y": 0.3 },
+        { "pinId": "JP6.GND", "x": -3, "y": -0.3 }
+      ]
+    },
+    {
+      "chipId": "R1",
+      "center": { "x": 0, "y": 0 },
+      "width": 1.5,
+      "height": 0.5,
+      "pins": [
+        { "pinId": "R1.1", "x": -0.6, "y": 0 },
+        { "pinId": "R1.2", "x": 0.6, "y": 0 }
+      ]
+    },
+    {
+      "chipId": "SJ2",
+      "center": { "x": 3, "y": 0 },
+      "width": 0.8,
+      "height": 0.8,
+      "pins": [
+        { "pinId": "SJ2.1", "x": 3, "y": 0.2 },
+        { "pinId": "SJ2.2", "x": 3, "y": -0.2 }
+      ]
+    }
+  ],
+  "directConnections": [],
+  "netConnections": [
+    {
+      "pinIds": ["JP6.GND", "R1.1", "SJ2.2"],
+      "netId": "GND"
+    },
+    {
+      "pinIds": ["JP6.VOUT", "R1.2", "SJ2.1"],
+      "netId": "VOUT"
+    }
+  ],
+  "availableNetLabelOrientations": {
+    "GND": ["y-"],
+    "VOUT": ["x+"]
+  },
+  "maxMspPairDistance": 8
+}

--- a/tests/examples/__snapshots__/after-mergeParallelTraces.snap.svg
+++ b/tests/examples/__snapshots__/after-mergeParallelTraces.snap.svg
@@ -1,67 +1,47 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
   <rect width="100%" height="100%" fill="white" />
   <g>
-    <circle data-type="point" data-label="JP6.VOUT
-y+" data-x="-3" data-y="0.6" cx="80.57971014492756" cy="271.30434782608694" r="3" fill="hsl(318, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U1.1
+y-" data-x="0" data-y="1" cx="71.11111111111111" cy="326.2222222222222" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="JP6.GND
-y-" data-x="-3" data-y="-0.6" cx="80.57971014492756" cy="368.69565217391306" r="3" fill="hsl(351, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U1.2
+y+" data-x="0" data-y="1.1" cx="71.11111111111111" cy="313.7777777777777" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="R1.1
-x-" data-x="-0.75" data-y="0" cx="263.18840579710144" cy="320" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U2.1
+y-" data-x="4" data-y="1" cx="568.8888888888889" cy="326.2222222222222" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="R1.2
-x+" data-x="0.75" data-y="0" cx="384.92753623188406" cy="320" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U2.2
+y+" data-x="4" data-y="1.1" cx="568.8888888888889" cy="313.7777777777777" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="SJ2.1
-y+" data-x="3" data-y="0.4" cx="567.536231884058" cy="287.536231884058" r="3" fill="hsl(62, 100%, 50%, 0.8)" />
+    <polyline data-points="0,1 0,1.1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 71.11111111111111,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <circle data-type="point" data-label="SJ2.2
-y-" data-x="3" data-y="-0.4" cx="567.536231884058" cy="352.463768115942" r="3" fill="hsl(63, 100%, 50%, 0.8)" />
+    <polyline data-points="0,1 4,1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,326.2222222222222" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,-0.6 -0.75,0" data-type="line" data-label="" points="80.57971014492756,368.69565217391306 263.18840579710144,320" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1 4,1.1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,-0.6 3,-0.4" data-type="line" data-label="" points="80.57971014492756,368.69565217391306 567.536231884058,352.463768115942" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1.1 4,1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,326.2222222222222" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-0.75,0 3,-0.4" data-type="line" data-label="" points="263.18840579710144,320 567.536231884058,352.463768115942" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1.1 4,1.1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,0.6 0.75,0" data-type="line" data-label="" points="80.57971014492756,271.30434782608694 384.92753623188406,320" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4,1 4,1.1" data-type="line" data-label="" points="568.8888888888889,326.2222222222222 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,0.6 3,0.4" data-type="line" data-label="" points="80.57971014492756,271.30434782608694 567.536231884058,287.536231884058" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1 4,1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,326.2222222222222" fill="none" stroke="teal" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.75,0 3,0.4" data-type="line" data-label="" points="384.92753623188406,320 567.536231884058,287.536231884058" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <rect data-type="rect" data-label="U1" data-x="0" data-y="1.05" x="40" y="301.3333333333333" width="62.22222222222223" height="37.333333333333314" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
   </g>
   <g>
-    <polyline data-points="-0.75,2.220446049250313e-16 -1.875,2.220446049250313e-16 -1.875,-0.8000000000000002 -3,-0.8000000000000002 -3,-0.6" data-type="line" data-label="" points="263.18840579710144,320 171.8840579710145,320 171.8840579710145,384.92753623188406 80.57971014492756,384.92753623188406 80.57971014492756,368.69565217391306" fill="none" stroke="teal" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="3,-0.4 3,-0.6000000000000001 -0.95,-0.6000000000000001 -0.95,0 -0.75,0" data-type="line" data-label="" points="567.536231884058,352.463768115942 567.536231884058,368.69565217391306 246.95652173913044,368.69565217391306 246.95652173913044,320 263.18840579710144,320" fill="none" stroke="teal" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="0.75,-1.1102230246251565e-16 0.9500000000000002,-1.1102230246251565e-16 0.9500000000000002,0.8000000000000002 -3,0.8000000000000002 -3,0.6" data-type="line" data-label="" points="384.92753623188406,320 401.15942028985506,320 401.15942028985506,255.07246376811594 80.57971014492756,255.07246376811594 80.57971014492756,271.30434782608694" fill="none" stroke="teal" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="3,0.4 3,0.6000000000000001 1.875,0.6000000000000001 1.875,0 0.75,0" data-type="line" data-label="" points="567.536231884058,287.536231884058 567.536231884058,271.30434782608694 476.231884057971,271.30434782608694 476.231884057971,320 384.92753623188406,320" fill="none" stroke="teal" stroke-width="1" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="JP6" data-x="-3" data-y="0" x="40" y="271.30434782608694" width="81.15942028985509" height="97.39130434782612" fill="hsl(208, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="R1" data-x="0" data-y="0" x="263.18840579710144" y="299.71014492753625" width="121.73913043478262" height="40.5797101449275" fill="hsl(71, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="SJ2" data-x="3" data-y="0" x="535.0724637681159" y="287.536231884058" width="64.92753623188412" height="64.927536231884" fill="hsl(27, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
+    <rect data-type="rect" data-label="U2" data-x="4" data-y="1.05" x="537.7777777777778" y="301.3333333333333" width="62.22222222222217" height="37.333333333333314" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -91,12 +71,12 @@ y-" data-x="3" data-y="-0.4" cx="567.536231884058" cy="352.463768115942" r="3" f
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 81.15942028985506,
+        "a": 124.44444444444444,
         "c": 0,
-        "e": 324.05797101449275,
+        "e": 71.11111111111111,
         "b": 0,
-        "d": -81.15942028985506,
-        "f": 320
+        "d": -124.44444444444444,
+        "f": 450.66666666666663
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/after-mergeParallelTraces.snap.svg
+++ b/tests/examples/__snapshots__/after-mergeParallelTraces.snap.svg
@@ -1,0 +1,123 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="JP6.VOUT
+y+" data-x="-3" data-y="0.6" cx="80.57971014492756" cy="271.30434782608694" r="3" fill="hsl(318, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="JP6.GND
+y-" data-x="-3" data-y="-0.6" cx="80.57971014492756" cy="368.69565217391306" r="3" fill="hsl(351, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.1
+x-" data-x="-0.75" data-y="0" cx="263.18840579710144" cy="320" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.2
+x+" data-x="0.75" data-y="0" cx="384.92753623188406" cy="320" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="SJ2.1
+y+" data-x="3" data-y="0.4" cx="567.536231884058" cy="287.536231884058" r="3" fill="hsl(62, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="SJ2.2
+y-" data-x="3" data-y="-0.4" cx="567.536231884058" cy="352.463768115942" r="3" fill="hsl(63, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <polyline data-points="-3,-0.6 -0.75,0" data-type="line" data-label="" points="80.57971014492756,368.69565217391306 263.18840579710144,320" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,-0.6 3,-0.4" data-type="line" data-label="" points="80.57971014492756,368.69565217391306 567.536231884058,352.463768115942" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-0.75,0 3,-0.4" data-type="line" data-label="" points="263.18840579710144,320 567.536231884058,352.463768115942" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,0.6 0.75,0" data-type="line" data-label="" points="80.57971014492756,271.30434782608694 384.92753623188406,320" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,0.6 3,0.4" data-type="line" data-label="" points="80.57971014492756,271.30434782608694 567.536231884058,287.536231884058" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.75,0 3,0.4" data-type="line" data-label="" points="384.92753623188406,320 567.536231884058,287.536231884058" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-0.75,2.220446049250313e-16 -1.875,2.220446049250313e-16 -1.875,-0.8000000000000002 -3,-0.8000000000000002 -3,-0.6" data-type="line" data-label="" points="263.18840579710144,320 171.8840579710145,320 171.8840579710145,384.92753623188406 80.57971014492756,384.92753623188406 80.57971014492756,368.69565217391306" fill="none" stroke="teal" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3,-0.4 3,-0.6000000000000001 -0.95,-0.6000000000000001 -0.95,0 -0.75,0" data-type="line" data-label="" points="567.536231884058,352.463768115942 567.536231884058,368.69565217391306 246.95652173913044,368.69565217391306 246.95652173913044,320 263.18840579710144,320" fill="none" stroke="teal" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.75,-1.1102230246251565e-16 0.9500000000000002,-1.1102230246251565e-16 0.9500000000000002,0.8000000000000002 -3,0.8000000000000002 -3,0.6" data-type="line" data-label="" points="384.92753623188406,320 401.15942028985506,320 401.15942028985506,255.07246376811594 80.57971014492756,255.07246376811594 80.57971014492756,271.30434782608694" fill="none" stroke="teal" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3,0.4 3,0.6000000000000001 1.875,0.6000000000000001 1.875,0 0.75,0" data-type="line" data-label="" points="567.536231884058,287.536231884058 567.536231884058,271.30434782608694 476.231884057971,271.30434782608694 476.231884057971,320 384.92753623188406,320" fill="none" stroke="teal" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="JP6" data-x="-3" data-y="0" x="40" y="271.30434782608694" width="81.15942028985509" height="97.39130434782612" fill="hsl(208, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="R1" data-x="0" data-y="0" x="263.18840579710144" y="299.71014492753625" width="121.73913043478262" height="40.5797101449275" fill="hsl(71, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="SJ2" data-x="3" data-y="0" x="535.0724637681159" y="287.536231884058" width="64.92753623188412" height="64.927536231884" fill="hsl(27, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 81.15942028985506,
+        "c": 0,
+        "e": 324.05797101449275,
+        "b": 0,
+        "d": -81.15942028985506,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/examples/__snapshots__/after-mergeParallelTraces.snap.svg
+++ b/tests/examples/__snapshots__/after-mergeParallelTraces.snap.svg
@@ -1,47 +1,50 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
   <rect width="100%" height="100%" fill="white" />
   <g>
-    <circle data-type="point" data-label="U1.1
-y-" data-x="0" data-y="1" cx="71.11111111111111" cy="326.2222222222222" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C14.1
+y-" data-x="0" data-y="0" cx="65.45454545454547" cy="383.6363636363636" r="3" fill="hsl(113, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U1.2
-y+" data-x="0" data-y="1.1" cx="71.11111111111111" cy="313.7777777777777" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C14.2
+x+" data-x="0" data-y="0.12" cx="65.45454545454547" cy="368.3636363636364" r="3" fill="hsl(114, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U2.1
-y-" data-x="4" data-y="1" cx="568.8888888888889" cy="326.2222222222222" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C15.1
+y-" data-x="4" data-y="0" cx="574.5454545454545" cy="383.6363636363636" r="3" fill="hsl(354, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U2.2
-y+" data-x="4" data-y="1.1" cx="568.8888888888889" cy="313.7777777777777" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C15.2
+x+" data-x="4" data-y="0.12" cx="574.5454545454545" cy="368.3636363636364" r="3" fill="hsl(355, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <polyline data-points="0,1 0,1.1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 71.11111111111111,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0 0,0.12" data-type="line" data-label="" points="65.45454545454547,383.6363636363636 65.45454545454547,368.3636363636364" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1 4,1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,326.2222222222222" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0 4,0" data-type="line" data-label="" points="65.45454545454547,383.6363636363636 574.5454545454545,383.6363636363636" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1 4,1.1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0 4,0.12" data-type="line" data-label="" points="65.45454545454547,383.6363636363636 574.5454545454545,368.3636363636364" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1.1 4,1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,326.2222222222222" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0.12 4,0" data-type="line" data-label="" points="65.45454545454547,368.3636363636364 574.5454545454545,383.6363636363636" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1.1 4,1.1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0.12 4,0.12" data-type="line" data-label="" points="65.45454545454547,368.3636363636364 574.5454545454545,368.3636363636364" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="4,1 4,1.1" data-type="line" data-label="" points="568.8888888888889,326.2222222222222 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4,0 4,0.12" data-type="line" data-label="" points="574.5454545454545,383.6363636363636 574.5454545454545,368.3636363636364" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1 4,1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,326.2222222222222" fill="none" stroke="teal" stroke-width="1" />
+    <polyline data-points="0,0 0,1 4,1 4,0" data-type="line" data-label="" points="65.45454545454547,383.6363636363636 65.45454545454547,256.3636363636364 574.5454545454545,256.3636363636364 574.5454545454545,383.6363636363636" fill="none" stroke="teal" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="0" data-y="1.05" x="40" y="301.3333333333333" width="62.22222222222223" height="37.333333333333314" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
+    <polyline data-points="0,0.12 0,1 4,1 4,0.12" data-type="line" data-label="" points="65.45454545454547,368.3636363636364 65.45454545454547,256.3636363636364 574.5454545454545,256.3636363636364 574.5454545454545,368.3636363636364" fill="none" stroke="teal" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U2" data-x="4" data-y="1.05" x="537.7777777777778" y="301.3333333333333" width="62.22222222222217" height="37.333333333333314" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
+    <rect data-type="rect" data-label="C14" data-x="0" data-y="0.5" x="40.000000000000014" y="243.63636363636363" width="50.90909090909091" height="152.72727272727275" fill="hsl(78, 100%, 50%, 0.8)" stroke="black" stroke-width="0.007857142857142858" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="C15" data-x="4" data-y="0.5" x="549.090909090909" y="243.63636363636363" width="50.90909090909099" height="152.72727272727275" fill="hsl(79, 100%, 50%, 0.8)" stroke="black" stroke-width="0.007857142857142858" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -71,12 +74,12 @@ y+" data-x="4" data-y="1.1" cx="568.8888888888889" cy="313.7777777777777" r="3" 
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 124.44444444444444,
+        "a": 127.27272727272727,
         "c": 0,
-        "e": 71.11111111111111,
+        "e": 65.45454545454547,
         "b": 0,
-        "d": -124.44444444444444,
-        "f": 450.66666666666663
+        "d": -127.27272727272727,
+        "f": 383.6363636363636
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/before-mergeParallelTraces.snap.svg
+++ b/tests/examples/__snapshots__/before-mergeParallelTraces.snap.svg
@@ -1,50 +1,50 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
   <rect width="100%" height="100%" fill="white" />
   <g>
-    <circle data-type="point" data-label="U1.1
-y-" data-x="0" data-y="1" cx="71.11111111111111" cy="326.2222222222222" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C14.1
+y-" data-x="0" data-y="0" cx="65.45454545454547" cy="384.90909090909093" r="3" fill="hsl(113, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U1.2
-y+" data-x="0" data-y="1.1" cx="71.11111111111111" cy="313.7777777777777" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C14.2
+x+" data-x="0" data-y="0.12" cx="65.45454545454547" cy="369.6363636363637" r="3" fill="hsl(114, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U2.1
-y-" data-x="4" data-y="1" cx="568.8888888888889" cy="326.2222222222222" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C15.1
+y-" data-x="4" data-y="0" cx="574.5454545454545" cy="384.90909090909093" r="3" fill="hsl(354, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U2.2
-y+" data-x="4" data-y="1.1" cx="568.8888888888889" cy="313.7777777777777" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C15.2
+x+" data-x="4" data-y="0.12" cx="574.5454545454545" cy="369.6363636363637" r="3" fill="hsl(355, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <polyline data-points="0,1 0,1.1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 71.11111111111111,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0 0,0.12" data-type="line" data-label="" points="65.45454545454547,384.90909090909093 65.45454545454547,369.6363636363637" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1 4,1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,326.2222222222222" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0 4,0" data-type="line" data-label="" points="65.45454545454547,384.90909090909093 574.5454545454545,384.90909090909093" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1 4,1.1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0 4,0.12" data-type="line" data-label="" points="65.45454545454547,384.90909090909093 574.5454545454545,369.6363636363637" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1.1 4,1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,326.2222222222222" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0.12 4,0" data-type="line" data-label="" points="65.45454545454547,369.6363636363637 574.5454545454545,384.90909090909093" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1.1 4,1.1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,0.12 4,0.12" data-type="line" data-label="" points="65.45454545454547,369.6363636363637 574.5454545454545,369.6363636363637" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="4,1 4,1.1" data-type="line" data-label="" points="568.8888888888889,326.2222222222222 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4,0 4,0.12" data-type="line" data-label="" points="574.5454545454545,384.90909090909093 574.5454545454545,369.6363636363637" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1 4,1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,326.2222222222222" fill="none" stroke="teal" stroke-width="1" />
+    <polyline data-points="0,0 0,1 4,1 4,0" data-type="line" data-label="" points="65.45454545454547,384.90909090909093 65.45454545454547,257.6363636363637 574.5454545454545,257.6363636363637 574.5454545454545,384.90909090909093" fill="none" stroke="teal" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0,1.1 4,1.1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,313.7777777777777" fill="none" stroke="teal" stroke-width="1" />
+    <polyline data-points="0,0.12 0,1.12 4,1.12 4,0.12" data-type="line" data-label="" points="65.45454545454547,369.6363636363637 65.45454545454547,242.36363636363637 574.5454545454545,242.36363636363637 574.5454545454545,369.6363636363637" fill="none" stroke="teal" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="0" data-y="1.05" x="40" y="301.3333333333333" width="62.22222222222223" height="37.333333333333314" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
+    <rect data-type="rect" data-label="C14" data-x="0" data-y="0.5" x="40.000000000000014" y="244.90909090909093" width="50.90909090909091" height="152.72727272727275" fill="hsl(78, 100%, 50%, 0.8)" stroke="black" stroke-width="0.007857142857142858" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U2" data-x="4" data-y="1.05" x="537.7777777777778" y="301.3333333333333" width="62.22222222222217" height="37.333333333333314" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
+    <rect data-type="rect" data-label="C15" data-x="4" data-y="0.5" x="549.090909090909" y="244.90909090909093" width="50.90909090909099" height="152.72727272727275" fill="hsl(79, 100%, 50%, 0.8)" stroke="black" stroke-width="0.007857142857142858" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -74,12 +74,12 @@ y+" data-x="4" data-y="1.1" cx="568.8888888888889" cy="313.7777777777777" r="3" 
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 124.44444444444444,
+        "a": 127.27272727272727,
         "c": 0,
-        "e": 71.11111111111111,
+        "e": 65.45454545454547,
         "b": 0,
-        "d": -124.44444444444444,
-        "f": 450.66666666666663
+        "d": -127.27272727272727,
+        "f": 384.90909090909093
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/before-mergeParallelTraces.snap.svg
+++ b/tests/examples/__snapshots__/before-mergeParallelTraces.snap.svg
@@ -1,67 +1,50 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
   <rect width="100%" height="100%" fill="white" />
   <g>
-    <circle data-type="point" data-label="JP6.VOUT
-y+" data-x="-3" data-y="0.6" cx="80.57971014492756" cy="271.30434782608694" r="3" fill="hsl(318, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U1.1
+y-" data-x="0" data-y="1" cx="71.11111111111111" cy="326.2222222222222" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="JP6.GND
-y-" data-x="-3" data-y="-0.6" cx="80.57971014492756" cy="368.69565217391306" r="3" fill="hsl(351, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U1.2
+y+" data-x="0" data-y="1.1" cx="71.11111111111111" cy="313.7777777777777" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="R1.1
-x-" data-x="-0.75" data-y="0" cx="263.18840579710144" cy="320" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U2.1
+y-" data-x="4" data-y="1" cx="568.8888888888889" cy="326.2222222222222" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="R1.2
-x+" data-x="0.75" data-y="0" cx="384.92753623188406" cy="320" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U2.2
+y+" data-x="4" data-y="1.1" cx="568.8888888888889" cy="313.7777777777777" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="SJ2.1
-y+" data-x="3" data-y="0.4" cx="567.536231884058" cy="287.536231884058" r="3" fill="hsl(62, 100%, 50%, 0.8)" />
+    <polyline data-points="0,1 0,1.1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 71.11111111111111,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <circle data-type="point" data-label="SJ2.2
-y-" data-x="3" data-y="-0.4" cx="567.536231884058" cy="352.463768115942" r="3" fill="hsl(63, 100%, 50%, 0.8)" />
+    <polyline data-points="0,1 4,1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,326.2222222222222" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,-0.6 -0.75,0" data-type="line" data-label="" points="80.57971014492756,368.69565217391306 263.18840579710144,320" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1 4,1.1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,-0.6 3,-0.4" data-type="line" data-label="" points="80.57971014492756,368.69565217391306 567.536231884058,352.463768115942" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1.1 4,1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,326.2222222222222" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-0.75,0 3,-0.4" data-type="line" data-label="" points="263.18840579710144,320 567.536231884058,352.463768115942" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1.1 4,1.1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,0.6 0.75,0" data-type="line" data-label="" points="80.57971014492756,271.30434782608694 384.92753623188406,320" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4,1 4,1.1" data-type="line" data-label="" points="568.8888888888889,326.2222222222222 568.8888888888889,313.7777777777777" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,0.6 3,0.4" data-type="line" data-label="" points="80.57971014492756,271.30434782608694 567.536231884058,287.536231884058" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1 4,1" data-type="line" data-label="" points="71.11111111111111,326.2222222222222 568.8888888888889,326.2222222222222" fill="none" stroke="teal" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.75,0 3,0.4" data-type="line" data-label="" points="384.92753623188406,320 567.536231884058,287.536231884058" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1.1 4,1.1" data-type="line" data-label="" points="71.11111111111111,313.7777777777777 568.8888888888889,313.7777777777777" fill="none" stroke="teal" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.75,2.220446049250313e-16 -1.875,2.220446049250313e-16 -1.875,-0.8000000000000002 -3,-0.8000000000000002 -3,-0.6" data-type="line" data-label="" points="263.18840579710144,320 171.8840579710145,320 171.8840579710145,384.92753623188406 80.57971014492756,384.92753623188406 80.57971014492756,368.69565217391306" fill="none" stroke="purple" stroke-width="1" />
+    <rect data-type="rect" data-label="U1" data-x="0" data-y="1.05" x="40" y="301.3333333333333" width="62.22222222222223" height="37.333333333333314" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
   </g>
   <g>
-    <polyline data-points="3,-0.4 3,-0.6000000000000001 -0.95,-0.6000000000000001 -0.95,0 -0.75,0" data-type="line" data-label="" points="567.536231884058,352.463768115942 567.536231884058,368.69565217391306 246.95652173913044,368.69565217391306 246.95652173913044,320 263.18840579710144,320" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="0.75,-1.1102230246251565e-16 0.9500000000000002,-1.1102230246251565e-16 0.9500000000000002,0.8000000000000002 -3,0.8000000000000002 -3,0.6" data-type="line" data-label="" points="384.92753623188406,320 401.15942028985506,320 401.15942028985506,255.07246376811594 80.57971014492756,255.07246376811594 80.57971014492756,271.30434782608694" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="3,0.4 3,0.6000000000000001 1.875,0.6000000000000001 1.875,0 0.75,0" data-type="line" data-label="" points="567.536231884058,287.536231884058 567.536231884058,271.30434782608694 476.231884057971,271.30434782608694 476.231884057971,320 384.92753623188406,320" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="JP6" data-x="-3" data-y="0" x="40" y="271.30434782608694" width="81.15942028985509" height="97.39130434782612" fill="hsl(208, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="R1" data-x="0" data-y="0" x="263.18840579710144" y="299.71014492753625" width="121.73913043478262" height="40.5797101449275" fill="hsl(71, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="SJ2" data-x="3" data-y="0" x="535.0724637681159" y="287.536231884058" width="64.92753623188412" height="64.927536231884" fill="hsl(27, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
+    <rect data-type="rect" data-label="U2" data-x="4" data-y="1.05" x="537.7777777777778" y="301.3333333333333" width="62.22222222222217" height="37.333333333333314" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -91,12 +74,12 @@ y-" data-x="3" data-y="-0.4" cx="567.536231884058" cy="352.463768115942" r="3" f
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 81.15942028985506,
+        "a": 124.44444444444444,
         "c": 0,
-        "e": 324.05797101449275,
+        "e": 71.11111111111111,
         "b": 0,
-        "d": -81.15942028985506,
-        "f": 320
+        "d": -124.44444444444444,
+        "f": 450.66666666666663
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/before-mergeParallelTraces.snap.svg
+++ b/tests/examples/__snapshots__/before-mergeParallelTraces.snap.svg
@@ -1,0 +1,123 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="JP6.VOUT
+y+" data-x="-3" data-y="0.6" cx="80.57971014492756" cy="271.30434782608694" r="3" fill="hsl(318, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="JP6.GND
+y-" data-x="-3" data-y="-0.6" cx="80.57971014492756" cy="368.69565217391306" r="3" fill="hsl(351, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.1
+x-" data-x="-0.75" data-y="0" cx="263.18840579710144" cy="320" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.2
+x+" data-x="0.75" data-y="0" cx="384.92753623188406" cy="320" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="SJ2.1
+y+" data-x="3" data-y="0.4" cx="567.536231884058" cy="287.536231884058" r="3" fill="hsl(62, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="SJ2.2
+y-" data-x="3" data-y="-0.4" cx="567.536231884058" cy="352.463768115942" r="3" fill="hsl(63, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <polyline data-points="-3,-0.6 -0.75,0" data-type="line" data-label="" points="80.57971014492756,368.69565217391306 263.18840579710144,320" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,-0.6 3,-0.4" data-type="line" data-label="" points="80.57971014492756,368.69565217391306 567.536231884058,352.463768115942" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-0.75,0 3,-0.4" data-type="line" data-label="" points="263.18840579710144,320 567.536231884058,352.463768115942" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,0.6 0.75,0" data-type="line" data-label="" points="80.57971014492756,271.30434782608694 384.92753623188406,320" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,0.6 3,0.4" data-type="line" data-label="" points="80.57971014492756,271.30434782608694 567.536231884058,287.536231884058" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.75,0 3,0.4" data-type="line" data-label="" points="384.92753623188406,320 567.536231884058,287.536231884058" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-0.75,2.220446049250313e-16 -1.875,2.220446049250313e-16 -1.875,-0.8000000000000002 -3,-0.8000000000000002 -3,-0.6" data-type="line" data-label="" points="263.18840579710144,320 171.8840579710145,320 171.8840579710145,384.92753623188406 80.57971014492756,384.92753623188406 80.57971014492756,368.69565217391306" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3,-0.4 3,-0.6000000000000001 -0.95,-0.6000000000000001 -0.95,0 -0.75,0" data-type="line" data-label="" points="567.536231884058,352.463768115942 567.536231884058,368.69565217391306 246.95652173913044,368.69565217391306 246.95652173913044,320 263.18840579710144,320" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.75,-1.1102230246251565e-16 0.9500000000000002,-1.1102230246251565e-16 0.9500000000000002,0.8000000000000002 -3,0.8000000000000002 -3,0.6" data-type="line" data-label="" points="384.92753623188406,320 401.15942028985506,320 401.15942028985506,255.07246376811594 80.57971014492756,255.07246376811594 80.57971014492756,271.30434782608694" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3,0.4 3,0.6000000000000001 1.875,0.6000000000000001 1.875,0 0.75,0" data-type="line" data-label="" points="567.536231884058,287.536231884058 567.536231884058,271.30434782608694 476.231884057971,271.30434782608694 476.231884057971,320 384.92753623188406,320" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="JP6" data-x="-3" data-y="0" x="40" y="271.30434782608694" width="81.15942028985509" height="97.39130434782612" fill="hsl(208, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="R1" data-x="0" data-y="0" x="263.18840579710144" y="299.71014492753625" width="121.73913043478262" height="40.5797101449275" fill="hsl(71, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="SJ2" data-x="3" data-y="0" x="535.0724637681159" y="287.536231884058" width="64.92753623188412" height="64.927536231884" fill="hsl(27, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012321428571428573" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 81.15942028985506,
+        "c": 0,
+        "e": 324.05797101449275,
+        "b": 0,
+        "d": -81.15942028985506,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/examples/__snapshots__/example35.snap.svg
+++ b/tests/examples/__snapshots__/example35.snap.svg
@@ -1,60 +1,60 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
   <rect width="100%" height="100%" fill="white" />
   <g>
-    <circle data-type="point" data-label="U1.1
-y-" data-x="0" data-y="0.9" cx="91.42857142857144" cy="331.42857142857144" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C14.1
+y-" data-x="0" data-y="-0.09999999999999998" cx="86.18556701030928" cy="371.958762886598" r="3" fill="hsl(113, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U1.2
-y+" data-x="0" data-y="1.2" cx="91.42857142857144" cy="297.1428571428571" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C14.2
+x-" data-x="-0.2" data-y="0.12" cx="63.09278350515464" cy="346.55670103092785" r="3" fill="hsl(114, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U2.1
-y-" data-x="4" data-y="0.9" cx="548.5714285714287" cy="331.42857142857144" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C15.1
+y-" data-x="4" data-y="-0.09999999999999998" cx="548.0412371134021" cy="371.958762886598" r="3" fill="hsl(354, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="U2.2
-y+" data-x="4" data-y="1.2" cx="548.5714285714287" cy="297.1428571428571" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="C15.2
+x-" data-x="3.8" data-y="0.12" cx="524.9484536082474" cy="346.55670103092785" r="3" fill="hsl(355, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="4" data-y="0.7" cx="548.5714285714287" cy="354.2857142857143" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.9999999999999996" data-y="-0.3" cx="548.0412371134021" cy="395.0515463917526" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="0,0.9 0,1.2" data-type="line" data-label="" points="91.42857142857144,331.42857142857144 91.42857142857144,297.1428571428571" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,-0.09999999999999998 -0.2,0.12" data-type="line" data-label="" points="86.18556701030928,371.958762886598 63.09278350515464,346.55670103092785" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,0.9 4,0.9" data-type="line" data-label="" points="91.42857142857144,331.42857142857144 548.5714285714287,331.42857142857144" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,-0.09999999999999998 4,-0.09999999999999998" data-type="line" data-label="" points="86.18556701030928,371.958762886598 548.0412371134021,371.958762886598" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,0.9 4,1.2" data-type="line" data-label="" points="91.42857142857144,331.42857142857144 548.5714285714287,297.1428571428571" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,-0.09999999999999998 3.8,0.12" data-type="line" data-label="" points="86.18556701030928,371.958762886598 524.9484536082474,346.55670103092785" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1.2 4,0.9" data-type="line" data-label="" points="91.42857142857144,297.1428571428571 548.5714285714287,331.42857142857144" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-0.2,0.12 4,-0.09999999999999998" data-type="line" data-label="" points="63.09278350515464,346.55670103092785 548.0412371134021,371.958762886598" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1.2 4,1.2" data-type="line" data-label="" points="91.42857142857144,297.1428571428571 548.5714285714287,297.1428571428571" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-0.2,0.12 3.8,0.12" data-type="line" data-label="" points="63.09278350515464,346.55670103092785 524.9484536082474,346.55670103092785" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="4,0.9 4,1.2" data-type="line" data-label="" points="548.5714285714287,331.42857142857144 548.5714285714287,297.1428571428571" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4,-0.09999999999999998 3.8,0.12" data-type="line" data-label="" points="548.0412371134021,371.958762886598 524.9484536082474,346.55670103092785" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="0,1.2 0,1.4 -0.45,1.4 -0.45,0.7 0,0.7 0,0.9" data-type="line" data-label="" points="91.42857142857144,297.1428571428571 91.42857142857144,274.2857142857143 40.000000000000014,274.2857142857143 40.000000000000014,354.2857142857143 91.42857142857144,354.2857142857143 91.42857142857144,331.42857142857144" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-0.2,0.12 -0.4,0.12 -0.4,-0.3 0,-0.3 0,-0.09999999999999998" data-type="line" data-label="" points="63.09278350515464,346.55670103092785 40,346.55670103092785 40,395.0515463917526 86.18556701030928,395.0515463917526 86.18556701030928,371.958762886598" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="4,0.9 4,0.7 0,0.7 0,0.9" data-type="line" data-label="" points="548.5714285714287,331.42857142857144 548.5714285714287,354.2857142857143 91.42857142857144,354.2857142857143 91.42857142857144,331.42857142857144" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="3.9999999999999996,-0.09999999999999998 3.9999999999999996,-0.3 0,-0.3 0,-0.09999999999999998" data-type="line" data-label="" points="548.0412371134021,371.958762886598 548.0412371134021,395.0515463917526 86.18556701030928,395.0515463917526 86.18556701030928,371.958762886598" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="4,1.1999999999999997 4,1.4 3.55,1.4 3.55,0.7 4,0.7 4,0.9" data-type="line" data-label="" points="548.5714285714287,297.14285714285717 548.5714285714287,274.2857142857143 497.14285714285717,274.2857142857143 497.14285714285717,354.2857142857143 548.5714285714287,354.2857142857143 548.5714285714287,331.42857142857144" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="3.8,0.12 3.5999999999999996,0.12 3.5999999999999996,-0.3 4,-0.3 4,-0.09999999999999998" data-type="line" data-label="" points="524.9484536082474,346.55670103092785 501.85567010309273,346.55670103092785 501.85567010309273,395.0515463917526 548.0412371134021,395.0515463917526 548.0412371134021,371.958762886598" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="0" data-y="1.05" x="62.857142857142875" y="297.1428571428571" width="57.14285714285714" height="34.285714285714334" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008749999999999999" />
+    <rect data-type="rect" data-label="C14" data-x="0" data-y="0.5" x="63.09278350515464" y="233.40206185567013" width="46.185567010309285" height="138.55670103092785" fill="hsl(78, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008660714285714285" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U2" data-x="4" data-y="1.05" x="520" y="297.1428571428571" width="57.14285714285711" height="34.285714285714334" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008749999999999999" />
+    <rect data-type="rect" data-label="C15" data-x="4" data-y="0.5" x="524.9484536082474" y="233.40206185567013" width="46.18556701030934" height="138.55670103092785" fill="hsl(79, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008660714285714285" />
   </g>
   <g>
-    <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0" data-x="4.225" data-y="0.7" x="548.5714285714286" y="342.85714285714283" width="51.428571428571445" height="22.85714285714289" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008749999999999999" />
+    <rect data-type="rect" data-label="netId: V3_3
+globalConnNetId: connectivity_net0" data-x="4.225" data-y="-0.3" x="548.0412371134021" y="383.50515463917526" width="51.958762886597924" height="23.09278350515467" fill="#ef444466" stroke="#ef4444" stroke-width="0.008660714285714285" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -84,12 +84,12 @@ globalConnNetId: connectivity_net0" data-x="4.225" data-y="0.7" x="548.571428571
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 114.28571428571429,
+        "a": 115.4639175257732,
         "c": 0,
-        "e": 91.42857142857144,
+        "e": 86.18556701030928,
         "b": 0,
-        "d": -114.28571428571429,
-        "f": 434.2857142857143
+        "d": -115.4639175257732,
+        "f": 360.41237113402065
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example35.snap.svg
+++ b/tests/examples/__snapshots__/example35.snap.svg
@@ -1,0 +1,137 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="JP6.VOUT
+y+" data-x="-3" data-y="0.6" cx="80.28776978417267" cy="253.52517985611513" r="3" fill="hsl(318, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="JP6.GND
+y-" data-x="-3" data-y="-0.6" cx="80.28776978417267" cy="350.2158273381295" r="3" fill="hsl(351, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.1
+x-" data-x="-0.75" data-y="0" cx="261.58273381294964" cy="301.8705035971223" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.2
+x+" data-x="0.75" data-y="0" cx="382.4460431654676" cy="301.8705035971223" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="SJ2.1
+y+" data-x="3" data-y="0.4" cx="563.7410071942445" cy="269.6402877697842" r="3" fill="hsl(62, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="SJ2.2
+y-" data-x="3" data-y="-0.4" cx="563.7410071942445" cy="334.1007194244604" r="3" fill="hsl(63, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="3" data-y="0.6000000000000001" cx="563.7410071942445" cy="253.5251798561151" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="-1.875" data-y="-0.8000000000000002" cx="170.93525179856113" cy="366.33093525179856" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <polyline data-points="-3,-0.6 -0.75,0" data-type="line" data-label="" points="80.28776978417267,350.2158273381295 261.58273381294964,301.8705035971223" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,-0.6 3,-0.4" data-type="line" data-label="" points="80.28776978417267,350.2158273381295 563.7410071942445,334.1007194244604" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-0.75,0 3,-0.4" data-type="line" data-label="" points="261.58273381294964,301.8705035971223 563.7410071942445,334.1007194244604" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,0.6 0.75,0" data-type="line" data-label="" points="80.28776978417267,253.52517985611513 382.4460431654676,301.8705035971223" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3,0.6 3,0.4" data-type="line" data-label="" points="80.28776978417267,253.52517985611513 563.7410071942445,269.6402877697842" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="0.75,0 3,0.4" data-type="line" data-label="" points="382.4460431654676,301.8705035971223 563.7410071942445,269.6402877697842" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-0.75,2.220446049250313e-16 -1.875,2.220446049250313e-16 -1.875,-0.8000000000000002 -3,-0.8000000000000002 -3,-0.6" data-type="line" data-label="" points="261.58273381294964,301.8705035971223 170.93525179856113,301.8705035971223 170.93525179856113,366.33093525179856 80.28776978417267,366.33093525179856 80.28776978417267,350.2158273381295" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3,-0.4 3,-0.6000000000000001 -0.95,-0.6000000000000001 -0.95,0 -0.75,0" data-type="line" data-label="" points="563.7410071942445,334.1007194244604 563.7410071942445,350.2158273381295 245.46762589928056,350.2158273381295 245.46762589928056,301.8705035971223 261.58273381294964,301.8705035971223" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.75,-1.1102230246251565e-16 0.9500000000000002,-1.1102230246251565e-16 0.9500000000000002,0.8000000000000002 -3,0.8000000000000002 -3,0.6" data-type="line" data-label="" points="382.4460431654676,301.8705035971223 398.56115107913666,301.8705035971223 398.56115107913666,237.41007194244605 80.28776978417267,237.41007194244605 80.28776978417267,253.52517985611513" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="3,0.4 3,0.6000000000000001 1.875,0.6000000000000001 1.875,0 0.75,0" data-type="line" data-label="" points="563.7410071942445,269.6402877697842 563.7410071942445,253.5251798561151 473.0935251798561,253.5251798561151 473.0935251798561,301.8705035971223 382.4460431654676,301.8705035971223" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="JP6" data-x="-3" data-y="0" x="40" y="253.52517985611513" width="80.5755395683453" height="96.69064748201436" fill="hsl(208, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012410714285714287" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="R1" data-x="0" data-y="0" x="261.58273381294964" y="281.726618705036" width="120.86330935251794" height="40.28776978417261" fill="hsl(71, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012410714285714287" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="SJ2" data-x="3" data-y="0" x="531.5107913669065" y="269.6402877697842" width="64.46043165467631" height="64.4604316546762" fill="hsl(27, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012410714285714287" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VOUT
+globalConnNetId: connectivity_net1" data-x="3.225" data-y="0.6000000000000001" x="563.7410071942445" y="245.46762589928056" width="36.2589928057555" height="16.11510791366908" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.012410714285714287" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net0" data-x="-1.875" data-y="-1.0250000000000001" x="162.8776978417266" y="366.33093525179856" width="16.11510791366908" height="36.25899280575538" fill="#00000066" stroke="#000000" stroke-width="0.012410714285714287" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 80.57553956834532,
+        "c": 0,
+        "e": 322.0143884892086,
+        "b": 0,
+        "d": -80.57553956834532,
+        "f": 301.8705035971223
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/examples/__snapshots__/example35.snap.svg
+++ b/tests/examples/__snapshots__/example35.snap.svg
@@ -1,81 +1,60 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
   <rect width="100%" height="100%" fill="white" />
   <g>
-    <circle data-type="point" data-label="JP6.VOUT
-y+" data-x="-3" data-y="0.6" cx="80.28776978417267" cy="253.52517985611513" r="3" fill="hsl(318, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U1.1
+y-" data-x="0" data-y="0.9" cx="91.42857142857144" cy="331.42857142857144" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="JP6.GND
-y-" data-x="-3" data-y="-0.6" cx="80.28776978417267" cy="350.2158273381295" r="3" fill="hsl(351, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U1.2
+y+" data-x="0" data-y="1.2" cx="91.42857142857144" cy="297.1428571428571" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="R1.1
-x-" data-x="-0.75" data-y="0" cx="261.58273381294964" cy="301.8705035971223" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U2.1
+y-" data-x="4" data-y="0.9" cx="548.5714285714287" cy="331.42857142857144" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="R1.2
-x+" data-x="0.75" data-y="0" cx="382.4460431654676" cy="301.8705035971223" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="U2.2
+y+" data-x="4" data-y="1.2" cx="548.5714285714287" cy="297.1428571428571" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="SJ2.1
-y+" data-x="3" data-y="0.4" cx="563.7410071942445" cy="269.6402877697842" r="3" fill="hsl(62, 100%, 50%, 0.8)" />
+    <circle data-type="point" data-label="" data-x="4" data-y="0.7" cx="548.5714285714287" cy="354.2857142857143" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="SJ2.2
-y-" data-x="3" data-y="-0.4" cx="563.7410071942445" cy="334.1007194244604" r="3" fill="hsl(63, 100%, 50%, 0.8)" />
+    <polyline data-points="0,0.9 0,1.2" data-type="line" data-label="" points="91.42857142857144,331.42857142857144 91.42857142857144,297.1428571428571" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="3" data-y="0.6000000000000001" cx="563.7410071942445" cy="253.5251798561151" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <polyline data-points="0,0.9 4,0.9" data-type="line" data-label="" points="91.42857142857144,331.42857142857144 548.5714285714287,331.42857142857144" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.875" data-y="-0.8000000000000002" cx="170.93525179856113" cy="366.33093525179856" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <polyline data-points="0,0.9 4,1.2" data-type="line" data-label="" points="91.42857142857144,331.42857142857144 548.5714285714287,297.1428571428571" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,-0.6 -0.75,0" data-type="line" data-label="" points="80.28776978417267,350.2158273381295 261.58273381294964,301.8705035971223" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1.2 4,0.9" data-type="line" data-label="" points="91.42857142857144,297.1428571428571 548.5714285714287,331.42857142857144" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,-0.6 3,-0.4" data-type="line" data-label="" points="80.28776978417267,350.2158273381295 563.7410071942445,334.1007194244604" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1.2 4,1.2" data-type="line" data-label="" points="91.42857142857144,297.1428571428571 548.5714285714287,297.1428571428571" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-0.75,0 3,-0.4" data-type="line" data-label="" points="261.58273381294964,301.8705035971223 563.7410071942445,334.1007194244604" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4,0.9 4,1.2" data-type="line" data-label="" points="548.5714285714287,331.42857142857144 548.5714285714287,297.1428571428571" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-3,0.6 0.75,0" data-type="line" data-label="" points="80.28776978417267,253.52517985611513 382.4460431654676,301.8705035971223" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="0,1.2 0,1.4 -0.45,1.4 -0.45,0.7 0,0.7 0,0.9" data-type="line" data-label="" points="91.42857142857144,297.1428571428571 91.42857142857144,274.2857142857143 40.000000000000014,274.2857142857143 40.000000000000014,354.2857142857143 91.42857142857144,354.2857142857143 91.42857142857144,331.42857142857144" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-3,0.6 3,0.4" data-type="line" data-label="" points="80.28776978417267,253.52517985611513 563.7410071942445,269.6402877697842" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4,0.9 4,0.7 0,0.7 0,0.9" data-type="line" data-label="" points="548.5714285714287,331.42857142857144 548.5714285714287,354.2857142857143 91.42857142857144,354.2857142857143 91.42857142857144,331.42857142857144" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.75,0 3,0.4" data-type="line" data-label="" points="382.4460431654676,301.8705035971223 563.7410071942445,269.6402877697842" fill="none" stroke="hsl(64, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="4,1.1999999999999997 4,1.4 3.55,1.4 3.55,0.7 4,0.7 4,0.9" data-type="line" data-label="" points="548.5714285714287,297.14285714285717 548.5714285714287,274.2857142857143 497.14285714285717,274.2857142857143 497.14285714285717,354.2857142857143 548.5714285714287,354.2857142857143 548.5714285714287,331.42857142857144" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.75,2.220446049250313e-16 -1.875,2.220446049250313e-16 -1.875,-0.8000000000000002 -3,-0.8000000000000002 -3,-0.6" data-type="line" data-label="" points="261.58273381294964,301.8705035971223 170.93525179856113,301.8705035971223 170.93525179856113,366.33093525179856 80.28776978417267,366.33093525179856 80.28776978417267,350.2158273381295" fill="none" stroke="purple" stroke-width="1" />
+    <rect data-type="rect" data-label="U1" data-x="0" data-y="1.05" x="62.857142857142875" y="297.1428571428571" width="57.14285714285714" height="34.285714285714334" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008749999999999999" />
   </g>
   <g>
-    <polyline data-points="3,-0.4 3,-0.6000000000000001 -0.95,-0.6000000000000001 -0.95,0 -0.75,0" data-type="line" data-label="" points="563.7410071942445,334.1007194244604 563.7410071942445,350.2158273381295 245.46762589928056,350.2158273381295 245.46762589928056,301.8705035971223 261.58273381294964,301.8705035971223" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="0.75,-1.1102230246251565e-16 0.9500000000000002,-1.1102230246251565e-16 0.9500000000000002,0.8000000000000002 -3,0.8000000000000002 -3,0.6" data-type="line" data-label="" points="382.4460431654676,301.8705035971223 398.56115107913666,301.8705035971223 398.56115107913666,237.41007194244605 80.28776978417267,237.41007194244605 80.28776978417267,253.52517985611513" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="3,0.4 3,0.6000000000000001 1.875,0.6000000000000001 1.875,0 0.75,0" data-type="line" data-label="" points="563.7410071942445,269.6402877697842 563.7410071942445,253.5251798561151 473.0935251798561,253.5251798561151 473.0935251798561,301.8705035971223 382.4460431654676,301.8705035971223" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="JP6" data-x="-3" data-y="0" x="40" y="253.52517985611513" width="80.5755395683453" height="96.69064748201436" fill="hsl(208, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012410714285714287" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="R1" data-x="0" data-y="0" x="261.58273381294964" y="281.726618705036" width="120.86330935251794" height="40.28776978417261" fill="hsl(71, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012410714285714287" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="SJ2" data-x="3" data-y="0" x="531.5107913669065" y="269.6402877697842" width="64.46043165467631" height="64.4604316546762" fill="hsl(27, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012410714285714287" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="netId: VOUT
-globalConnNetId: connectivity_net1" data-x="3.225" data-y="0.6000000000000001" x="563.7410071942445" y="245.46762589928056" width="36.2589928057555" height="16.11510791366908" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.012410714285714287" />
+    <rect data-type="rect" data-label="U2" data-x="4" data-y="1.05" x="520" y="297.1428571428571" width="57.14285714285711" height="34.285714285714334" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008749999999999999" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0" data-x="-1.875" data-y="-1.0250000000000001" x="162.8776978417266" y="366.33093525179856" width="16.11510791366908" height="36.25899280575538" fill="#00000066" stroke="#000000" stroke-width="0.012410714285714287" />
+globalConnNetId: connectivity_net0" data-x="4.225" data-y="0.7" x="548.5714285714286" y="342.85714285714283" width="51.428571428571445" height="22.85714285714289" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008749999999999999" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -105,12 +84,12 @@ globalConnNetId: connectivity_net0" data-x="-1.875" data-y="-1.0250000000000001"
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 80.57553956834532,
+        "a": 114.28571428571429,
         "c": 0,
-        "e": 322.0143884892086,
+        "e": 91.42857142857144,
         "b": 0,
-        "d": -80.57553956834532,
-        "f": 301.8705035971223
+        "d": -114.28571428571429,
+        "f": 434.2857142857143
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/example35.test.ts
+++ b/tests/examples/example35.test.ts
@@ -15,9 +15,9 @@ const cloneInputTracePaths = (traces: SolvedTracePath[]): SolvedTracePath[] =>
   }))
 
 /**
- * Issue #34: two parallel same-net traces (y=1 and y=1.1) merge into one.
- * Uses explicit pre-merge traces so before/after snapshots differ by geometry,
- * not only stroke color between pipeline stages.
+ * Issue #34: same-net trace segments that are almost on the same Y (or X) get
+ * snapped onto a shared axis — removes the small jog between parallel runs.
+ * Repro matches the bypass-cap style case from the issue screenshot (C14/C15).
  */
 test("example35 before/after mergeParallelTracesSolver", () => {
   const inputTracePaths = cloneInputTracePaths(
@@ -40,11 +40,18 @@ test("example35 before/after mergeParallelTracesSolver", () => {
   mergeSolver.solve()
 
   expect(mergeSolver.solved).toBe(true)
-  expect(Object.keys(mergeSolver.correctedTraceMap)).toHaveLength(1)
-  expect(mergeSolver.getOutput().traces[0]!.tracePath).toEqual([
-    { x: 0, y: 1 },
-    { x: 4, y: 1 },
-  ])
+  expect(Object.keys(mergeSolver.correctedTraceMap)).toHaveLength(2)
+
+  const traceA = mergeSolver.correctedTraceMap["trace-a"]!
+  const traceB = mergeSolver.correctedTraceMap["trace-b"]!
+
+  // Internal horizontal runs align to y=1 (same Y), pin legs keep their offset
+  expect(traceA.tracePath[1]!.y).toBe(1)
+  expect(traceA.tracePath[2]!.y).toBe(1)
+  expect(traceB.tracePath[1]!.y).toBe(1)
+  expect(traceB.tracePath[2]!.y).toBe(1)
+  expect(traceB.tracePath[0]!.y).toBe(0.12)
+  expect(traceB.tracePath[3]!.y).toBe(0.12)
 
   expect(mergeSolver).toMatchSolverSnapshot(
     import.meta.path,

--- a/tests/examples/example35.test.ts
+++ b/tests/examples/example35.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "../assets/example35.json"
+import "tests/fixtures/matcher"
+
+/** Issue #34: parallel same-net traces before/after MergeParallelTracesSolver */
+test("example35 before/after mergeParallelTracesSolver", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solveUntilPhase("mergeParallelTracesSolver")
+  expect(solver.traceOverlapShiftSolver).toBeDefined()
+
+  expect(solver.traceOverlapShiftSolver!).toMatchSolverSnapshot(
+    import.meta.path,
+    "before-mergeParallelTraces",
+  )
+
+  while (!solver.mergeParallelTracesSolver?.solved) {
+    solver.step()
+  }
+
+  expect(solver.mergeParallelTracesSolver!).toMatchSolverSnapshot(
+    import.meta.path,
+    "after-mergeParallelTraces",
+  )
+})
+
+test("example35 full pipeline", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+  solver.solve()
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})

--- a/tests/examples/example35.test.ts
+++ b/tests/examples/example35.test.ts
@@ -1,25 +1,52 @@
 import { expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { MergeParallelTracesSolver } from "lib/solvers/MergeParallelTracesSolver/MergeParallelTracesSolver"
 import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 import inputProblem from "../assets/example35.json"
+import preMergeTraces from "../assets/example35-pre-merge-traces.json"
 import "tests/fixtures/matcher"
 
-/** Issue #34: parallel same-net traces before/after MergeParallelTracesSolver */
+const cloneInputTracePaths = (traces: SolvedTracePath[]): SolvedTracePath[] =>
+  traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+    mspConnectionPairIds: [...trace.mspConnectionPairIds],
+    pinIds: [...trace.pinIds],
+  }))
+
+/**
+ * Issue #34: two parallel same-net traces (y=1 and y=1.1) merge into one.
+ * Uses explicit pre-merge traces so before/after snapshots differ by geometry,
+ * not only stroke color between pipeline stages.
+ */
 test("example35 before/after mergeParallelTracesSolver", () => {
-  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+  const inputTracePaths = cloneInputTracePaths(
+    preMergeTraces as SolvedTracePath[],
+  )
 
-  solver.solveUntilPhase("mergeParallelTracesSolver")
-  expect(solver.traceOverlapShiftSolver).toBeDefined()
+  const mergeSolver = new MergeParallelTracesSolver({
+    inputProblem: inputProblem as any,
+    inputTracePaths,
+  })
 
-  expect(solver.traceOverlapShiftSolver!).toMatchSolverSnapshot(
+  expect(mergeSolver.solved).toBe(false)
+  expect(Object.keys(mergeSolver.correctedTraceMap)).toHaveLength(2)
+
+  expect(mergeSolver).toMatchSolverSnapshot(
     import.meta.path,
     "before-mergeParallelTraces",
   )
 
-  while (!solver.mergeParallelTracesSolver?.solved) {
-    solver.step()
-  }
+  mergeSolver.solve()
 
-  expect(solver.mergeParallelTracesSolver!).toMatchSolverSnapshot(
+  expect(mergeSolver.solved).toBe(true)
+  expect(Object.keys(mergeSolver.correctedTraceMap)).toHaveLength(1)
+  expect(mergeSolver.getOutput().traces[0]!.tracePath).toEqual([
+    { x: 0, y: 1 },
+    { x: 4, y: 1 },
+  ])
+
+  expect(mergeSolver).toMatchSolverSnapshot(
     import.meta.path,
     "after-mergeParallelTraces",
   )

--- a/tests/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments.test.ts
+++ b/tests/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { mergeParallelTraceSegments } from "lib/solvers/MergeParallelTracesSolver/mergeParallelTraceSegments"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [
+      { pinId: `${mspPairId}-a`, chipId: "U1", ...tracePath[0]! },
+      {
+        pinId: `${mspPairId}-b`,
+        chipId: "U1",
+        ...tracePath[tracePath.length - 1]!,
+      },
+    ],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}-a`, `${mspPairId}-b`],
+  }) as SolvedTracePath
+
+test("snaps nearby internal same-net horizontal segments onto the same y", () => {
+  const [first, second] = mergeParallelTraceSegments([
+    makeTrace("trace-a", "net-1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 0 },
+    ]),
+    makeTrace("trace-b", "net-1", [
+      { x: 0, y: 0.12 },
+      { x: 0, y: 1.12 },
+      { x: 4, y: 1.12 },
+      { x: 4, y: 0.12 },
+    ]),
+  ])
+
+  expect(first!.tracePath[1]!.y).toBe(1)
+  expect(first!.tracePath[2]!.y).toBe(1)
+  expect(second!.tracePath[1]!.y).toBe(1)
+  expect(second!.tracePath[2]!.y).toBe(1)
+  expect(second!.tracePath[0]!.y).toBe(0.12)
+  expect(second!.tracePath[3]!.y).toBe(0.12)
+})
+
+test("snaps nearby internal same-net vertical segments onto the same x", () => {
+  const [first, second] = mergeParallelTraceSegments([
+    makeTrace("trace-a", "net-1", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 4 },
+      { x: 0, y: 4 },
+    ]),
+    makeTrace("trace-b", "net-1", [
+      { x: 0.12, y: 0 },
+      { x: 1.12, y: 0 },
+      { x: 1.12, y: 4 },
+      { x: 0.12, y: 4 },
+    ]),
+  ])
+
+  expect(first!.tracePath[1]!.x).toBe(1)
+  expect(first!.tracePath[2]!.x).toBe(1)
+  expect(second!.tracePath[1]!.x).toBe(1)
+  expect(second!.tracePath[2]!.x).toBe(1)
+  expect(second!.tracePath[0]!.x).toBe(0.12)
+  expect(second!.tracePath[3]!.x).toBe(0.12)
+})
+
+test("merges two close parallel same-net traces into one", () => {
+  const result = mergeParallelTraceSegments([
+    makeTrace("trace-a", "net-1", [
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+    ]),
+    makeTrace("trace-b", "net-1", [
+      { x: 0, y: 1.1 },
+      { x: 4, y: 1.1 },
+    ]),
+  ])
+
+  expect(result).toHaveLength(1)
+  expect(result[0]!.tracePath).toEqual([
+    { x: 0, y: 1 },
+    { x: 4, y: 1 },
+  ])
+  expect(result[0]!.globalConnNetId).toBe("net-1")
+  expect(result[0]!.mspConnectionPairIds).toEqual(["trace-a", "trace-b"])
+  expect(result[0]!.pinIds).toEqual([
+    "trace-a-a",
+    "trace-a-b",
+    "trace-b-a",
+    "trace-b-b",
+  ])
+})
+
+test("merges two close parallel vertical same-net traces into one", () => {
+  const result = mergeParallelTraceSegments([
+    makeTrace("trace-a", "net-1", [
+      { x: 2, y: 0 },
+      { x: 2, y: 5 },
+    ]),
+    makeTrace("trace-b", "net-1", [
+      { x: 2.12, y: 0 },
+      { x: 2.12, y: 5 },
+    ]),
+  ])
+
+  expect(result).toHaveLength(1)
+  expect(result[0]!.tracePath).toEqual([
+    { x: 2, y: 0 },
+    { x: 2, y: 5 },
+  ])
+})
+
+test("does not snap nearby segments from different nets", () => {
+  const [first, second] = mergeParallelTraceSegments([
+    makeTrace("trace-a", "net-1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 0 },
+    ]),
+    makeTrace("trace-b", "net-2", [
+      { x: 0, y: 0.12 },
+      { x: 0, y: 1.12 },
+      { x: 4, y: 1.12 },
+      { x: 4, y: 0.12 },
+    ]),
+  ])
+
+  expect(first!.tracePath[1]!.y).toBe(1)
+  expect(first!.tracePath[2]!.y).toBe(1)
+  expect(second!.tracePath[1]!.y).toBe(1.12)
+  expect(second!.tracePath[2]!.y).toBe(1.12)
+})


### PR DESCRIPTION
Implemented MergeParallelTracesSolver to merge nearby parallel same-net traces. Added unit tests.

Thanks for the clarification — re-read #34 and updated the example.

**Issue #34** is about snapping **same-net segments that are almost on the same Y or X** onto a shared axis (remove the small jog between parallel runs), not collapsing two unrelated 2-point traces into one line.

### Repro (`example35`)
- `tests/assets/example35.json` — minimal C14/C15-style layout on `V3_3`
- `tests/assets/example35-pre-merge-traces.json` — two routed paths whose **internal horizontal runs** are offset by ~0.12 (the jog from the screenshot)

### Before / after
`tests/examples/example35.test.ts` runs `MergeParallelTracesSolver` on deep-cloned traces:

| Before | After |
|--------|-------|
| Parallel horizontal runs at **y=1** and **y=1.12** (visible jog) | Internal horizontals snapped to **y=1**; pin legs unchanged |
| ![before](https://github.com/ron1nrest/schematic-trace-solver/raw/main/tests/examples/__snapshots__/before-mergeParallelTraces.snap.svg) | ![after](https://github.com/ron1nrest/schematic-trace-solver/raw/main/tests/examples/__snapshots__/after-mergeParallelTraces.snap.svg) |

Assertions: still **2 traces**; `tracePath[1].y` and `tracePath[2].y` → `1` on both; endpoints at `0` / `0.12` preserved.

Sorry for the earlier repro — it demonstrated trace consolidation, not same-Y alignment.

Closes #34
/claim #34