### PR TITLE
fix: prevent mutation of directConnMap when creating netConnMap (#79)

### DIFF
--- a/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
+++ b/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
@@ -14,7 +14,9 @@ export const getConnectivityMapsFromInputProblem = (
     ])
   }
 
-  const netConnMap = new ConnectivityMap(directConnMap.netMap)
+  const netConnMap = new ConnectivityMap(
+    JSON.parse(JSON.stringify(directConnMap.netMap)),
+  )
 
   for (const netConn of inputProblem.netConnections) {
     netConnMap.addConnections([[netConn.netId, ...netConn.pinIds]])


### PR DESCRIPTION
## Summary

Fixes #79 - eliminates extra trace lines and redundant net labels by preventing unintended mutation of the connectivity map.

## Root Cause

In `getConnectivityMapsFromInputProblem.ts`, the `netConnMap` was initialized using `directConnMap.netMap` by reference. This caused logical net-label connections to be inadvertently added to the physical `directConnMap`.

## Changes

- Implemented deep cloning of `directConnMap.netMap` to ensure that `directConnMap` remains pure and only contains physical connections.

## Testing

✅ All 57 existing tests pass.
