### PR TITLE
fix: remove zero-length segments in simplifyPath

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,38 +4,34 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
-export const simplifyPath = (path: Point[]): Point[] => {
+const EPS = 1e-9
+
+const dedupConsecutive = (path: Point[]): Point[] =>
+  path.filter(
+    (p, i) =>
+      i === 0 ||
+      Math.abs(p.x - path[i - 1]!.x) > EPS ||
+      Math.abs(p.y - path[i - 1]!.y) > EPS,
+  )
+
+const collapseCollinear = (path: Point[]): Point[] => {
   if (path.length < 3) return path
-  const newPath: Point[] = [path[0]]
+  const out: Point[] = [path[0]!]
   for (let i = 1; i < path.length - 1; i++) {
-    const p1 = newPath[newPath.length - 1]
-    const p2 = path[i]
-    const p3 = path[i + 1]
-    if (
-      (isVertical(p1, p2) && isVertical(p2, p3)) ||
-      (isHorizontal(p1, p2) && isHorizontal(p2, p3))
-    ) {
-      continue
-    }
-    newPath.push(p2)
+    const prev = out[out.length - 1]!
+    const cur = path[i]!
+    const next = path[i + 1]!
+    const collinear =
+      (isVertical(prev, cur) && isVertical(cur, next)) ||
+      (isHorizontal(prev, cur) && isHorizontal(cur, next))
+    if (!collinear) out.push(cur)
   }
-  newPath.push(path[path.length - 1])
+  out.push(path[path.length - 1]!)
+  return out
+}
 
-  if (newPath.length < 3) return newPath
-  const finalPath: Point[] = [newPath[0]]
-  for (let i = 1; i < newPath.length - 1; i++) {
-    const p1 = finalPath[finalPath.length - 1]
-    const p2 = newPath[i]
-    const p3 = newPath[i + 1]
-    if (
-      (isVertical(p1, p2) && isVertical(p2, p3)) ||
-      (isHorizontal(p1, p2) && isHorizontal(p2, p3))
-    ) {
-      continue
-    }
-    finalPath.push(p2)
-  }
-  finalPath.push(newPath[newPath.length - 1])
-
-  return finalPath
+export const simplifyPath = (path: Point[]): Point[] => {
+  const pass1 = collapseCollinear(dedupConsecutive(path))
+  const pass2 = collapseCollinear(dedupConsecutive(pass1))
+  return dedupConsecutive(pass2)
 }

--- a/tests/solvers/TraceCleanupSolver/simplify-path.test.ts
+++ b/tests/solvers/TraceCleanupSolver/simplify-path.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+test("removes duplicate consecutive points (zero-length segments)", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 0 }, // duplicate
+    { x: 2, y: 0 },
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+  ])
+})
+
+test("removes duplicate at start", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 0, y: 0 }, // duplicate of start
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("removes duplicate at end", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 1, y: 1 }, // duplicate of end
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("collapses collinear points on horizontal segment", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+    { x: 3, y: 1 },
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 3, y: 1 },
+  ])
+})
+
+test("collapses collinear points on vertical segment", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 0, y: 1 },
+    { x: 0, y: 2 },
+    { x: 1, y: 2 },
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 0, y: 2 },
+    { x: 1, y: 2 },
+  ])
+})
+
+test("handles multiple consecutive duplicates", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 0 }, // three copies of same point
+    { x: 2, y: 0 },
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+  ])
+})
+
+test("handles L-shaped path with no simplification needed", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("removes zero-length segment followed by direction change", () => {
+  // Duplicate point creates an extra trace line when rendered
+  const path = [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 0 }, // zero-length stub → causes extra line in post-processing
+    { x: 2, y: 1 },
+    { x: 3, y: 1 },
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 1 },
+    { x: 3, y: 1 },
+  ])
+})


### PR DESCRIPTION
Fixes #78

/claim #78

## Root Cause

`simplifyPath` collapsed collinear midpoints but did not remove duplicate consecutive points (zero-length segments). Adjacent path points with identical coordinates produce a zero-length stub that renders as an extra trace line in the schematic.

## Fix

Added `dedupConsecutive` to strip identical adjacent points before each collinear-collapse pass. `simplifyPath` now runs `collapseCollinear(dedupConsecutive(path))` twice, with a final `dedupConsecutive` pass.

## Tests

8 new unit tests: duplicate in middle, at start, at end, multiple consecutive duplicates, collinear collapse (H and V), zero-length stub at direction change.

Full suite: 65 pass, 4 skip, 0 fail. Format + type check pass.