### PR TITLE
Add same-net trace combining phase

### DIFF
--- a/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
+++ b/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
@@ -1,0 +1,447 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
+import { getColorFromString } from "lib/utils/getColorFromString"
+
+type Orientation = "horizontal" | "vertical"
+
+interface SegmentLocator {
+  traceIndex: number
+  segmentIndex: number
+  orientation: Orientation
+  axis: number
+  min: number
+  max: number
+  length: number
+  isTerminal: boolean
+}
+
+interface MergeCandidate {
+  source: SegmentLocator
+  target: SegmentLocator
+  distance: number
+  overlapLength: number
+}
+
+export class SameNetTraceCombiningSolver extends BaseSolver {
+  inputProblem?: InputProblem
+  inputTraces: SolvedTracePath[]
+  outputTraces: SolvedTracePath[]
+  mergeDistance: number
+  mergeCount = 0
+
+  private readonly EPS = 1e-6
+  private readonly MAX_PASSES = 100
+
+  constructor(params: {
+    inputProblem?: InputProblem
+    traces: SolvedTracePath[]
+    mergeDistance?: number
+  }) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.inputTraces = params.traces
+    this.outputTraces = params.traces.map((trace) => ({
+      ...trace,
+      tracePath: trace.tracePath.map((point) => ({ ...point })),
+      mspConnectionPairIds: [...trace.mspConnectionPairIds],
+      pinIds: [...trace.pinIds],
+      pins: [{ ...trace.pins[0] }, { ...trace.pins[1] }],
+    }))
+    this.mergeDistance = params.mergeDistance ?? 0.15
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceCombiningSolver
+  >[0] {
+    return {
+      inputProblem: this.inputProblem,
+      traces: this.inputTraces,
+      mergeDistance: this.mergeDistance,
+    }
+  }
+
+  override _step() {
+    for (let pass = 0; pass < this.MAX_PASSES; pass++) {
+      const candidate = this.findBestCandidate()
+      if (!candidate) break
+
+      this.applyCandidate(candidate)
+      this.mergeCount++
+    }
+
+    this.stats.mergeCount = this.mergeCount
+    this.solved = true
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  private findBestCandidate(): MergeCandidate | null {
+    const candidates: MergeCandidate[] = []
+    const byNet = new Map<string, number[]>()
+
+    for (
+      let traceIndex = 0;
+      traceIndex < this.outputTraces.length;
+      traceIndex++
+    ) {
+      const trace = this.outputTraces[traceIndex]!
+      if (!byNet.has(trace.globalConnNetId))
+        byNet.set(trace.globalConnNetId, [])
+      byNet.get(trace.globalConnNetId)!.push(traceIndex)
+    }
+
+    for (const traceIndexes of byNet.values()) {
+      if (traceIndexes.length < 2) continue
+
+      for (let i = 0; i < traceIndexes.length; i++) {
+        for (let j = i + 1; j < traceIndexes.length; j++) {
+          const traceAIndex = traceIndexes[i]!
+          const traceBIndex = traceIndexes[j]!
+          const segmentsA = this.getTraceSegments(traceAIndex)
+          const segmentsB = this.getTraceSegments(traceBIndex)
+
+          for (const segmentA of segmentsA) {
+            for (const segmentB of segmentsB) {
+              const candidate = this.getCandidate(segmentA, segmentB)
+              if (candidate && this.canApplyCandidate(candidate)) {
+                candidates.push(candidate)
+              }
+            }
+          }
+        }
+      }
+    }
+
+    candidates.sort((a, b) => {
+      if (Math.abs(a.distance - b.distance) > this.EPS) {
+        return a.distance - b.distance
+      }
+      if (Math.abs(a.overlapLength - b.overlapLength) > this.EPS) {
+        return b.overlapLength - a.overlapLength
+      }
+      const traceDelta = a.source.traceIndex - b.source.traceIndex
+      if (traceDelta !== 0) return traceDelta
+      return a.source.segmentIndex - b.source.segmentIndex
+    })
+
+    return candidates[0] ?? null
+  }
+
+  private getTraceSegments(traceIndex: number): SegmentLocator[] {
+    const trace = this.outputTraces[traceIndex]!
+    const segments: SegmentLocator[] = []
+
+    for (
+      let segmentIndex = 0;
+      segmentIndex < trace.tracePath.length - 1;
+      segmentIndex++
+    ) {
+      const start = trace.tracePath[segmentIndex]!
+      const end = trace.tracePath[segmentIndex + 1]!
+      const orientation = this.getOrientation(start, end)
+      if (!orientation) continue
+
+      const isHorizontal = orientation === "horizontal"
+      const min = isHorizontal
+        ? Math.min(start.x, end.x)
+        : Math.min(start.y, end.y)
+      const max = isHorizontal
+        ? Math.max(start.x, end.x)
+        : Math.max(start.y, end.y)
+      const axis = isHorizontal ? start.y : start.x
+      const length = max - min
+
+      if (length <= this.EPS) continue
+
+      segments.push({
+        traceIndex,
+        segmentIndex,
+        orientation,
+        axis,
+        min,
+        max,
+        length,
+        isTerminal:
+          segmentIndex === 0 || segmentIndex === trace.tracePath.length - 2,
+      })
+    }
+
+    return segments
+  }
+
+  private getCandidate(
+    segmentA: SegmentLocator,
+    segmentB: SegmentLocator,
+  ): MergeCandidate | null {
+    if (segmentA.orientation !== segmentB.orientation) return null
+
+    const distance = Math.abs(segmentA.axis - segmentB.axis)
+    if (distance <= this.EPS || distance > this.mergeDistance) return null
+
+    const overlapLength =
+      Math.min(segmentA.max, segmentB.max) -
+      Math.max(segmentA.min, segmentB.min)
+    if (overlapLength <= this.EPS) return null
+
+    const source = this.chooseSourceSegment(segmentA, segmentB)
+    if (!source) return null
+
+    const target = source === segmentA ? segmentB : segmentA
+
+    return {
+      source,
+      target,
+      distance,
+      overlapLength,
+    }
+  }
+
+  private chooseSourceSegment(
+    segmentA: SegmentLocator,
+    segmentB: SegmentLocator,
+  ): SegmentLocator | null {
+    if (segmentA.isTerminal && segmentB.isTerminal) return null
+    if (segmentA.isTerminal) return segmentB
+    if (segmentB.isTerminal) return segmentA
+
+    if (Math.abs(segmentA.length - segmentB.length) > this.EPS) {
+      return segmentA.length < segmentB.length ? segmentA : segmentB
+    }
+
+    if (segmentA.traceIndex !== segmentB.traceIndex) {
+      return segmentA.traceIndex > segmentB.traceIndex ? segmentA : segmentB
+    }
+
+    return segmentA.segmentIndex > segmentB.segmentIndex ? segmentA : segmentB
+  }
+
+  private canApplyCandidate(candidate: MergeCandidate): boolean {
+    const sourceTrace = this.outputTraces[candidate.source.traceIndex]!
+    const proposedTrace = this.getTraceWithSegmentOnAxis(
+      sourceTrace,
+      candidate.source.segmentIndex,
+      candidate.source.orientation,
+      candidate.target.axis,
+    )
+
+    const oldIntersections = this.getDifferentNetIntersectionKeys(sourceTrace)
+    const newIntersections = this.getDifferentNetIntersectionKeys(proposedTrace)
+
+    for (const key of newIntersections) {
+      if (!oldIntersections.has(key)) return false
+    }
+
+    return true
+  }
+
+  private applyCandidate(candidate: MergeCandidate) {
+    const sourceTrace = this.outputTraces[candidate.source.traceIndex]!
+    this.outputTraces[candidate.source.traceIndex] =
+      this.getTraceWithSegmentOnAxis(
+        sourceTrace,
+        candidate.source.segmentIndex,
+        candidate.source.orientation,
+        candidate.target.axis,
+      )
+  }
+
+  private getTraceWithSegmentOnAxis(
+    trace: SolvedTracePath,
+    segmentIndex: number,
+    orientation: Orientation,
+    axis: number,
+  ): SolvedTracePath {
+    const tracePath = trace.tracePath.map((point) => ({ ...point }))
+    const start = tracePath[segmentIndex]!
+    const end = tracePath[segmentIndex + 1]!
+
+    if (orientation === "horizontal") {
+      start.y = axis
+      end.y = axis
+    } else {
+      start.x = axis
+      end.x = axis
+    }
+
+    return {
+      ...trace,
+      tracePath: this.removeConsecutiveDuplicatePoints(tracePath),
+    }
+  }
+
+  private removeConsecutiveDuplicatePoints(points: Point[]): Point[] {
+    const cleaned: Point[] = []
+
+    for (const point of points) {
+      const prev = cleaned[cleaned.length - 1]
+      if (!prev || !this.samePoint(prev, point)) {
+        cleaned.push(point)
+      }
+    }
+
+    return cleaned
+  }
+
+  private getDifferentNetIntersectionKeys(trace: SolvedTracePath): Set<string> {
+    const keys = new Set<string>()
+    const traceSegments = this.getSegmentsFromTrace(trace)
+
+    for (const otherTrace of this.outputTraces) {
+      if (otherTrace.mspPairId === trace.mspPairId) continue
+      if (otherTrace.globalConnNetId === trace.globalConnNetId) continue
+
+      const otherSegments = this.getSegmentsFromTrace(otherTrace)
+
+      for (const traceSegment of traceSegments) {
+        for (const otherSegment of otherSegments) {
+          const intersection = this.getSegmentIntersectionKey(
+            traceSegment,
+            otherSegment,
+          )
+          if (intersection) {
+            keys.add(`${otherTrace.mspPairId}:${intersection}`)
+          }
+        }
+      }
+    }
+
+    return keys
+  }
+
+  private getSegmentsFromTrace(trace: SolvedTracePath) {
+    return trace.tracePath
+      .slice(0, -1)
+      .map((start, index) => {
+        const end = trace.tracePath[index + 1]!
+        const orientation = this.getOrientation(start, end)
+        if (!orientation) return null
+
+        return {
+          orientation,
+          start,
+          end,
+          axis: orientation === "horizontal" ? start.y : start.x,
+          min:
+            orientation === "horizontal"
+              ? Math.min(start.x, end.x)
+              : Math.min(start.y, end.y),
+          max:
+            orientation === "horizontal"
+              ? Math.max(start.x, end.x)
+              : Math.max(start.y, end.y),
+        }
+      })
+      .filter(Boolean) as Array<{
+      orientation: Orientation
+      start: Point
+      end: Point
+      axis: number
+      min: number
+      max: number
+    }>
+  }
+
+  private getSegmentIntersectionKey(
+    segmentA: {
+      orientation: Orientation
+      axis: number
+      min: number
+      max: number
+    },
+    segmentB: {
+      orientation: Orientation
+      axis: number
+      min: number
+      max: number
+    },
+  ): string | null {
+    if (segmentA.orientation === segmentB.orientation) {
+      if (Math.abs(segmentA.axis - segmentB.axis) > this.EPS) return null
+
+      const overlapMin = Math.max(segmentA.min, segmentB.min)
+      const overlapMax = Math.min(segmentA.max, segmentB.max)
+      if (overlapMax - overlapMin <= this.EPS) return null
+
+      return [
+        "overlap",
+        segmentA.orientation,
+        this.round(segmentA.axis),
+        this.round(overlapMin),
+        this.round(overlapMax),
+      ].join(":")
+    }
+
+    const horizontal =
+      segmentA.orientation === "horizontal" ? segmentA : segmentB
+    const vertical = segmentA.orientation === "vertical" ? segmentA : segmentB
+
+    if (
+      !this.isStrictlyBetween(vertical.axis, horizontal.min, horizontal.max)
+    ) {
+      return null
+    }
+    if (!this.isStrictlyBetween(horizontal.axis, vertical.min, vertical.max)) {
+      return null
+    }
+
+    return [
+      "cross",
+      this.round(vertical.axis),
+      this.round(horizontal.axis),
+    ].join(":")
+  }
+
+  private getOrientation(start: Point, end: Point): Orientation | null {
+    if (Math.abs(start.y - end.y) <= this.EPS) return "horizontal"
+    if (Math.abs(start.x - end.x) <= this.EPS) return "vertical"
+    return null
+  }
+
+  private isStrictlyBetween(value: number, a: number, b: number): boolean {
+    return (
+      value > Math.min(a, b) + this.EPS && value < Math.max(a, b) - this.EPS
+    )
+  }
+
+  private samePoint(a: Point, b: Point): boolean {
+    return Math.abs(a.x - b.x) <= this.EPS && Math.abs(a.y - b.y) <= this.EPS
+  }
+
+  private round(value: number): string {
+    return value.toFixed(6)
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics = this.inputProblem
+      ? visualizeInputProblem(this.inputProblem, {
+          chipAlpha: 0.1,
+          connectionAlpha: 0.1,
+        })
+      : {
+          lines: [],
+          points: [],
+          rects: [],
+          circles: [],
+          texts: [],
+        }
+
+    graphics.lines = graphics.lines ?? []
+
+    for (const trace of this.outputTraces) {
+      graphics.lines.push({
+        points: trace.tracePath,
+        strokeColor: getColorFromString(trace.globalConnNetId, 0.85),
+      })
+    }
+
+    return graphics
+  }
+}

--- a/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
+++ b/lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.ts
@@ -1,9 +1,12 @@
 import type { Point } from "@tscircuit/math-utils"
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import { getInputChipBounds } from "lib/solvers/GuidelinesSolver/getInputChipBounds"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { segmentIntersectsRect } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
-import type { InputProblem } from "lib/types/InputProblem"
+import type { InputChip, InputProblem } from "lib/types/InputProblem"
 import { getColorFromString } from "lib/utils/getColorFromString"
 
 type Orientation = "horizontal" | "vertical"
@@ -239,6 +242,13 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
       if (!oldIntersections.has(key)) return false
     }
 
+    const oldChipCollisions = this.getChipObstacleCollisionKeys(sourceTrace)
+    const newChipCollisions = this.getChipObstacleCollisionKeys(proposedTrace)
+
+    for (const key of newChipCollisions) {
+      if (!oldChipCollisions.has(key)) return false
+    }
+
     return true
   }
 
@@ -368,7 +378,15 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
 
       const overlapMin = Math.max(segmentA.min, segmentB.min)
       const overlapMax = Math.min(segmentA.max, segmentB.max)
-      if (overlapMax - overlapMin <= this.EPS) return null
+      if (overlapMax < overlapMin - this.EPS) return null
+      if (Math.abs(overlapMax - overlapMin) <= this.EPS) {
+        return [
+          "touch",
+          segmentA.orientation,
+          this.round(segmentA.axis),
+          this.round((overlapMin + overlapMax) / 2),
+        ].join(":")
+      }
 
       return [
         "overlap",
@@ -384,11 +402,11 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
     const vertical = segmentA.orientation === "vertical" ? segmentA : segmentB
 
     if (
-      !this.isStrictlyBetween(vertical.axis, horizontal.min, horizontal.max)
+      !this.isBetweenInclusive(vertical.axis, horizontal.min, horizontal.max)
     ) {
       return null
     }
-    if (!this.isStrictlyBetween(horizontal.axis, vertical.min, vertical.max)) {
+    if (!this.isBetweenInclusive(horizontal.axis, vertical.min, vertical.max)) {
       return null
     }
 
@@ -405,9 +423,94 @@ export class SameNetTraceCombiningSolver extends BaseSolver {
     return null
   }
 
-  private isStrictlyBetween(value: number, a: number, b: number): boolean {
+  private getChipObstacleCollisionKeys(trace: SolvedTracePath): Set<string> {
+    const keys = new Set<string>()
+    if (!this.inputProblem) return keys
+
+    const chipById = new Map(
+      this.inputProblem.chips.map((chip) => [chip.chipId, chip]),
+    )
+    const obstacleRects = getObstacleRects(this.inputProblem)
+
+    for (
+      let segmentIndex = 0;
+      segmentIndex < trace.tracePath.length - 1;
+      segmentIndex++
+    ) {
+      const start = trace.tracePath[segmentIndex]!
+      const end = trace.tracePath[segmentIndex + 1]!
+      const allowedEndpointChipIds = this.getAllowedEndpointChipIds(
+        trace,
+        start,
+        end,
+        chipById,
+      )
+
+      for (const rect of obstacleRects) {
+        if (allowedEndpointChipIds.has(rect.chipId)) continue
+        if (segmentIntersectsRect(start, end, rect, this.EPS)) {
+          keys.add(`${segmentIndex}:${rect.chipId}`)
+        }
+      }
+    }
+
+    return keys
+  }
+
+  private getAllowedEndpointChipIds(
+    trace: SolvedTracePath,
+    start: Point,
+    end: Point,
+    chipById: Map<string, InputChip>,
+  ): Set<string> {
+    const allowedChipIds = new Set<string>()
+
+    for (const pin of trace.pins) {
+      const chip = chipById.get(pin.chipId)
+      if (!chip) continue
+
+      if (
+        this.samePoint(pin, start) &&
+        !this.segmentEntersPinChip(start, end, chip)
+      ) {
+        allowedChipIds.add(pin.chipId)
+      }
+
+      if (
+        this.samePoint(pin, end) &&
+        !this.segmentEntersPinChip(end, start, chip)
+      ) {
+        allowedChipIds.add(pin.chipId)
+      }
+    }
+
+    return allowedChipIds
+  }
+
+  private segmentEntersPinChip(
+    pinPoint: Point,
+    otherPoint: Point,
+    chip: InputChip,
+  ): boolean {
+    const bounds = getInputChipBounds(chip)
+    const dx = otherPoint.x - pinPoint.x
+    const dy = otherPoint.y - pinPoint.y
+    const onLeft = Math.abs(pinPoint.x - bounds.minX) <= this.EPS
+    const onRight = Math.abs(pinPoint.x - bounds.maxX) <= this.EPS
+    const onBottom = Math.abs(pinPoint.y - bounds.minY) <= this.EPS
+    const onTop = Math.abs(pinPoint.y - bounds.maxY) <= this.EPS
+
     return (
-      value > Math.min(a, b) + this.EPS && value < Math.max(a, b) - this.EPS
+      (onLeft && dx > this.EPS) ||
+      (onRight && dx < -this.EPS) ||
+      (onBottom && dy > this.EPS) ||
+      (onTop && dy < -this.EPS)
+    )
+  }
+
+  private isBetweenInclusive(value: number, a: number, b: number): boolean {
+    return (
+      value >= Math.min(a, b) - this.EPS && value <= Math.max(a, b) + this.EPS
     )
   }
 

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -26,6 +26,7 @@ import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
 import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
 import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceCombiningSolver } from "../SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -80,6 +81,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
   traceAnchoredNetLabelOverlapSolver?: TraceAnchoredNetLabelOverlapSolver
   netLabelTraceCollisionSolver?: NetLabelTraceCollisionSolver
+  sameNetTraceCombiningSolver?: SameNetTraceCombiningSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -218,10 +220,21 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceCombiningSolver",
+      SameNetTraceCombiningSolver,
+      (instance) => [
+        {
+          inputProblem: instance.inputProblem,
+          traces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceCombiningSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +250,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceCombiningSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
+++ b/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test"
 import { SameNetTraceCombiningSolver } from "lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
 
 const makeTrace = (
   mspPairId: string,
@@ -34,6 +35,13 @@ const makeTrace = (
     pinIds: [`${mspPairId}.1`, `${mspPairId}.2`],
   }
 }
+
+const makeInputProblem = (chips: InputProblem["chips"]): InputProblem => ({
+  chips,
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+})
 
 test("snaps close overlapping same-net horizontal internal segments onto a shared axis", () => {
   const solver = new SameNetTraceCombiningSolver({
@@ -165,6 +173,75 @@ test("rejects same-net snap candidates that create a different-net crossing", ()
         { x: 0, y: -0.05 },
         { x: 0, y: 0.05 },
         { x: -1, y: 0.05 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traceB = solver
+    .getOutput()
+    .traces.find((t) => t.mspPairId === "trace-b")!
+  expect(traceB.tracePath[1]!.y).toBe(0.12)
+  expect(traceB.tracePath[2]!.y).toBe(0.12)
+  expect(solver.mergeCount).toBe(0)
+})
+
+test("rejects same-net snap candidates that create a different-net endpoint touch", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      makeTrace("trace-a", "NET1", [
+        { x: -2, y: -1 },
+        { x: -2, y: 0 },
+        { x: 2, y: 0 },
+        { x: 2, y: -1 },
+      ]),
+      makeTrace("trace-b", "NET1", [
+        { x: -2, y: 1 },
+        { x: -2, y: 0.12 },
+        { x: 2, y: 0.12 },
+        { x: 2, y: 1 },
+      ]),
+      makeTrace("trace-c", "NET2", [
+        { x: -3, y: 0 },
+        { x: -2, y: 0 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traceB = solver
+    .getOutput()
+    .traces.find((t) => t.mspPairId === "trace-b")!
+  expect(traceB.tracePath[1]!.y).toBe(0.12)
+  expect(traceB.tracePath[2]!.y).toBe(0.12)
+  expect(solver.mergeCount).toBe(0)
+})
+
+test("rejects same-net snap candidates that move a connector into a chip obstacle", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    inputProblem: makeInputProblem([
+      {
+        chipId: "obstacle-chip",
+        center: { x: -2, y: 0.05 },
+        width: 0.05,
+        height: 0.05,
+        pins: [],
+      },
+    ]),
+    traces: [
+      makeTrace("trace-a", "NET1", [
+        { x: -2.5, y: -1 },
+        { x: -2.5, y: 0 },
+        { x: 2, y: 0 },
+        { x: 2, y: -1 },
+      ]),
+      makeTrace("trace-b", "NET1", [
+        { x: -2, y: 1 },
+        { x: -2, y: 0.12 },
+        { x: 1.5, y: 0.12 },
+        { x: 1.5, y: 1 },
       ]),
     ],
   })

--- a/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
+++ b/tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts
@@ -1,0 +1,180 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceCombiningSolver } from "lib/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath => {
+  const start = tracePath[0]!
+  const end = tracePath[tracePath.length - 1]!
+
+  return {
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    userNetId: globalConnNetId,
+    pins: [
+      {
+        pinId: `${mspPairId}.1`,
+        chipId: `${mspPairId}-chip-a`,
+        x: start.x,
+        y: start.y,
+      },
+      {
+        pinId: `${mspPairId}.2`,
+        chipId: `${mspPairId}-chip-b`,
+        x: end.x,
+        y: end.y,
+      },
+    ],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}.1`, `${mspPairId}.2`],
+  }
+}
+
+test("snaps close overlapping same-net horizontal internal segments onto a shared axis", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      makeTrace("trace-a", "NET1", [
+        { x: -2, y: -1 },
+        { x: -2, y: 0 },
+        { x: 2, y: 0 },
+        { x: 2, y: -1 },
+      ]),
+      makeTrace("trace-b", "NET1", [
+        { x: -2, y: 1 },
+        { x: -2, y: 0.08 },
+        { x: 2, y: 0.08 },
+        { x: 2, y: 1 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traceB = solver
+    .getOutput()
+    .traces.find((t) => t.mspPairId === "trace-b")!
+  expect(traceB.tracePath[1]!.y).toBe(0)
+  expect(traceB.tracePath[2]!.y).toBe(0)
+  expect(solver.mergeCount).toBe(1)
+})
+
+test("snaps close overlapping same-net vertical internal segments onto a shared axis", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      makeTrace("trace-a", "NET1", [
+        { x: -1, y: -2 },
+        { x: 0, y: -2 },
+        { x: 0, y: 2 },
+        { x: -1, y: 2 },
+      ]),
+      makeTrace("trace-b", "NET1", [
+        { x: 1, y: -2 },
+        { x: 0.07, y: -2 },
+        { x: 0.07, y: 2 },
+        { x: 1, y: 2 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traceB = solver
+    .getOutput()
+    .traces.find((t) => t.mspPairId === "trace-b")!
+  expect(traceB.tracePath[1]!.x).toBe(0)
+  expect(traceB.tracePath[2]!.x).toBe(0)
+  expect(solver.mergeCount).toBe(1)
+})
+
+test("does not combine close segments from different nets", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      makeTrace("trace-a", "NET1", [
+        { x: -2, y: -1 },
+        { x: -2, y: 0 },
+        { x: 2, y: 0 },
+        { x: 2, y: -1 },
+      ]),
+      makeTrace("trace-b", "NET2", [
+        { x: -2, y: 1 },
+        { x: -2, y: 0.08 },
+        { x: 2, y: 0.08 },
+        { x: 2, y: 1 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traceB = solver
+    .getOutput()
+    .traces.find((t) => t.mspPairId === "trace-b")!
+  expect(traceB.tracePath[1]!.y).toBe(0.08)
+  expect(traceB.tracePath[2]!.y).toBe(0.08)
+  expect(solver.mergeCount).toBe(0)
+})
+
+test("preserves terminal segments so pin endpoints do not drift", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      makeTrace("trace-a", "NET1", [
+        { x: -2, y: 0 },
+        { x: 2, y: 0 },
+        { x: 2, y: 1 },
+      ]),
+      makeTrace("trace-b", "NET1", [
+        { x: -2, y: 0.08 },
+        { x: 2, y: 0.08 },
+        { x: 2, y: -1 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traceB = solver
+    .getOutput()
+    .traces.find((t) => t.mspPairId === "trace-b")!
+  expect(traceB.tracePath[0]!.y).toBe(0.08)
+  expect(traceB.tracePath[1]!.y).toBe(0.08)
+  expect(solver.mergeCount).toBe(0)
+})
+
+test("rejects same-net snap candidates that create a different-net crossing", () => {
+  const solver = new SameNetTraceCombiningSolver({
+    traces: [
+      makeTrace("trace-a", "NET1", [
+        { x: -2, y: -1 },
+        { x: -2, y: 0 },
+        { x: 2, y: 0 },
+        { x: 2, y: -1 },
+      ]),
+      makeTrace("trace-b", "NET1", [
+        { x: -2, y: 1 },
+        { x: -2, y: 0.12 },
+        { x: 2, y: 0.12 },
+        { x: 2, y: 1 },
+      ]),
+      makeTrace("trace-c", "NET2", [
+        { x: -1, y: -0.05 },
+        { x: 0, y: -0.05 },
+        { x: 0, y: 0.05 },
+        { x: -1, y: 0.05 },
+      ]),
+    ],
+  })
+
+  solver.solve()
+
+  const traceB = solver
+    .getOutput()
+    .traces.find((t) => t.mspPairId === "trace-b")!
+  expect(traceB.tracePath[1]!.y).toBe(0.12)
+  expect(traceB.tracePath[2]!.y).toBe(0.12)
+  expect(solver.mergeCount).toBe(0)
+})


### PR DESCRIPTION
/claim #29

## Summary
- add a dedicated `SameNetTraceCombiningSolver` post-cleanup pipeline phase
- group traces by `globalConnNetId` and snap close overlapping same-net internal horizontal/vertical segments onto a shared axis
- preserve terminal pin segments and reject candidates that introduce new different-net intersections

## Verification
- `bun test tests/solvers/SameNetTraceCombiningSolver/SameNetTraceCombiningSolver.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`