### PR TITLE
Combine close same-net trace segments during cleanup

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -6,6 +6,7 @@ import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { combineCloseSameNetTraceSegments } from "./combineCloseSameNetTraceSegments"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -25,6 +26,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
  * Represents the different stages or steps within the trace cleanup pipeline.
  */
 type PipelineStep =
+  | "combining_same_net_segments"
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
@@ -42,7 +44,7 @@ export class TraceCleanupSolver extends BaseSolver {
   private outputTraces: SolvedTracePath[]
   private traceIdQueue: string[]
   private tracesMap: Map<string, SolvedTracePath>
-  private pipelineStep: PipelineStep = "untangling_traces"
+  private pipelineStep: PipelineStep = "combining_same_net_segments"
   private activeTraceId: string | null = null // New property
   override activeSubSolver: BaseSolver | null = null
 
@@ -75,6 +77,9 @@ export class TraceCleanupSolver extends BaseSolver {
     }
 
     switch (this.pipelineStep) {
+      case "combining_same_net_segments":
+        this._runCombineSameNetSegmentsStep()
+        break
       case "untangling_traces":
         this._runUntangleTracesStep()
         break
@@ -87,6 +92,13 @@ export class TraceCleanupSolver extends BaseSolver {
     }
   }
 
+  private _runCombineSameNetSegmentsStep() {
+    this.outputTraces = combineCloseSameNetTraceSegments(this.outputTraces)
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.traceIdQueue = this.outputTraces.map((e) => e.mspPairId)
+    this.pipelineStep = "untangling_traces"
+  }
+
   private _runUntangleTracesStep() {
     this.activeSubSolver = new UntangleTraceSubsolver({
       ...this.input,
@@ -97,9 +109,7 @@ export class TraceCleanupSolver extends BaseSolver {
   private _runMinimizeTurnsStep() {
     if (this.traceIdQueue.length === 0) {
       this.pipelineStep = "balancing_l_shapes"
-      this.traceIdQueue = Array.from(
-        this.input.allTraces.map((e) => e.mspPairId),
-      )
+      this.traceIdQueue = this.outputTraces.map((e) => e.mspPairId)
       return
     }
 

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -1,12 +1,12 @@
-import type { InputProblem } from "lib/types/InputProblem"
 import type { GraphicsObject, Line } from "graphics-debug"
-import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
-import { balanceZShapes } from "./balanceZShapes"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { balanceZShapes } from "./balanceZShapes"
 import { combineCloseSameNetTraceSegments } from "./combineCloseSameNetTraceSegments"
+import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -19,8 +19,8 @@ interface TraceCleanupSolverInput {
   paddingBuffer: number
 }
 
-import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.

--- a/lib/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments.ts
@@ -1,0 +1,124 @@
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+type Point = { x: number; y: number }
+
+const DEFAULT_MAX_ENDPOINT_DISTANCE = 0.35
+const EPS = 1e-6
+
+const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y)
+
+const pointsEqual = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) < EPS && Math.abs(a.y - b.y) < EPS
+
+const uniq = <T>(items: T[]) => Array.from(new Set(items))
+
+const reversePath = (path: Point[]) => [...path].reverse()
+
+const removeDuplicateNeighborPoints = (path: Point[]) => {
+  const result: Point[] = []
+  for (const point of path) {
+    const previous = result[result.length - 1]
+    if (!previous || !pointsEqual(previous, point)) {
+      result.push(point)
+    }
+  }
+  return result
+}
+
+const getEndpointVariants = (trace: SolvedTracePath) => {
+  const path = trace.tracePath
+  return [path, reversePath(path)]
+}
+
+const buildOrthogonalBridge = (from: Point, to: Point) => {
+  if (pointsEqual(from, to)) return []
+  if (Math.abs(from.x - to.x) < EPS || Math.abs(from.y - to.y) < EPS) {
+    return [to]
+  }
+  return [{ x: to.x, y: from.y }, to]
+}
+
+const mergeTracePair = (
+  traceA: SolvedTracePath,
+  traceB: SolvedTracePath,
+  maxEndpointDistance: number,
+): SolvedTracePath | null => {
+  let best: {
+    distance: number
+    pathA: Point[]
+    pathB: Point[]
+  } | null = null
+
+  for (const variantA of getEndpointVariants(traceA)) {
+    for (const variantB of getEndpointVariants(traceB)) {
+      const endpointDistance = distance(
+        variantA[variantA.length - 1]!,
+        variantB[0]!,
+      )
+      if (
+        endpointDistance <= maxEndpointDistance &&
+        (!best || endpointDistance < best.distance)
+      ) {
+        best = {
+          distance: endpointDistance,
+          pathA: variantA,
+          pathB: variantB,
+        }
+      }
+    }
+  }
+
+  if (!best) return null
+
+  const bridge = buildOrthogonalBridge(
+    best.pathA[best.pathA.length - 1]!,
+    best.pathB[0]!,
+  )
+
+  return {
+    ...traceA,
+    mspPairId: traceA.mspPairId,
+    tracePath: removeDuplicateNeighborPoints([
+      ...best.pathA,
+      ...bridge,
+      ...best.pathB,
+    ]),
+    mspConnectionPairIds: uniq([
+      ...(traceA.mspConnectionPairIds ?? [traceA.mspPairId]),
+      ...(traceB.mspConnectionPairIds ?? [traceB.mspPairId]),
+    ]),
+    pinIds: uniq([...(traceA.pinIds ?? []), ...(traceB.pinIds ?? [])]),
+  }
+}
+
+export const combineCloseSameNetTraceSegments = (
+  traces: SolvedTracePath[],
+  params: { maxEndpointDistance?: number } = {},
+): SolvedTracePath[] => {
+  const maxEndpointDistance =
+    params.maxEndpointDistance ?? DEFAULT_MAX_ENDPOINT_DISTANCE
+  const remaining = [...traces]
+  let didMerge = true
+
+  while (didMerge) {
+    didMerge = false
+
+    outer: for (let i = 0; i < remaining.length; i++) {
+      for (let j = i + 1; j < remaining.length; j++) {
+        const traceA = remaining[i]!
+        const traceB = remaining[j]!
+        if (traceA.globalConnNetId !== traceB.globalConnNetId) continue
+
+        const mergedTrace = mergeTracePair(traceA, traceB, maxEndpointDistance)
+        if (!mergedTrace) continue
+
+        remaining.splice(j, 1)
+        remaining[i] = mergedTrace
+        didMerge = true
+        break outer
+      }
+    }
+  }
+
+  return remaining
+}

--- a/lib/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments.ts
@@ -2,7 +2,7 @@ import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/Sche
 
 type Point = { x: number; y: number }
 
-const DEFAULT_MAX_ENDPOINT_DISTANCE = 0.35
+const DEFAULT_MAX_ENDPOINT_DISTANCE = 0.05
 const EPS = 1e-6
 
 const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y)
@@ -30,13 +30,8 @@ const getEndpointVariants = (trace: SolvedTracePath) => {
   return [path, reversePath(path)]
 }
 
-const buildOrthogonalBridge = (from: Point, to: Point) => {
-  if (pointsEqual(from, to)) return []
-  if (Math.abs(from.x - to.x) < EPS || Math.abs(from.y - to.y) < EPS) {
-    return [to]
-  }
-  return [{ x: to.x, y: from.y }, to]
-}
+const pointsShareAxis = (from: Point, to: Point) =>
+  Math.abs(from.x - to.x) < EPS || Math.abs(from.y - to.y) < EPS
 
 const mergeTracePair = (
   traceA: SolvedTracePath,
@@ -51,11 +46,16 @@ const mergeTracePair = (
 
   for (const variantA of getEndpointVariants(traceA)) {
     for (const variantB of getEndpointVariants(traceB)) {
+      if (!pointsShareAxis(variantA[variantA.length - 1]!, variantB[0]!)) {
+        continue
+      }
+
       const endpointDistance = distance(
         variantA[variantA.length - 1]!,
         variantB[0]!,
       )
       if (
+        endpointDistance > EPS &&
         endpointDistance <= maxEndpointDistance &&
         (!best || endpointDistance < best.distance)
       ) {
@@ -70,19 +70,10 @@ const mergeTracePair = (
 
   if (!best) return null
 
-  const bridge = buildOrthogonalBridge(
-    best.pathA[best.pathA.length - 1]!,
-    best.pathB[0]!,
-  )
-
   return {
     ...traceA,
     mspPairId: traceA.mspPairId,
-    tracePath: removeDuplicateNeighborPoints([
-      ...best.pathA,
-      ...bridge,
-      ...best.pathB,
-    ]),
+    tracePath: removeDuplicateNeighborPoints([...best.pathA, ...best.pathB]),
     mspConnectionPairIds: uniq([
       ...(traceA.mspConnectionPairIds ?? [traceA.mspPairId]),
       ...(traceB.mspConnectionPairIds ?? [traceB.mspPairId]),

--- a/tests/solvers/TraceCleanupSolver/combine-close-same-net-trace-segments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/combine-close-same-net-trace-segments.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
-import { combineCloseSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { combineCloseSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments"
 
 const makeTrace = (
   mspPairId: string,

--- a/tests/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import { combineCloseSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [] as any,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [mspPairId],
+  }) as SolvedTracePath
+
+test("combines close same-net trace endpoints into one trace", () => {
+  const result = combineCloseSameNetTraceSegments(
+    [
+      makeTrace("A.1-B.1", "net0", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("C.1-D.1", "net0", [
+        { x: 1.2, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+    { maxEndpointDistance: 0.25 },
+  )
+
+  expect(result).toHaveLength(1)
+  expect(result[0]!.tracePath).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1.2, y: 0 },
+    { x: 2, y: 0 },
+  ])
+  expect(result[0]!.mspConnectionPairIds).toEqual(["A.1-B.1", "C.1-D.1"])
+})
+
+test("does not combine close endpoints from different nets", () => {
+  const result = combineCloseSameNetTraceSegments(
+    [
+      makeTrace("A.1-B.1", "net0", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ]),
+      makeTrace("C.1-D.1", "net1", [
+        { x: 1.1, y: 0 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+    { maxEndpointDistance: 0.25 },
+  )
+
+  expect(result).toHaveLength(2)
+})


### PR DESCRIPTION
/claim #29

## Summary
- add a TraceCleanupSolver pipeline phase that combines close same-net trace segments before untangling/minimization
- only merges endpoints on the same X or Y axis and within a small distance threshold
- preserve merged connection ids and pin ids so later cleanup phases keep the trace metadata
- add focused coverage for same-net merge and different-net non-merge behavior

## Tests
- `npx biome check lib/solvers/TraceCleanupSolver/combineCloseSameNetTraceSegments.ts lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts tests/solvers/TraceCleanupSolver/combine-close-same-net-trace-segments.test.ts`
- `npx bun test tests/solvers/TraceCleanupSolver/combine-close-same-net-trace-segments.test.ts tests/solvers/TraceCleanupSolver/TraceCleanupSolver.test.ts`

Note: `npx tsup-node lib/index.ts --format esm --dts` could not run in this local checkout because `typescript` is not installed in node_modules.