### PR TITLE
Fix #29: add same-net trace segment alignment cleanup

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,6 +20,7 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { alignNearbySameNetSegments } from "./alignNearbySameNetSegments"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -28,6 +29,7 @@ type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
+  | "aligning_same_net_segments"
 
 /**
  * The TraceCleanupSolver is responsible for improving the aesthetics and readability of schematic traces.
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "aligning_same_net_segments":
+        this._runAlignSameNetSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +113,19 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "aligning_same_net_segments"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runAlignSameNetSegmentsStep() {
+    this.outputTraces = alignNearbySameNetSegments(this.outputTraces, {
+      maxAxisDistance: this.input.paddingBuffer,
+    })
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -1,0 +1,278 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+const EPS = 1e-9
+
+interface SegmentRef {
+  traceIndex: number
+  segmentIndex: number
+  orientation: "horizontal" | "vertical"
+  length: number
+  axis: number
+  minAlong: number
+  maxAlong: number
+}
+
+interface AlignNearbySameNetSegmentsOptions {
+  maxAxisDistance?: number
+  maxIterations?: number
+}
+
+const getSegmentRef = (
+  trace: SolvedTracePath,
+  traceIndex: number,
+  segmentIndex: number,
+): SegmentRef | null => {
+  const p1 = trace.tracePath[segmentIndex]
+  const p2 = trace.tracePath[segmentIndex + 1]
+  if (!p1 || !p2) return null
+
+  if (Math.abs(p1.y - p2.y) < EPS) {
+    return {
+      traceIndex,
+      segmentIndex,
+      orientation: "horizontal",
+      length: Math.abs(p2.x - p1.x),
+      axis: p1.y,
+      minAlong: Math.min(p1.x, p2.x),
+      maxAlong: Math.max(p1.x, p2.x),
+    }
+  }
+
+  if (Math.abs(p1.x - p2.x) < EPS) {
+    return {
+      traceIndex,
+      segmentIndex,
+      orientation: "vertical",
+      length: Math.abs(p2.y - p1.y),
+      axis: p1.x,
+      minAlong: Math.min(p1.y, p2.y),
+      maxAlong: Math.max(p1.y, p2.y),
+    }
+  }
+
+  return null
+}
+
+const getInternalSegments = (trace: SolvedTracePath, traceIndex: number) => {
+  const segments: SegmentRef[] = []
+  for (
+    let segmentIndex = 1;
+    segmentIndex < trace.tracePath.length - 2;
+    segmentIndex++
+  ) {
+    const segment = getSegmentRef(trace, traceIndex, segmentIndex)
+    if (segment && segment.length > EPS) {
+      segments.push(segment)
+    }
+  }
+  return segments
+}
+
+const rangesOverlap = (a: SegmentRef, b: SegmentRef) =>
+  Math.min(a.maxAlong, b.maxAlong) - Math.max(a.minAlong, b.minAlong) > EPS
+
+const pointsEqual = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) < EPS && Math.abs(a.y - b.y) < EPS
+
+const collinearSegmentsOverlap = (
+  a1: Point,
+  a2: Point,
+  b1: Point,
+  b2: Point,
+) => {
+  const aHorizontal = Math.abs(a1.y - a2.y) < EPS
+  const bHorizontal = Math.abs(b1.y - b2.y) < EPS
+  const aVertical = Math.abs(a1.x - a2.x) < EPS
+  const bVertical = Math.abs(b1.x - b2.x) < EPS
+
+  if (aHorizontal && bHorizontal && Math.abs(a1.y - b1.y) < EPS) {
+    return (
+      Math.min(Math.max(a1.x, a2.x), Math.max(b1.x, b2.x)) -
+        Math.max(Math.min(a1.x, a2.x), Math.min(b1.x, b2.x)) >
+      EPS
+    )
+  }
+
+  if (aVertical && bVertical && Math.abs(a1.x - b1.x) < EPS) {
+    return (
+      Math.min(Math.max(a1.y, a2.y), Math.max(b1.y, b2.y)) -
+        Math.max(Math.min(a1.y, a2.y), Math.min(b1.y, b2.y)) >
+      EPS
+    )
+  }
+
+  return false
+}
+
+const segmentsCrossAtInterior = (
+  a1: Point,
+  a2: Point,
+  b1: Point,
+  b2: Point,
+) => {
+  const aHorizontal = Math.abs(a1.y - a2.y) < EPS
+  const bHorizontal = Math.abs(b1.y - b2.y) < EPS
+  const aVertical = Math.abs(a1.x - a2.x) < EPS
+  const bVertical = Math.abs(b1.x - b2.x) < EPS
+
+  if (!((aHorizontal && bVertical) || (aVertical && bHorizontal))) {
+    return false
+  }
+
+  const horizontal = aHorizontal ? [a1, a2] : [b1, b2]
+  const vertical = aVertical ? [a1, a2] : [b1, b2]
+  const cross = { x: vertical[0].x, y: horizontal[0].y }
+
+  const withinHorizontal =
+    cross.x > Math.min(horizontal[0].x, horizontal[1].x) + EPS &&
+    cross.x < Math.max(horizontal[0].x, horizontal[1].x) - EPS
+  const withinVertical =
+    cross.y > Math.min(vertical[0].y, vertical[1].y) + EPS &&
+    cross.y < Math.max(vertical[0].y, vertical[1].y) - EPS
+
+  if (!withinHorizontal || !withinVertical) return false
+
+  return !(
+    pointsEqual(cross, a1) ||
+    pointsEqual(cross, a2) ||
+    pointsEqual(cross, b1) ||
+    pointsEqual(cross, b2)
+  )
+}
+
+const wouldConflictWithDifferentNet = (
+  candidatePath: Point[],
+  candidateNetId: string,
+  allTraces: SolvedTracePath[],
+  candidateTraceIndex: number,
+) => {
+  for (
+    let candidateSegmentIndex = 0;
+    candidateSegmentIndex < candidatePath.length - 1;
+    candidateSegmentIndex++
+  ) {
+    const c1 = candidatePath[candidateSegmentIndex]
+    const c2 = candidatePath[candidateSegmentIndex + 1]
+    if (!c1 || !c2) continue
+
+    for (let traceIndex = 0; traceIndex < allTraces.length; traceIndex++) {
+      if (traceIndex === candidateTraceIndex) continue
+
+      const trace = allTraces[traceIndex]
+      if (trace.globalConnNetId === candidateNetId) continue
+
+      for (
+        let segmentIndex = 0;
+        segmentIndex < trace.tracePath.length - 1;
+        segmentIndex++
+      ) {
+        const p1 = trace.tracePath[segmentIndex]
+        const p2 = trace.tracePath[segmentIndex + 1]
+        if (!p1 || !p2) continue
+
+        if (
+          collinearSegmentsOverlap(c1, c2, p1, p2) ||
+          segmentsCrossAtInterior(c1, c2, p1, p2)
+        ) {
+          return true
+        }
+      }
+    }
+  }
+
+  return false
+}
+
+const snapSegmentAxis = (
+  trace: SolvedTracePath,
+  segment: SegmentRef,
+  axis: number,
+): Point[] => {
+  const nextPath = trace.tracePath.map((point) => ({ ...point }))
+  if (segment.orientation === "horizontal") {
+    nextPath[segment.segmentIndex]!.y = axis
+    nextPath[segment.segmentIndex + 1]!.y = axis
+  } else {
+    nextPath[segment.segmentIndex]!.x = axis
+    nextPath[segment.segmentIndex + 1]!.x = axis
+  }
+  return simplifyPath(nextPath)
+}
+
+export const alignNearbySameNetSegments = (
+  traces: SolvedTracePath[],
+  options: AlignNearbySameNetSegmentsOptions = {},
+): SolvedTracePath[] => {
+  const maxAxisDistance = options.maxAxisDistance ?? 0.15
+  const maxIterations = options.maxIterations ?? 8
+  let outputTraces = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  for (let iteration = 0; iteration < maxIterations; iteration++) {
+    let changed = false
+    const segmentsByTrace = outputTraces.map(getInternalSegments)
+
+    for (let traceIndex = 0; traceIndex < outputTraces.length; traceIndex++) {
+      for (
+        let otherTraceIndex = traceIndex + 1;
+        otherTraceIndex < outputTraces.length;
+        otherTraceIndex++
+      ) {
+        const trace = outputTraces[traceIndex]
+        const otherTrace = outputTraces[otherTraceIndex]
+        if (trace.globalConnNetId !== otherTrace.globalConnNetId) continue
+
+        for (const segment of segmentsByTrace[traceIndex]) {
+          for (const otherSegment of segmentsByTrace[otherTraceIndex]) {
+            if (segment.orientation !== otherSegment.orientation) continue
+            if (!rangesOverlap(segment, otherSegment)) continue
+
+            const axisDistance = Math.abs(segment.axis - otherSegment.axis)
+            if (axisDistance < EPS || axisDistance > maxAxisDistance) continue
+
+            const [sourceSegment, targetSegment] =
+              segment.length >= otherSegment.length
+                ? [segment, otherSegment]
+                : [otherSegment, segment]
+            const targetTrace = outputTraces[targetSegment.traceIndex]
+            const candidatePath = snapSegmentAxis(
+              targetTrace,
+              targetSegment,
+              sourceSegment.axis,
+            )
+
+            if (
+              wouldConflictWithDifferentNet(
+                candidatePath,
+                targetTrace.globalConnNetId,
+                outputTraces,
+                targetSegment.traceIndex,
+              )
+            ) {
+              continue
+            }
+
+            outputTraces = outputTraces.map((existingTrace, index) =>
+              index === targetSegment.traceIndex
+                ? { ...existingTrace, tracePath: candidatePath }
+                : existingTrace,
+            )
+            changed = true
+            break
+          }
+          if (changed) break
+        }
+        if (changed) break
+      }
+      if (changed) break
+    }
+
+    if (!changed) break
+  }
+
+  return outputTraces
+}

--- a/tests/solvers/TraceCleanupSolver/__snapshots__/before-after.snap.svg
+++ b/tests/solvers/TraceCleanupSolver/__snapshots__/before-after.snap.svg
@@ -1,0 +1,144 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="" data-x="0" data-y="0" cx="40" cy="376.77777777777777" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1" data-y="0" cx="89.77777777777777" cy="376.77777777777777" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="1" data-y="1" cx="89.77777777777777" cy="327" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="4" data-y="1" cx="239.11111111111111" cy="327" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="4" data-y="0" cx="239.11111111111111" cy="376.77777777777777" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="5" data-y="0" cx="288.8888888888889" cy="376.77777777777777" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="0" data-y="2" cx="40" cy="277.22222222222223" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="2" data-y="2" cx="139.55555555555554" cy="277.22222222222223" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="2" data-y="1.08" cx="139.55555555555554" cy="323.0177777777778" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="3" data-y="1.08" cx="189.33333333333334" cy="323.0177777777778" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="3" data-y="2" cx="189.33333333333334" cy="277.22222222222223" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="5" data-y="2" cx="288.8888888888889" cy="277.22222222222223" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="6.25" data-y="0" cx="351.11111111111114" cy="376.77777777777777" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="7.25" data-y="0" cx="400.8888888888889" cy="376.77777777777777" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="7.25" data-y="1" cx="400.8888888888889" cy="327" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="10.25" data-y="1" cx="550.2222222222222" cy="327" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="10.25" data-y="0" cx="550.2222222222222" cy="376.77777777777777" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="11.25" data-y="0" cx="600" cy="376.77777777777777" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="6.25" data-y="2" cx="351.11111111111114" cy="277.22222222222223" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="8.25" data-y="2" cx="450.6666666666667" cy="277.22222222222223" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="8.25" data-y="1" cx="450.6666666666667" cy="327" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="9.25" data-y="1" cx="500.44444444444446" cy="327" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="9.25" data-y="2" cx="500.44444444444446" cy="277.22222222222223" r="3" fill="green" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="" data-x="11.25" data-y="2" cx="600" cy="277.22222222222223" r="3" fill="green" />
+  </g>
+  <g>
+    <polyline data-points="0,0 1,0 1,1 4,1 4,0 5,0" data-type="line" data-label="" points="40,376.77777777777777 89.77777777777777,376.77777777777777 89.77777777777777,327 239.11111111111111,327 239.11111111111111,376.77777777777777 288.8888888888889,376.77777777777777" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0,2 2,2 2,1.08 3,1.08 3,2 5,2" data-type="line" data-label="" points="40,277.22222222222223 139.55555555555554,277.22222222222223 139.55555555555554,323.0177777777778 189.33333333333334,323.0177777777778 189.33333333333334,277.22222222222223 288.8888888888889,277.22222222222223" fill="none" stroke="red" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="6.25,0 7.25,0 7.25,1 10.25,1 10.25,0 11.25,0" data-type="line" data-label="" points="351.11111111111114,376.77777777777777 400.8888888888889,376.77777777777777 400.8888888888889,327 550.2222222222222,327 550.2222222222222,376.77777777777777 600,376.77777777777777" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="6.25,2 8.25,2 8.25,1 9.25,1 9.25,2 11.25,2" data-type="line" data-label="" points="351.11111111111114,277.22222222222223 450.6666666666667,277.22222222222223 450.6666666666667,327 500.44444444444446,327 500.44444444444446,277.22222222222223 600,277.22222222222223" fill="none" stroke="red" stroke-width="1" />
+  </g><text data-type="text" data-label="Before" data-x="2.5" data-y="2.28125" x="164.44444444444446" y="263.22222222222223" fill="black" font-size="14" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Before</text><text data-type="text" data-label="After" data-x="8.75" data-y="2.28125" x="475.55555555555554" y="263.22222222222223" fill="black" font-size="14" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">After</text>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 49.77777777777778,
+        "c": 0,
+        "e": 40,
+        "b": 0,
+        "d": -49.77777777777778,
+        "f": 376.77777777777777
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -1,4 +1,9 @@
 import { expect, test } from "bun:test"
+import {
+  getSvgFromGraphicsObject,
+  stackGraphicsHorizontally,
+  type GraphicsObject,
+} from "graphics-debug"
 import { alignNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 
@@ -16,6 +21,19 @@ const makeTrace = (
     pinIds: [],
     tracePath,
   }) as unknown as SolvedTracePath
+
+const renderTraces = (traces: SolvedTracePath[]): GraphicsObject => ({
+  lines: traces.map((trace, index) => ({
+    points: trace.tracePath,
+    strokeColor: index === 0 ? "blue" : "red",
+  })),
+  points: traces.flatMap((trace) =>
+    trace.tracePath.map((point) => ({
+      ...point,
+      color: trace.globalConnNetId === "net1" ? "green" : "orange",
+    })),
+  ),
+})
 
 test("aligns close overlapping horizontal segments on the same net", () => {
   const [anchorTrace, adjustedTrace] = alignNearbySameNetSegments(
@@ -43,6 +61,43 @@ test("aligns close overlapping horizontal segments on the same net", () => {
   expect(anchorTrace.tracePath[2].y).toBe(1)
   expect(adjustedTrace.tracePath[2].y).toBe(1)
   expect(adjustedTrace.tracePath[3].y).toBe(1)
+})
+
+test("renders before and after proof for same-net segment alignment", () => {
+  const before = [
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 0 },
+      { x: 5, y: 0 },
+    ]),
+    makeTrace("b", "net1", [
+      { x: 0, y: 2 },
+      { x: 2, y: 2 },
+      { x: 2, y: 1.08 },
+      { x: 3, y: 1.08 },
+      { x: 3, y: 2 },
+      { x: 5, y: 2 },
+    ]),
+  ]
+
+  const after = alignNearbySameNetSegments(before, {
+    maxAxisDistance: 0.1,
+  })
+
+  expect(after[1].tracePath[2].y).toBe(1)
+  expect(after[1].tracePath[3].y).toBe(1)
+
+  const proofSvg = getSvgFromGraphicsObject(
+    stackGraphicsHorizontally([renderTraces(before), renderTraces(after)], {
+      titles: ["Before", "After"],
+    }),
+    { backgroundColor: "white" },
+  )
+
+  expect(proofSvg).toMatchSvgSnapshot(import.meta.path, "before-after")
 })
 
 test("aligns close overlapping vertical segments on the same net", () => {

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -1,0 +1,150 @@
+import { expect, test } from "bun:test"
+import { alignNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [],
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+    tracePath,
+  }) as unknown as SolvedTracePath
+
+test("aligns close overlapping horizontal segments on the same net", () => {
+  const [anchorTrace, adjustedTrace] = alignNearbySameNetSegments(
+    [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 0 },
+        { x: 5, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 0, y: 2 },
+        { x: 2, y: 2 },
+        { x: 2, y: 1.08 },
+        { x: 3, y: 1.08 },
+        { x: 3, y: 2 },
+        { x: 5, y: 2 },
+      ]),
+    ],
+    { maxAxisDistance: 0.1 },
+  )
+
+  expect(anchorTrace.tracePath[2].y).toBe(1)
+  expect(adjustedTrace.tracePath[2].y).toBe(1)
+  expect(adjustedTrace.tracePath[3].y).toBe(1)
+})
+
+test("aligns close overlapping vertical segments on the same net", () => {
+  const [, adjustedTrace] = alignNearbySameNetSegments(
+    [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 4 },
+        { x: 2, y: 4 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 3, y: 0 },
+        { x: 1.06, y: 0 },
+        { x: 1.06, y: 3 },
+        { x: 3, y: 3 },
+      ]),
+    ],
+    { maxAxisDistance: 0.1 },
+  )
+
+  expect(adjustedTrace.tracePath[1].x).toBe(1)
+  expect(adjustedTrace.tracePath[2].x).toBe(1)
+})
+
+test("does not align different nets", () => {
+  const [, otherNetTrace] = alignNearbySameNetSegments(
+    [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 0 },
+        { x: 5, y: 0 },
+      ]),
+      makeTrace("b", "net2", [
+        { x: 0, y: 2 },
+        { x: 2, y: 2 },
+        { x: 2, y: 1.08 },
+        { x: 3, y: 1.08 },
+        { x: 3, y: 2 },
+        { x: 5, y: 2 },
+      ]),
+    ],
+    { maxAxisDistance: 0.1 },
+  )
+
+  expect(otherNetTrace.tracePath[2].y).toBe(1.08)
+  expect(otherNetTrace.tracePath[3].y).toBe(1.08)
+})
+
+test("leaves endpoint segments in place", () => {
+  const [firstTrace, secondTrace] = alignNearbySameNetSegments(
+    [
+      makeTrace("a", "net1", [
+        { x: 0, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 2 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 0, y: 1.05 },
+        { x: 3, y: 1.05 },
+        { x: 3, y: 2 },
+      ]),
+    ],
+    { maxAxisDistance: 0.1 },
+  )
+
+  expect(firstTrace.tracePath[0].y).toBe(1)
+  expect(firstTrace.tracePath[1].y).toBe(1)
+  expect(secondTrace.tracePath[0].y).toBe(1.05)
+  expect(secondTrace.tracePath[1].y).toBe(1.05)
+})
+
+test("skips same-net alignment when it would overlap a different net", () => {
+  const [, adjustedTrace] = alignNearbySameNetSegments(
+    [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 },
+        { x: 4, y: 1 },
+        { x: 4, y: 0 },
+        { x: 5, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 0, y: 2 },
+        { x: 2, y: 2 },
+        { x: 2, y: 1.08 },
+        { x: 3, y: 1.08 },
+        { x: 3, y: 2 },
+        { x: 5, y: 2 },
+      ]),
+      makeTrace("c", "net2", [
+        { x: 2.2, y: 1 },
+        { x: 2.8, y: 1 },
+      ]),
+    ],
+    { maxAxisDistance: 0.1 },
+  )
+
+  expect(adjustedTrace.tracePath[2].y).toBe(1.08)
+  expect(adjustedTrace.tracePath[3].y).toBe(1.08)
+})


### PR DESCRIPTION
## Summary
- fixes #29 and fixes #34
- add a final TraceCleanupSolver phase that aligns close overlapping internal H/V segments on the same global net
- preserve endpoint segments so pin anchors stay fixed
- reject candidate alignments that would overlap or cross a different-net segment
- add focused solver coverage for horizontal/vertical alignment, cross-net protection, endpoint preservation, conflict rejection, and before/after visual proof

## Proof
- In-repo before/after proof snapshot: `tests/solvers/TraceCleanupSolver/__snapshots__/before-after.snap.svg`
- #29 proof comment: https://github.com/tscircuit/schematic-trace-solver/issues/29#issuecomment-4495465906
- #34 proof comment: https://github.com/tscircuit/schematic-trace-solver/issues/34#issuecomment-4495360853
- Visual proof gist: https://gist.github.com/PassivelyWealthyDad/2d7002c01851066d0f98fc35dd653cd5

## Verification
- .\node_modules\.bin\bun.cmd test tests\solvers\TraceCleanupSolver\alignNearbySameNetSegments.test.ts
- .\node_modules\.bin\bun.cmd test tests\examples\example29.test.ts
- .\node_modules\.bin\bun.cmd test tests\examples\example34.test.ts
- .\node_modules\.bin\bun.cmd test
- .\node_modules\.bin\tsc.cmd --noEmit
- git diff --check -- lib\solvers\TraceCleanupSolver\TraceCleanupSolver.ts lib\solvers\TraceCleanupSolver\alignNearbySameNetSegments.ts tests\solvers\TraceCleanupSolver\alignNearbySameNetSegments.test.ts tests\solvers\TraceCleanupSolver\__snapshots__\before-after.snap.svg

/claim #29
/claim #34