### PR TITLE
fix: merge close same-net traces during cleanup

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,11 +20,13 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { mergeSameNetCloseTraces } from "./mergeSameNetCloseTraces"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
  */
 type PipelineStep =
+  | "merging_same_net_close_traces"
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
@@ -66,10 +68,10 @@ export class TraceCleanupSolver extends BaseSolver {
         this.outputTraces = output.traces
         this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "merging_same_net_close_traces"
       } else if (this.activeSubSolver.failed) {
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "merging_same_net_close_traces"
       }
       return
     }
@@ -77,6 +79,9 @@ export class TraceCleanupSolver extends BaseSolver {
     switch (this.pipelineStep) {
       case "untangling_traces":
         this._runUntangleTracesStep()
+        break
+      case "merging_same_net_close_traces":
+        this._runMergeSameNetCloseTracesStep()
         break
       case "minimizing_turns":
         this._runMinimizeTurnsStep()
@@ -92,6 +97,15 @@ export class TraceCleanupSolver extends BaseSolver {
       ...this.input,
       allTraces: Array.from(this.tracesMap.values()),
     })
+  }
+
+  private _runMergeSameNetCloseTracesStep() {
+    this.outputTraces = mergeSameNetCloseTraces(
+      Array.from(this.tracesMap.values()),
+    )
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.traceIdQueue = Array.from(this.outputTraces.map((e) => e.mspPairId))
+    this.pipelineStep = "minimizing_turns"
   }
 
   private _runMinimizeTurnsStep() {

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.ts
@@ -1,0 +1,128 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const DEFAULT_CLOSE_THRESHOLD = 0.2
+const EPSILON = 1e-9
+
+type Endpoint = "start" | "end"
+
+const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y)
+
+const areSamePoint = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) < EPSILON && Math.abs(a.y - b.y) < EPSILON
+
+const getEndpoint = (trace: SolvedTracePath, endpoint: Endpoint) =>
+  endpoint === "start" ? trace.tracePath[0]! : trace.tracePath.at(-1)!
+
+const orientPathWithEndpointAtEnd = (
+  trace: SolvedTracePath,
+  endpoint: Endpoint,
+) =>
+  endpoint === "start" ? [...trace.tracePath].reverse() : [...trace.tracePath]
+
+const orientPathWithEndpointAtStart = (
+  trace: SolvedTracePath,
+  endpoint: Endpoint,
+) =>
+  endpoint === "end" ? [...trace.tracePath].reverse() : [...trace.tracePath]
+
+const dedupeConsecutivePoints = (points: Point[]) => {
+  const deduped: Point[] = []
+  for (const point of points) {
+    if (deduped.length === 0 || !areSamePoint(deduped.at(-1)!, point)) {
+      deduped.push(point)
+    }
+  }
+  return deduped
+}
+
+const mergeTracePair = (
+  a: SolvedTracePath,
+  b: SolvedTracePath,
+  aEndpoint: Endpoint,
+  bEndpoint: Endpoint,
+): SolvedTracePath => {
+  const aPath = orientPathWithEndpointAtEnd(a, aEndpoint)
+  const bPath = orientPathWithEndpointAtStart(b, bEndpoint)
+  const aJoin = aPath.at(-1)!
+  const bJoin = bPath[0]!
+
+  const joinPoint =
+    Math.abs(aJoin.x - bJoin.x) <= Math.abs(aJoin.y - bJoin.y)
+      ? { x: (aJoin.x + bJoin.x) / 2, y: aJoin.y }
+      : { x: aJoin.x, y: (aJoin.y + bJoin.y) / 2 }
+
+  const mergedPath = dedupeConsecutivePoints([
+    ...aPath.slice(0, -1),
+    joinPoint,
+    ...bPath.slice(1),
+  ])
+
+  return {
+    ...a,
+    mspPairId: `${a.mspPairId}+${b.mspPairId}`,
+    mspConnectionPairIds: [
+      ...a.mspConnectionPairIds,
+      ...b.mspConnectionPairIds,
+    ],
+    pinIds: [...new Set([...a.pinIds, ...b.pinIds])],
+    tracePath: mergedPath,
+  }
+}
+
+export const mergeSameNetCloseTraces = (
+  traces: SolvedTracePath[],
+  closeThreshold = DEFAULT_CLOSE_THRESHOLD,
+): SolvedTracePath[] => {
+  const remaining = [...traces]
+  let mergedAny = true
+
+  while (mergedAny) {
+    mergedAny = false
+
+    outer: for (let i = 0; i < remaining.length; i++) {
+      for (let j = i + 1; j < remaining.length; j++) {
+        const a = remaining[i]!
+        const b = remaining[j]!
+
+        if (a.globalConnNetId !== b.globalConnNetId) continue
+
+        const candidates = [
+          [
+            "start",
+            "start",
+            distance(getEndpoint(a, "start"), getEndpoint(b, "start")),
+          ],
+          [
+            "start",
+            "end",
+            distance(getEndpoint(a, "start"), getEndpoint(b, "end")),
+          ],
+          [
+            "end",
+            "start",
+            distance(getEndpoint(a, "end"), getEndpoint(b, "start")),
+          ],
+          [
+            "end",
+            "end",
+            distance(getEndpoint(a, "end"), getEndpoint(b, "end")),
+          ],
+        ] satisfies Array<[Endpoint, Endpoint, number]>
+
+        candidates.sort((left, right) => left[2] - right[2])
+
+        const [aEndpoint, bEndpoint, minDistance] = candidates[0]!
+        if (minDistance > closeThreshold) continue
+
+        const merged = mergeTracePair(a, b, aEndpoint, bEndpoint)
+        remaining.splice(j, 1)
+        remaining.splice(i, 1, merged)
+        mergedAny = true
+        break outer
+      }
+    }
+  }
+
+  return remaining
+}

--- a/tests/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import { mergeSameNetCloseTraces } from "lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  id: string,
+  globalConnNetId: string,
+  tracePath: SolvedTracePath["tracePath"],
+): SolvedTracePath => ({
+  mspPairId: id,
+  dcConnNetId: globalConnNetId,
+  globalConnNetId,
+  pins: [
+    {
+      pinId: `${id}-a`,
+      x: tracePath[0]!.x,
+      y: tracePath[0]!.y,
+      chipId: "chip-a",
+    },
+    {
+      pinId: `${id}-b`,
+      x: tracePath.at(-1)!.x,
+      y: tracePath.at(-1)!.y,
+      chipId: "chip-b",
+    },
+  ],
+  tracePath,
+  mspConnectionPairIds: [id],
+  pinIds: [`${id}-a`, `${id}-b`],
+})
+
+test("mergeSameNetCloseTraces combines close traces on the same net", () => {
+  const traces = [
+    makeTrace("a", "GND", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ]),
+    makeTrace("b", "GND", [
+      { x: 1.05, y: 0.04 },
+      { x: 2, y: 0.04 },
+    ]),
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, 0.1)
+
+  expect(result).toHaveLength(1)
+  expect(result[0]!.mspConnectionPairIds).toEqual(["a", "b"])
+  expect(result[0]!.tracePath).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0.02 },
+    { x: 2, y: 0.04 },
+  ])
+})
+
+test("mergeSameNetCloseTraces leaves different nets separate", () => {
+  const traces = [
+    makeTrace("a", "GND", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ]),
+    makeTrace("b", "VCC", [
+      { x: 1.05, y: 0.04 },
+      { x: 2, y: 0.04 },
+    ]),
+  ]
+
+  expect(mergeSameNetCloseTraces(traces, 0.1)).toHaveLength(2)
+})
+
+test("mergeSameNetCloseTraces leaves far same-net traces separate", () => {
+  const traces = [
+    makeTrace("a", "GND", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ]),
+    makeTrace("b", "GND", [
+      { x: 2, y: 0 },
+      { x: 3, y: 0 },
+    ]),
+  ]
+
+  expect(mergeSameNetCloseTraces(traces, 0.1)).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary
- Add a cleanup pipeline phase that merges close trace paths on the same net before turn minimization.
- Snap close endpoints onto a shared horizontal/vertical join point so near-touching same-net segments become one path.
- Preserve MSP pair IDs and pin IDs from merged traces.

## Test plan
- `npx bun test tests/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.test.ts`
- `./node_modules/.bin/tsc --noEmit`

/claim #29