### PR TITLE
Avoid traces between repeated single-pin net labels

### DIFF
--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -74,8 +74,11 @@ export class LongDistancePairSolver extends BaseSolver {
     const addedPairKeys = new Set<string>()
 
     for (const netId of Object.keys(netConnMap.netMap)) {
-      const allPinIdsInNet = netConnMap.getIdsConnectedToNet(netId)
+      const allPinIdsInNet = netConnMap
+        .getIdsConnectedToNet(netId)
+        .filter((pinId) => pinMap.has(pinId))
       if (allPinIdsInNet.length < 2) continue
+      if (this.isRepeatedSinglePinNetLabelNet(allPinIdsInNet)) continue
 
       const unconnectedPinIds = allPinIdsInNet.filter(
         (pinId) => !primaryConnectedPinIds.has(pinId),
@@ -123,6 +126,43 @@ export class LongDistancePairSolver extends BaseSolver {
       }
     }
     this.queuedCandidatePairs = candidatePairs
+  }
+
+  private isRepeatedSinglePinNetLabelNet(pinIdsInNet: PinId[]) {
+    const userNetIds = new Set<string>()
+
+    for (const pinId of pinIdsInNet) {
+      for (const netConn of this.inputProblem.netConnections) {
+        if (netConn.pinIds.includes(pinId)) {
+          userNetIds.add(netConn.netId)
+        }
+      }
+    }
+
+    if (userNetIds.size !== 1) return false
+
+    const [userNetId] = [...userNetIds]
+    const matchingNetConnections = this.inputProblem.netConnections.filter(
+      (netConn) => netConn.netId === userNetId,
+    )
+
+    if (matchingNetConnections.length < 2) return false
+    if (matchingNetConnections.some((netConn) => netConn.pinIds.length !== 1)) {
+      return false
+    }
+
+    const netConnectionPinIds = new Set(
+      matchingNetConnections.flatMap((netConn) => netConn.pinIds),
+    )
+
+    if (netConnectionPinIds.size !== pinIdsInNet.length) return false
+    if (pinIdsInNet.some((pinId) => !netConnectionPinIds.has(pinId))) {
+      return false
+    }
+
+    return !this.inputProblem.directConnections.some((directConn) =>
+      directConn.pinIds.some((pinId) => netConnectionPinIds.has(pinId)),
+    )
   }
 
   override getConstructorParams() {

--- a/tests/solvers/MspConnectionPairSolver/MspConnectionPairSolver_portOnlyLabels.test.ts
+++ b/tests/solvers/MspConnectionPairSolver/MspConnectionPairSolver_portOnlyLabels.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "C1",
+      center: { x: 2, y: 0 },
+      width: 0.5,
+      height: 1,
+      pins: [
+        { pinId: "C1.1", x: 2, y: -0.5 },
+        { pinId: "C1.2", x: 2, y: 0.5 },
+      ],
+    },
+    {
+      chipId: "C2",
+      center: { x: 0, y: 0 },
+      width: 0.5,
+      height: 1,
+      pins: [
+        { pinId: "C2.1", x: 0, y: -0.5 },
+        { pinId: "C2.2", x: 0, y: 0.5 },
+      ],
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    { netId: "GND", pinIds: ["C1.1"] },
+    { netId: "VCC", pinIds: ["C1.2"] },
+    { netId: "GND", pinIds: ["C2.1"] },
+    { netId: "VCC", pinIds: ["C2.2"] },
+  ],
+  availableNetLabelOrientations: {
+    GND: ["y+"],
+    VCC: ["y-"],
+  },
+}
+
+test("keeps repeated single-pin net labels as labels instead of routing traces between them", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+
+  solver.solve()
+
+  const output = solver.netLabelTraceCollisionSolver!.getOutput()
+  expect(output.traces).toEqual([])
+  expect(output.netLabelPlacements).toHaveLength(4)
+})


### PR DESCRIPTION
Fixes #79

## Summary

- Prevent long-distance trace candidates from connecting separate single-pin net label entries that share the same net id.
- Keep those repeated single-pin entries as port-only labels instead.
- Add a regression test for the repro shape from the issue.

## Verification

- `npx bun test tests/solvers/MspConnectionPairSolver/MspConnectionPairSolver_portOnlyLabels.test.ts`
- `npx bun test`
- `npx bun run format:check`

## Notes

- This keeps multi-pin net connections and direct connections eligible for trace routing.
