### PR TITLE
Fix zero-length trace path cleanup

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,13 +4,30 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
-export const simplifyPath = (path: Point[]): Point[] => {
+const pointsEqual = (a: Point, b: Point) => a.x === b.x && a.y === b.y
+
+export const removeConsecutiveDuplicatePoints = (path: Point[]): Point[] => {
+  const dedupedPath: Point[] = []
+
+  for (const point of path) {
+    const previousPoint = dedupedPath[dedupedPath.length - 1]
+    if (!previousPoint || !pointsEqual(previousPoint, point)) {
+      dedupedPath.push(point)
+    }
+  }
+
+  return dedupedPath
+}
+
+const collapseCollinearPoints = (path: Point[]): Point[] => {
   if (path.length < 3) return path
   const newPath: Point[] = [path[0]]
+
   for (let i = 1; i < path.length - 1; i++) {
     const p1 = newPath[newPath.length - 1]
     const p2 = path[i]
     const p3 = path[i + 1]
+
     if (
       (isVertical(p1, p2) && isVertical(p2, p3)) ||
       (isHorizontal(p1, p2) && isHorizontal(p2, p3))
@@ -21,21 +38,23 @@ export const simplifyPath = (path: Point[]): Point[] => {
   }
   newPath.push(path[path.length - 1])
 
-  if (newPath.length < 3) return newPath
-  const finalPath: Point[] = [newPath[0]]
-  for (let i = 1; i < newPath.length - 1; i++) {
-    const p1 = finalPath[finalPath.length - 1]
-    const p2 = newPath[i]
-    const p3 = newPath[i + 1]
-    if (
-      (isVertical(p1, p2) && isVertical(p2, p3)) ||
-      (isHorizontal(p1, p2) && isHorizontal(p2, p3))
-    ) {
-      continue
-    }
-    finalPath.push(p2)
-  }
-  finalPath.push(newPath[newPath.length - 1])
+  return newPath
+}
 
-  return finalPath
+export const simplifyPath = (path: Point[]): Point[] => {
+  let simplifiedPath = removeConsecutiveDuplicatePoints(path)
+
+  while (simplifiedPath.length >= 3) {
+    const nextPath = removeConsecutiveDuplicatePoints(
+      collapseCollinearPoints(simplifiedPath),
+    )
+
+    if (nextPath.length === simplifiedPath.length) {
+      return nextPath
+    }
+
+    simplifiedPath = nextPath
+  }
+
+  return simplifiedPath
 }

--- a/tests/solvers/TraceCleanupSolver/simplifyPath.test.ts
+++ b/tests/solvers/TraceCleanupSolver/simplifyPath.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import {
+  removeConsecutiveDuplicatePoints,
+  simplifyPath,
+} from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+test("removeConsecutiveDuplicatePoints removes zero-length path segments", () => {
+  expect(
+    removeConsecutiveDuplicatePoints([
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 2 },
+      { x: 1, y: 2 },
+    ]),
+  ).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 2 },
+  ])
+})
+
+test("simplifyPath removes duplicate points before collapsing collinear spans", () => {
+  expect(
+    simplifyPath([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 2 },
+      { x: 2, y: 2 },
+      { x: 2, y: 4 },
+    ]),
+  ).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 4 },
+  ])
+})
+
+test("simplifyPath reduces a zero-length path to a single point", () => {
+  expect(
+    simplifyPath([
+      { x: 3, y: 4 },
+      { x: 3, y: 4 },
+    ]),
+  ).toEqual([{ x: 3, y: 4 }])
+})


### PR DESCRIPTION
/claim #78

## Summary
- strip consecutive duplicate path points before collinear cleanup so zero-length trace segments cannot survive post-processing
- rerun collinear collapse with duplicate-point cleanup until the path stops shrinking
- add focused unit coverage for duplicate points and zero-length two-point paths

## Tests
- bun test tests/solvers/TraceCleanupSolver/simplifyPath.test.ts tests/solvers/TraceCleanupSolver/TraceCleanupSolver.test.ts
- bun test
- bun run format:check
- bun run build
- git diff --check