### PR TITLE
feat: Implement TraceSegmentCombinerSolver to combine same-net trace segments

### DIFF
--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -6,26 +6,27 @@
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { InputProblem } from "lib/types/InputProblem"
+import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
+import { Example28Solver } from "../Example28Solver/Example28Solver"
+import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MspConnectionPairSolver } from "../MspConnectionPairSolver/MspConnectionPairSolver"
+import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
 import {
   SchematicTraceLinesSolver,
   type SolvedTracePath,
 } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
-import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
-import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
-import { visualizeInputProblem } from "./visualizeInputProblem"
+import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
+import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import type { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceLabelOverlapAvoidanceSolver } from "../TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver"
+import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
+import { TraceSegmentCombinerSolver } from "../TraceSegmentCombinerSolver/TraceSegmentCombinerSolver"
+import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
+import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
 import { correctPinsInsideChips } from "./correctPinsInsideChip"
 import { expandChipsToFitPins } from "./expandChipsToFitPins"
-import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
-import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
-import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
-import { Example28Solver } from "../Example28Solver/Example28Solver"
-import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
-import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
-import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
-import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { visualizeInputProblem } from "./visualizeInputProblem"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -70,6 +71,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   // guidelinesSolver?: GuidelinesSolver
   schematicTraceLinesSolver?: SchematicTraceLinesSolver
   longDistancePairSolver?: LongDistancePairSolver
+  traceSegmentCombinerSolver?: TraceSegmentCombinerSolver
   traceOverlapShiftSolver?: TraceOverlapShiftSolver
   netLabelPlacementSolver?: NetLabelPlacementSolver
   labelMergingSolver?: MergedNetLabelObstacleSolver
@@ -94,7 +96,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       MspConnectionPairSolver,
       () => [{ inputProblem: this.inputProblem }],
       {
-        onSolved: (mspSolver) => {},
+        onSolved: (_mspSolver) => {},
       },
     ),
     // definePipelineStep(
@@ -136,8 +138,19 @@ export class SchematicTracePipelineSolver extends BaseSolver {
         },
       ],
       {
-        onSolved: (schematicTraceLinesSolver) => {},
+        onSolved: (_schematicTraceLinesSolver) => {},
       },
+    ),
+    definePipelineStep(
+      "traceSegmentCombinerSolver",
+      TraceSegmentCombinerSolver,
+      (instance) => [
+        {
+          inputProblem: instance.inputProblem,
+          allTraces:
+            instance.longDistancePairSolver!.getOutput().allTracesMerged,
+        },
+      ],
     ),
     definePipelineStep(
       "traceOverlapShiftSolver",
@@ -145,8 +158,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       () => [
         {
           inputProblem: this.inputProblem,
-          inputTracePaths:
-            this.longDistancePairSolver?.getOutput().allTracesMerged!,
+          inputTracePaths: this.traceSegmentCombinerSolver!.getOutput().traces!,
           globalConnMap: this.mspConnectionPairSolver!.globalConnMap,
         },
       ],
@@ -163,9 +175,10 @@ export class SchematicTracePipelineSolver extends BaseSolver {
           inputTraceMap:
             this.traceOverlapShiftSolver?.correctedTraceMap ??
             Object.fromEntries(
-              this.longDistancePairSolver!.getOutput().allTracesMerged.map(
-                (p) => [p.mspPairId, p],
-              ),
+              this.traceSegmentCombinerSolver!.getOutput().traces.map((p) => [
+                p.mspPairId,
+                p,
+              ]),
             ),
         },
       ],
@@ -183,8 +196,8 @@ export class SchematicTracePipelineSolver extends BaseSolver {
           instance.traceOverlapShiftSolver?.correctedTraceMap ??
           Object.fromEntries(
             instance
-              .longDistancePairSolver!.getOutput()
-              .allTracesMerged.map((p) => [p.mspPairId, p]),
+              .traceSegmentCombinerSolver!.getOutput()
+              .traces.map((p: SolvedTracePath) => [p.mspPairId, p]),
           )
         const traces = Object.values(traceMap)
         const netLabelPlacements =
@@ -360,7 +373,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     }
 
     const constructorParams = pipelineStepDef.getConstructorParams(this)
-    // @ts-ignore
+    // @ts-expect-error
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
     ;(this as any)[pipelineStepDef.solverName] = this.activeSubSolver
     this.timeSpentOnPhase[pipelineStepDef.solverName] = 0

--- a/lib/solvers/TraceSegmentCombinerSolver/TraceSegmentCombinerSolver.ts
+++ b/lib/solvers/TraceSegmentCombinerSolver/TraceSegmentCombinerSolver.ts
@@ -1,0 +1,151 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { simplifyPath } from "../TraceCleanupSolver/simplifyPath"
+
+export interface TraceSegmentCombinerSolverParams {
+  inputProblem: InputProblem
+  allTraces: SolvedTracePath[]
+}
+
+export class TraceSegmentCombinerSolver extends BaseSolver {
+  inputProblem: InputProblem
+  allTraces: SolvedTracePath[]
+  outputTraces: SolvedTracePath[]
+
+  constructor(params: TraceSegmentCombinerSolverParams) {
+    super()
+    this.inputProblem = params.inputProblem
+    this.allTraces = params.allTraces
+    this.outputTraces = JSON.parse(JSON.stringify(params.allTraces))
+  }
+
+  override _step() {
+    this.combineSameNetTraces()
+    this.solved = true
+  }
+
+  private combineSameNetTraces() {
+    const EPS = 0.1001 // Distance threshold for "close together"
+    const netGroups: Record<string, SolvedTracePath[]> = {}
+
+    for (const trace of this.outputTraces) {
+      const netId = trace.globalConnNetId
+      if (!netGroups[netId]) netGroups[netId] = []
+      netGroups[netId].push(trace)
+    }
+
+    for (const netId in netGroups) {
+      const paths = netGroups[netId]!
+      if (paths.length < 2) continue
+
+      let changed = true
+      while (changed) {
+        changed = false
+        for (let i = 0; i < paths.length; i++) {
+          for (let j = 0; j < paths.length; j++) {
+            if (i === j) continue
+            if (this.tryCombinePaths(paths[i]!, paths[j]!, EPS)) {
+              changed = true
+            }
+          }
+        }
+      }
+    }
+
+    // Final simplification pass
+    for (const trace of this.outputTraces) {
+      trace.tracePath = simplifyPath(trace.tracePath)
+    }
+  }
+
+  private tryCombinePaths(
+    pathA: SolvedTracePath,
+    pathB: SolvedTracePath,
+    eps: number,
+  ): boolean {
+    let changed = false
+    const ptsA = pathA.tracePath
+    const ptsB = pathB.tracePath
+
+    for (let i = 0; i < ptsA.length - 1; i++) {
+      const a1 = ptsA[i]!
+      const a2 = ptsA[i + 1]!
+      const aVert = Math.abs(a1.x - a2.x) < 1e-6
+      const aHorz = Math.abs(a1.y - a2.y) < 1e-6
+      if (!aVert && !aHorz) continue
+
+      for (let j = 0; j < ptsB.length - 1; j++) {
+        const b1 = ptsB[j]!
+        const b2 = ptsB[j + 1]!
+        const bVert = Math.abs(b1.x - b2.x) < 1e-6
+        const bHorz = Math.abs(b1.y - b2.y) < 1e-6
+        if (!bVert && !bHorz) continue
+
+        if (aVert && bVert) {
+          // Both vertical, check if they are close in X and overlap in Y
+          const dx = Math.abs(a1.x - b1.x)
+          if (dx > 0 && dx < eps) {
+            if (this.segmentsOverlap1D(a1.y, a2.y, b1.y, b2.y)) {
+              // Snap B's segments to A's X
+              this.snapSegmentX(pathB, j, a1.x)
+              changed = true
+            }
+          }
+        } else if (aHorz && bHorz) {
+          // Both horizontal, check if they are close in Y and overlap in X
+          const dy = Math.abs(a1.y - b1.y)
+          if (dy > 0 && dy < eps) {
+            if (this.segmentsOverlap1D(a1.x, a2.x, b1.x, b2.x)) {
+              // Snap B's segments to A's Y
+              this.snapSegmentY(pathB, j, a1.y)
+              changed = true
+            }
+          }
+        }
+      }
+    }
+    return changed
+  }
+
+  private segmentsOverlap1D(
+    a1: number,
+    a2: number,
+    b1: number,
+    b2: number,
+  ): boolean {
+    const minA = Math.min(a1, a2)
+    const maxA = Math.max(a1, a2)
+    const minB = Math.min(b1, b2)
+    const maxB = Math.max(b1, b2)
+    return Math.max(minA, minB) < Math.min(maxA, maxB) - 1e-6
+  }
+
+  private snapSegmentX(path: SolvedTracePath, segIdx: number, newX: number) {
+    path.tracePath[segIdx]!.x = newX
+    path.tracePath[segIdx + 1]!.x = newX
+  }
+
+  private snapSegmentY(path: SolvedTracePath, segIdx: number, newY: number) {
+    path.tracePath[segIdx]!.y = newY
+    path.tracePath[segIdx + 1]!.y = newY
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  override visualize() {
+    const graphics = visualizeInputProblem(this.inputProblem)
+    for (const trace of this.outputTraces) {
+      graphics.lines!.push({
+        points: trace.tracePath,
+        strokeColor: "blue",
+      })
+    }
+    return graphics
+  }
+}

--- a/tests/examples/__snapshots__/example29.snap.svg
+++ b/tests/examples/__snapshots__/example29.snap.svg
@@ -489,188 +489,142 @@ x+" data-x="-8.4" data-y="-16.6" cx="198.31710258539454" cy="392.52251162760695"
 x+" data-x="-8.4" data-y="-17" cx="198.31710258539454" cy="399.68032912258366" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-6.262500000000001" data-y="0" cx="236.56668982417676" cy="95.47308558607014" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.262500000000001" data-y="0" cx="236.56668982417676" cy="95.47308558607014" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="0.2999999999999998" data-y="1.9000000000000015" cx="353.9996331011397" cy="61.47345248493036" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="0.2999999999999998" data-y="1.9000000000000015" cx="353.9996331011397" cy="61.47345248493036" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.9500000000000006" data-y="1.7000000000000017" cx="383.525630267919" cy="65.05236123241875" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.9500000000000006" data-y="1.7000000000000017" cx="383.525630267919" cy="65.05236123241875" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-5.750000000000001" data-y="-1.9999999999999998" cx="245.73764348961578" cy="131.26217306095407" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.2125" data-y="-1.9999999999999998" cx="237.46141701104887" cy="131.26217306095407" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-3" data-y="-4.225" cx="294.9476387675812" cy="171.07753287676246" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-3" data-y="-4.225" cx="294.9476387675812" cy="171.07753287676246" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="1.5000000000000013" cx="413.0516274346982" cy="68.63126997990716" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="1.5000000000000013" cx="413.0516274346982" cy="68.63126997990716" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-6.262500000000001" data-y="-4" cx="236.56668982417676" cy="167.05126053583803" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.262500000000001" data-y="-4" cx="236.56668982417676" cy="167.05126053583803" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-6.225" cx="277.0530950301392" cy="206.86662035164642" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4" data-y="-6.225" cx="277.0530950301392" cy="206.86662035164642" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="1.3000000000000014" cx="413.0516274346982" cy="72.21017872739554" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="1.3000000000000014" cx="413.0516274346982" cy="72.21017872739554" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-5.750000000000001" data-y="-6" cx="245.73764348961578" cy="202.84034801072198" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.112500000000001" data-y="-6" cx="239.25087138479304" cy="202.84034801072198" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-4.225" data-y="-8" cx="273.0268226892148" cy="238.62943548560594" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4.225" data-y="-8" cx="273.0268226892148" cy="238.62943548560594" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="1.1000000000000014" cx="413.0516274346982" cy="75.78908747488394" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="1.1000000000000014" cx="413.0516274346982" cy="75.78908747488394" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-6.262500000000001" data-y="-8" cx="236.56668982417676" cy="238.62943548560594" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.262500000000001" data-y="-8" cx="236.56668982417676" cy="238.62943548560594" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-10.225" cx="277.0530950301392" cy="278.44479530141433" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4" data-y="-10.225" cx="277.0530950301392" cy="278.44479530141433" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="0.7000000000000015" cx="413.0516274346982" cy="82.94690496986073" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="0.7000000000000015" cx="413.0516274346982" cy="82.94690496986073" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-5.750000000000001" data-y="-10" cx="245.73764348961578" cy="274.4185229604899" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-5.65" data-y="-10" cx="247.52709786335998" cy="274.4185229604899" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-11.775" cx="277.0530950301392" cy="306.1813380944494" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4" data-y="-11.775" cx="277.0530950301392" cy="306.1813380944494" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="0.5000000000000013" cx="413.0516274346982" cy="86.52581371734914" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="0.5000000000000013" cx="413.0516274346982" cy="86.52581371734914" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-6.112500000000001" data-y="-12" cx="239.25087138479304" cy="310.2076104353738" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.112500000000001" data-y="-12" cx="239.25087138479304" cy="310.2076104353738" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-14.225" cx="277.0530950301392" cy="350.0229702511822" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4" data-y="-14.225" cx="277.0530950301392" cy="350.0229702511822" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="0.30000000000000115" cx="413.0516274346982" cy="90.10472246483752" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="0.30000000000000115" cx="413.0516274346982" cy="90.10472246483752" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-6.162500000000001" data-y="-14" cx="238.35614419792094" cy="345.9966979102578" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.162500000000001" data-y="-14" cx="238.35614419792094" cy="345.9966979102578" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-4.225" data-y="-16" cx="273.0268226892148" cy="381.7857853851417" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4.225" data-y="-16" cx="273.0268226892148" cy="381.7857853851417" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="-0.0999999999999992" cx="413.0516274346982" cy="97.26253995981432" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="-0.0999999999999992" cx="413.0516274346982" cy="97.26253995981432" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-6.2125" data-y="-16" cx="237.46141701104887" cy="381.7857853851417" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.2125" data-y="-16" cx="237.46141701104887" cy="381.7857853851417" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-18.225" cx="277.0530950301392" cy="421.6011452009501" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4" data-y="-18.225" cx="277.0530950301392" cy="421.6011452009501" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="-0.2999999999999994" cx="413.0516274346982" cy="100.84144870730272" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="-0.2999999999999994" cx="413.0516274346982" cy="100.84144870730272" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-5.550000000000001" data-y="-18" cx="249.31655223710416" cy="417.5748728600257" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-5.550000000000001" data-y="-18" cx="249.31655223710416" cy="417.5748728600257" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-8.4" data-y="-10.4" cx="198.31710258539454" cy="281.5763404554667" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-8.4" data-y="-10.4" cx="198.31710258539454" cy="281.5763404554667" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-4.225" data-y="-20" cx="273.0268226892148" cy="453.3639603349096" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4.225" data-y="-20" cx="273.0268226892148" cy="453.3639603349096" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="-0.49999999999999956" cx="413.0516274346982" cy="104.42035745479112" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="-0.49999999999999956" cx="413.0516274346982" cy="104.42035745479112" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-5.550000000000001" data-y="-20" cx="249.31655223710416" cy="453.3639603349096" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-5.550000000000001" data-y="-20" cx="249.31655223710416" cy="453.3639603349096" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-8.4" data-y="-10.8" cx="198.31710258539454" cy="288.7341579504435" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-8.4" data-y="-10.8" cx="198.31710258539454" cy="288.7341579504435" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-22.225" cx="277.0530950301392" cy="493.179320150718" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4" data-y="-22.225" cx="277.0530950301392" cy="493.179320150718" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="-0.6999999999999997" cx="413.0516274346982" cy="107.99926620227951" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="-0.6999999999999997" cx="413.0516274346982" cy="107.99926620227951" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-6.262500000000001" data-y="-22" cx="236.56668982417676" cy="489.15304780979363" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-6.262500000000001" data-y="-22" cx="236.56668982417676" cy="489.15304780979363" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-4.225" data-y="-24" cx="273.0268226892148" cy="524.9421352846775" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4.225" data-y="-24" cx="273.0268226892148" cy="524.9421352846775" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="-0.8999999999999999" cx="413.0516274346982" cy="111.57817494976791" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="-0.8999999999999999" cx="413.0516274346982" cy="111.57817494976791" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-5.550000000000001" data-y="-24" cx="249.31655223710416" cy="524.9421352846775" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-5.550000000000001" data-y="-24" cx="249.31655223710416" cy="524.9421352846775" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-8.4" data-y="-15.4" cx="198.31710258539454" cy="371.0490591426766" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-8.4" data-y="-15.4" cx="198.31710258539454" cy="371.0490591426766" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-26.225" cx="277.0530950301392" cy="564.7574951004859" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-4" data-y="-26.225" cx="277.0530950301392" cy="564.7574951004859" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="3.5999999999999996" data-y="-1.0999999999999996" cx="413.0516274346982" cy="115.15708369725631" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.5999999999999996" data-y="-1.0999999999999996" cx="413.0516274346982" cy="115.15708369725631" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-5.550000000000001" data-y="-26" cx="249.31655223710416" cy="560.7312227595614" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-5.550000000000001" data-y="-26" cx="249.31655223710416" cy="560.7312227595614" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-8.4" data-y="-15.8" cx="198.31710258539454" cy="378.2068766376534" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-8.4" data-y="-15.8" cx="198.31710258539454" cy="378.2068766376534" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-5.550000000000001" data-y="-28" cx="249.31655223710416" cy="596.5203102344454" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-5.550000000000001" data-y="-28" cx="249.31655223710416" cy="596.5203102344454" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-8.4" data-y="-16.2" cx="198.31710258539454" cy="385.3646941326301" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-8.4" data-y="-16.2" cx="198.31710258539454" cy="385.3646941326301" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,0 -8.4,-3" data-type="line" data-label="" points="249.31655223710416,95.47308558607014 198.31710258539454,149.15671679839608" fill="none" stroke="hsl(32, 100%, 50%, 0.8)" stroke-width="1" />
@@ -859,7 +813,7 @@ orientation: x+" data-x="-8.4" data-y="-16.2" cx="198.31710258539454" cy="385.36
     <polyline data-points="3.6000000000000005,1.7000000000000017 0.3000000000000007,1.7000000000000017 0.3000000000000007,-1.7500000000000002 -3,-1.7500000000000002 -3,-1.55" data-type="line" data-label="" points="413.0516274346983,65.05236123241875 353.99963310113975,65.05236123241875 353.99963310113975,126.7885371265936 294.9476387675812,126.7885371265936 294.9476387675812,123.2096283791052" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-5.550000000000001,-1.9999999999999998 -5.750000000000001,-1.9999999999999998 -5.750000000000001,-3.4 -8.4,-3.4" data-type="line" data-label="" points="249.31655223710416,131.26217306095407 245.73764348961578,131.26217306095407 245.73764348961578,156.31453429337284 198.31710258539454,156.31453429337284" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-5.550000000000001,-1.9999999999999998 -6.875000000000001,-1.9999999999999998 -6.875000000000001,-3.4 -8.4,-3.4" data-type="line" data-label="" points="249.31655223710416,131.26217306095407 225.60628178499354,131.26217306095407 225.60628178499354,156.31453429337284 198.31710258539454,156.31453429337284" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-4.449999999999999,-4 -4,-4 -4,-3.55" data-type="line" data-label="" points="269.00055034829035,167.05126053583803 277.0530950301392,167.05126053583803 277.0530950301392,158.99871585398915" fill="none" stroke="purple" stroke-width="1" />
@@ -877,7 +831,7 @@ orientation: x+" data-x="-8.4" data-y="-16.2" cx="198.31710258539454" cy="385.36
     <polyline data-points="-4.449999999999999,-6 -4,-6 -4,-6.449999999999999" data-type="line" data-label="" points="269.00055034829035,202.84034801072198 277.0530950301392,202.84034801072198 277.0530950301392,210.89289269257085" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-5.550000000000001,-6 -5.750000000000001,-6 -5.750000000000001,-4.2 -8.4,-4.2" data-type="line" data-label="" points="249.31655223710416,202.84034801072198 245.73764348961578,202.84034801072198 245.73764348961578,170.63016928332644 198.31710258539454,170.63016928332644" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-5.550000000000001,-6 -6.675000000000001,-6 -6.675000000000001,-4.2 -8.4,-4.2" data-type="line" data-label="" points="249.31655223710416,202.84034801072198 229.18519053248195,202.84034801072198 229.18519053248195,170.63016928332644 198.31710258539454,170.63016928332644" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-4.449999999999999,-8 -4,-8 -4,-7.550000000000001" data-type="line" data-label="" points="269.00055034829035,238.62943548560594 277.0530950301392,238.62943548560594 277.0530950301392,230.57689080375707" fill="none" stroke="purple" stroke-width="1" />
@@ -895,7 +849,7 @@ orientation: x+" data-x="-8.4" data-y="-16.2" cx="198.31710258539454" cy="385.36
     <polyline data-points="-4.449999999999999,-10 -4,-10 -4,-10.45" data-type="line" data-label="" points="269.00055034829035,274.4185229604899 277.0530950301392,274.4185229604899 277.0530950301392,282.47106764233877" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-5.550000000000001,-10 -5.750000000000001,-10 -5.750000000000001,-9 -8.200000000000001,-9 -8.200000000000001,-5 -8.4,-5" data-type="line" data-label="" points="249.31655223710416,274.4185229604899 245.73764348961578,274.4185229604899 245.73764348961578,256.52397922304795 201.89601133288292,256.52397922304795 201.89601133288292,184.94580427328003 198.31710258539454,184.94580427328003" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-5.550000000000001,-10 -5.65,-10 -5.65,-9 -7.075,-9 -7.075,-5 -8.4,-5" data-type="line" data-label="" points="249.31655223710416,274.4185229604899 247.52709786335998,274.4185229604899 247.52709786335998,256.52397922304795 222.02737303750516,256.52397922304795 222.02737303750516,184.94580427328003 198.31710258539454,184.94580427328003" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-4,-11.55 -4,-12 -3,-12 -3,-12.45" data-type="line" data-label="" points="277.0530950301392,302.1550657535249 277.0530950301392,310.2076104353738 294.9476387675812,310.2076104353738 294.9476387675812,318.2601551172227" fill="none" stroke="purple" stroke-width="1" />
@@ -1070,7 +1024,7 @@ globalConnNetId: connectivity_net2" data-x="1.9500000000000006" data-y="1.475000
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R3 &gt; .pin1 to J1.pin2
-globalConnNetId: connectivity_net3" data-x="-5.750000000000001" data-y="-1.7749999999999997" x="243.94818911587157" y="123.2096283791052" width="3.5789087474883843" height="8.052544681848872" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net3" data-x="-6.2125" data-y="-1.7749999999999997" x="235.67196263730466" y="123.2096283791052" width="3.5789087474883843" height="8.052544681848872" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R4 &gt; .pin2 to C6.pin1
@@ -1094,7 +1048,7 @@ globalConnNetId: connectivity_net6" data-x="3.3739999999999997" data-y="1.300000
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R7 &gt; .pin1 to J1.pin4
-globalConnNetId: connectivity_net7" data-x="-5.750000000000001" data-y="-6.225" x="243.94818911587157" y="202.84034801072198" width="3.5789087474883843" height="8.052544681848872" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net7" data-x="-6.112500000000001" data-y="-5.775" x="237.46141701104887" y="194.7878033288731" width="3.578908747488356" height="8.052544681848872" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R8 &gt; .pin2 to C8.pin1
@@ -1118,7 +1072,7 @@ globalConnNetId: connectivity_net10" data-x="3.3739999999999997" data-y="0.70000
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R11 &gt; .pin1 to J1.pin6
-globalConnNetId: connectivity_net11" data-x="-5.750000000000001" data-y="-10.225" x="243.94818911587157" y="274.4185229604899" width="3.5789087474883843" height="8.052544681848872" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net11" data-x="-5.875" data-y="-10" x="239.4745531815111" y="272.6290685867457" width="8.052544681848872" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C9 &gt; .pin2 to C10.pin1

--- a/tests/solvers/trace-segment-combiner-solver.test.ts
+++ b/tests/solvers/trace-segment-combiner-solver.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { TraceSegmentCombinerSolver } from "lib/solvers/TraceSegmentCombinerSolver/TraceSegmentCombinerSolver"
+
+test("TraceSegmentCombinerSolver - combines parallel close segments", () => {
+  const allTraces: SolvedTracePath[] = [
+    {
+      mspPairId: "trace1",
+      globalConnNetId: "NET1",
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      pins: [] as any,
+      dcConnNetId: "NET1",
+      mspConnectionPairIds: ["trace1"],
+      pinIds: ["P1", "P3"],
+    },
+    {
+      mspPairId: "trace2",
+      globalConnNetId: "NET1",
+      tracePath: [
+        { x: 0, y: 0.05 },
+        { x: 10, y: 0.05 },
+      ],
+      pins: [] as any,
+      dcConnNetId: "NET1",
+      mspConnectionPairIds: ["trace2"],
+      pinIds: ["P2", "P4"],
+    },
+  ]
+
+  const solver = new TraceSegmentCombinerSolver({
+    inputProblem: {
+      chips: [],
+      directConnections: [],
+      netConnections: [],
+      availableNetLabelOrientations: {},
+    },
+    allTraces,
+  })
+
+  solver.step()
+  const output = solver.getOutput().traces
+
+  expect(output[1].tracePath[0].y).toBe(0)
+  expect(output[1].tracePath[1].y).toBe(0)
+})
+
+test("TraceSegmentCombinerSolver - does not combine different nets", () => {
+  const allTraces: SolvedTracePath[] = [
+    {
+      mspPairId: "trace1",
+      globalConnNetId: "NET1",
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      pins: [] as any,
+      dcConnNetId: "NET1",
+      mspConnectionPairIds: ["trace1"],
+      pinIds: ["P1", "P3"],
+    },
+    {
+      mspPairId: "trace2",
+      globalConnNetId: "NET2",
+      tracePath: [
+        { x: 0, y: 0.05 },
+        { x: 10, y: 0.05 },
+      ],
+      pins: [] as any,
+      dcConnNetId: "NET2",
+      mspConnectionPairIds: ["trace2"],
+      pinIds: ["P2", "P4"],
+    },
+  ]
+
+  const solver = new TraceSegmentCombinerSolver({
+    inputProblem: {
+      chips: [],
+      directConnections: [],
+      netConnections: [],
+      availableNetLabelOrientations: {},
+    },
+    allTraces,
+  })
+
+  solver.step()
+  const output = solver.getOutput().traces
+
+  expect(output[1].tracePath[0].y).toBe(0.05)
+})


### PR DESCRIPTION
This PR implements a new pipeline phase, `TraceSegmentCombinerSolver`, that identifies and combines parallel trace segments belonging to the same net that are close to each other (within 0.1 units). This simplifies the final schematic by reducing redundant parallel traces.

Resolves #29