### PR TITLE
Add same-net trace segment combine phase

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -2,6 +2,7 @@ import type { InputProblem } from "lib/types/InputProblem"
 import type { GraphicsObject, Line } from "graphics-debug"
 import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
 import { balanceZShapes } from "./balanceZShapes"
+import { combineSameNetTraceSegments } from "./combineSameNetTraceSegments"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
@@ -25,6 +26,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
  * Represents the different stages or steps within the trace cleanup pipeline.
  */
 type PipelineStep =
+  | "combining_same_net_segments"
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
@@ -33,8 +35,9 @@ type PipelineStep =
  * The TraceCleanupSolver is responsible for improving the aesthetics and readability of schematic traces.
  * It operates in a multi-step pipeline:
  * 1. **Untangling Traces**: It first attempts to untangle any overlapping or highly convoluted traces using a sub-solver.
- * 2. **Minimizing Turns**: After untangling, it iterates through each trace to minimize the number of turns, simplifying their paths.
- * 3. **Balancing L-Shapes**: Finally, it balances L-shaped trace segments to create more visually appealing and consistent layouts.
+ * 2. **Combining Same-Net Segments**: Close overlapping same-net segments are snapped together to avoid duplicate traces.
+ * 3. **Minimizing Turns**: After untangling, it iterates through each trace to minimize the number of turns, simplifying their paths.
+ * 4. **Balancing L-Shapes**: Finally, it balances L-shaped trace segments to create more visually appealing and consistent layouts.
  * The solver processes traces one by one, applying these cleanup steps sequentially to refine the overall trace layout.
  */
 export class TraceCleanupSolver extends BaseSolver {
@@ -66,10 +69,10 @@ export class TraceCleanupSolver extends BaseSolver {
         this.outputTraces = output.traces
         this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "combining_same_net_segments"
       } else if (this.activeSubSolver.failed) {
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "combining_same_net_segments"
       }
       return
     }
@@ -77,6 +80,9 @@ export class TraceCleanupSolver extends BaseSolver {
     switch (this.pipelineStep) {
       case "untangling_traces":
         this._runUntangleTracesStep()
+        break
+      case "combining_same_net_segments":
+        this._runCombineSameNetSegmentsStep()
         break
       case "minimizing_turns":
         this._runMinimizeTurnsStep()
@@ -92,6 +98,16 @@ export class TraceCleanupSolver extends BaseSolver {
       ...this.input,
       allTraces: Array.from(this.tracesMap.values()),
     })
+  }
+
+  private _runCombineSameNetSegmentsStep() {
+    this.outputTraces = combineSameNetTraceSegments({
+      traces: Array.from(this.tracesMap.values()),
+      maxDistance: this.input.paddingBuffer * 2,
+    })
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.traceIdQueue = Array.from(this.outputTraces.map((e) => e.mspPairId))
+    this.pipelineStep = "minimizing_turns"
   }
 
   private _runMinimizeTurnsStep() {

--- a/lib/solvers/TraceCleanupSolver/combineSameNetTraceSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/combineSameNetTraceSegments.ts
@@ -1,0 +1,175 @@
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+type SegmentOrientation = "horizontal" | "vertical"
+
+interface SegmentLocator {
+  traceIndex: number
+  segmentIndex: number
+  orientation: SegmentOrientation
+  fixedCoord: number
+  spanMin: number
+  spanMax: number
+  length: number
+  isAnchored: boolean
+}
+
+const EPS = 1e-9
+
+const cloneTrace = (trace: SolvedTracePath): SolvedTracePath => ({
+  ...trace,
+  tracePath: trace.tracePath.map((point) => ({ ...point })),
+})
+
+const getTraceNetId = (trace: SolvedTracePath) =>
+  trace.globalConnNetId ?? trace.userNetId ?? trace.dcConnNetId
+
+const getSegments = (
+  trace: SolvedTracePath,
+  traceIndex: number,
+): SegmentLocator[] => {
+  const segments: SegmentLocator[] = []
+  const { tracePath } = trace
+
+  for (
+    let segmentIndex = 0;
+    segmentIndex < tracePath.length - 1;
+    segmentIndex++
+  ) {
+    const start = tracePath[segmentIndex]!
+    const end = tracePath[segmentIndex + 1]!
+    const isHorizontal = Math.abs(start.y - end.y) < EPS
+    const isVertical = Math.abs(start.x - end.x) < EPS
+
+    if (!isHorizontal && !isVertical) continue
+
+    const orientation = isHorizontal ? "horizontal" : "vertical"
+    const fixedCoord = isHorizontal ? start.y : start.x
+    const spanStart = isHorizontal ? start.x : start.y
+    const spanEnd = isHorizontal ? end.x : end.y
+    const spanMin = Math.min(spanStart, spanEnd)
+    const spanMax = Math.max(spanStart, spanEnd)
+    const length = spanMax - spanMin
+
+    if (length < EPS) continue
+
+    segments.push({
+      traceIndex,
+      segmentIndex,
+      orientation,
+      fixedCoord,
+      spanMin,
+      spanMax,
+      length,
+      isAnchored:
+        segmentIndex === 0 || segmentIndex + 1 === tracePath.length - 1,
+    })
+  }
+
+  return segments
+}
+
+const getSpanOverlap = (a: SegmentLocator, b: SegmentLocator) =>
+  Math.min(a.spanMax, b.spanMax) - Math.max(a.spanMin, b.spanMin)
+
+const chooseMove = (
+  a: SegmentLocator,
+  b: SegmentLocator,
+): { movable: SegmentLocator; target: SegmentLocator } | null => {
+  if (a.isAnchored && b.isAnchored) return null
+  if (a.isAnchored) return { movable: b, target: a }
+  if (b.isAnchored) return { movable: a, target: b }
+
+  if (a.length >= b.length) {
+    return { movable: b, target: a }
+  }
+
+  return { movable: a, target: b }
+}
+
+const moveSegmentToCoord = (
+  trace: SolvedTracePath,
+  segment: SegmentLocator,
+  targetCoord: number,
+) => {
+  const path = trace.tracePath
+  const start = path[segment.segmentIndex]!
+  const end = path[segment.segmentIndex + 1]!
+
+  if (segment.orientation === "horizontal") {
+    start.y = targetCoord
+    end.y = targetCoord
+  } else {
+    start.x = targetCoord
+    end.x = targetCoord
+  }
+
+  trace.tracePath = simplifyPath(path)
+}
+
+export const combineSameNetTraceSegments = ({
+  traces,
+  maxDistance,
+}: {
+  traces: SolvedTracePath[]
+  maxDistance: number
+}): SolvedTracePath[] => {
+  if (traces.length === 0 || maxDistance <= EPS) return traces
+
+  const nextTraces = traces.map(cloneTrace)
+  const maxPasses = Math.max(20, nextTraces.length * 20)
+
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let changed = false
+    const traceIndexesByNet = new Map<string, number[]>()
+
+    for (let traceIndex = 0; traceIndex < nextTraces.length; traceIndex++) {
+      const trace = nextTraces[traceIndex]!
+      const netId = getTraceNetId(trace)
+      if (!netId) continue
+      if (!traceIndexesByNet.has(netId)) traceIndexesByNet.set(netId, [])
+      traceIndexesByNet.get(netId)!.push(traceIndex)
+    }
+
+    for (const traceIndexes of traceIndexesByNet.values()) {
+      const segments = traceIndexes.flatMap((traceIndex) =>
+        getSegments(nextTraces[traceIndex]!, traceIndex),
+      )
+
+      for (let i = 0; i < segments.length; i++) {
+        const a = segments[i]!
+
+        for (let j = i + 1; j < segments.length; j++) {
+          const b = segments[j]!
+          if (a.orientation !== b.orientation) continue
+          if (Math.abs(a.fixedCoord - b.fixedCoord) > maxDistance) continue
+          if (getSpanOverlap(a, b) <= EPS) continue
+
+          const move = chooseMove(a, b)
+          if (!move) continue
+          if (
+            Math.abs(move.movable.fixedCoord - move.target.fixedCoord) <= EPS
+          ) {
+            continue
+          }
+
+          moveSegmentToCoord(
+            nextTraces[move.movable.traceIndex]!,
+            move.movable,
+            move.target.fixedCoord,
+          )
+          changed = true
+          break
+        }
+
+        if (changed) break
+      }
+
+      if (changed) break
+    }
+
+    if (!changed) break
+  }
+
+  return nextTraces
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-cosmos-plugin-vite": "^7.0.0",
     "react-dom": "^19.1.1",
     "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
     "vite": "^7.1.3"
   },
   "peerDependencies": {

--- a/tests/examples/__snapshots__/example06.snap.svg
+++ b/tests/examples/__snapshots__/example06.snap.svg
@@ -2,39 +2,38 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="R1.1
-x-" data-x="-3.5512907000000005" data-y="0.0002732499999993365" cx="62.695035460992926" cy="318.8552397163121" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+x-" data-x="-3.5512907000000005" data-y="0.0002732499999993365" cx="40" cy="321.17156888419566" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R1.2
-x+" data-x="-2.4487092999999995" data-y="-0.0002732499999993365" cx="146.10544869976368" cy="318.89658250591015" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+x+" data-x="-2.4487092999999995" data-y="-0.0002732499999993365" cx="126.93355635339674" cy="321.21465793734586" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C1.1
-x-" data-x="2.4487906999999995" data-y="-0.00027334999999961695" cx="516.6019026004727" cy="318.89659007092195" r="3" fill="hsl(121, 100%, 50%, 0.8)" />
+x-" data-x="2.4487906999999995" data-y="-0.00027334999999961695" cx="513.0792796902498" cy="321.21466582189356" r="3" fill="hsl(121, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C1.2
-x+" data-x="3.5512093000000005" data-y="0.00027334999999961695" cx="600" cy="318.8552321513003" r="3" fill="hsl(122, 100%, 50%, 0.8)" />
+x+" data-x="3.5512093000000005" data-y="0.00027334999999961695" cx="600" cy="321.17156099964797" r="3" fill="hsl(122, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-3.7512907000000006" data-y="0.0002732499999993365" cx="47.565011820330994" cy="318.8552397163121" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-0.6512500000000006" data-y="0.0002732499999993365" cx="268.6550921506511" cy="321.17156888419566" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="-3.5512907000000005,0.0002732499999993365 2.4487906999999995,-0.00027334999999961695" data-type="line" data-label="" points="62.695035460992926,318.8552397163121 516.6019026004727,318.89659007092195" fill="none" stroke="hsl(72, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="-3.5512907000000005,0.0002732499999993365 2.4487906999999995,-0.00027334999999961695" data-type="line" data-label="" points="40,321.17156888419566 513.0792796902498,321.21466582189356" fill="none" stroke="hsl(72, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-3.5512907000000005,0.0002732499999993365 -3.7512907000000006,0.0002732499999993365 -3.7512907000000006,0.20027324999999935 2.2487906999999994,0.20027324999999935 2.2487906999999994,-0.00027334999999961695 2.4487906999999987,-0.00027334999999961695" data-type="line" data-label="" points="62.695035460992926,318.8552397163121 47.565011820330994,318.8552397163121 47.565011820330994,303.72521607565017 501.4718789598108,303.72521607565017 501.4718789598108,318.89659007092195 516.6019026004726,318.89659007092195" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3.5512907000000005,0.0002732499999993365 2.2487906999999994,0.0002732499999993365 2.2487906999999994,-0.00027334999999961695 2.4487906999999987,-0.00027334999999961695" data-type="line" data-label="" points="40,321.17156888419566 497.31018430130223,321.17156888419566 497.31018430130223,321.21466582189356 513.0792796902498,321.21466582189356" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="-3" data-y="0" x="62.695035460992926" y="304.1653408983452" width="83.41041323877076" height="29.421140425531803" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.013218750000000003" />
+    <rect data-type="rect" data-label="schematic_component_0" data-x="-3" data-y="0" x="40" y="305.8611885955649" width="86.93355635339674" height="30.663849630411733" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012683035714285716" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="3" data-y="0" x="516.6019026004727" y="287.10220709219846" width="83.39809739952727" height="63.547408037825335" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.013218750000000003" />
+    <rect data-type="rect" data-label="schematic_component_1" data-x="3" data-y="0" x="513.0792796902498" y="288.07733108060523" width="86.92072030975021" height="66.23156466033106" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.012683035714285716" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R1 &gt; .pin1 to .C1 &gt; .pin1
-globalConnNetId: connectivity_net0" data-x="-3.7512907000000006" data-y="-0.22472675000000067" x="40" y="318.8552397163121" width="15.130023640661989" height="34.04255319148939" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.013218750000000003" />
+globalConnNetId: connectivity_net0" data-x="-0.6512500000000006" data-y="0.22527324999999934" x="260.77054445617733" y="285.69110425906365" width="15.769095388947562" height="35.480464625132015" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.012683035714285716" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -64,12 +63,12 @@ globalConnNetId: connectivity_net0" data-x="-3.7512907000000006" data-y="-0.2247
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 75.65011820330967,
+        "a": 78.84547694473775,
         "c": 0,
-        "e": 331.3505966903073,
+        "e": 320.00320901091163,
         "b": 0,
-        "d": -75.65011820330967,
-        "f": 318.8759111111111
+        "d": -78.84547694473775,
+        "f": 321.19311341077076
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example18.snap.svg
+++ b/tests/examples/__snapshots__/example18.snap.svg
@@ -2,193 +2,183 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="U3.8
-x-" data-x="-1.4" data-y="0.42500000000000004" cx="211.29957848579102" cy="266.28437168733643" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
+x-" data-x="-1.4" data-y="0.42500000000000004" cx="198.69418654530432" cy="227.58519984468603" r="3" fill="hsl(88, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U3.4
-x-" data-x="-1.4" data-y="-0.42500000000000004" cx="211.29957848579102" cy="342.38151179694313" r="3" fill="hsl(84, 100%, 50%, 0.8)" />
+x-" data-x="-1.4" data-y="-0.42500000000000004" cx="198.69418654530432" cy="312.5069080955151" r="3" fill="hsl(84, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U3.1
-x+" data-x="1.4" data-y="0.5" cx="461.9725106115543" cy="259.56991814825346" r="3" fill="hsl(81, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="0.5" cx="478.4362843127411" cy="220.09210794020112" r="3" fill="hsl(81, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U3.6
-x+" data-x="1.4" data-y="0.30000000000000004" cx="461.9725106115543" cy="277.47512758580797" r="3" fill="hsl(86, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="0.30000000000000004" cx="478.4362843127411" cy="240.0736863521609" r="3" fill="hsl(86, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U3.5
-x+" data-x="1.4" data-y="0.10000000000000009" cx="461.9725106115543" cy="295.38033702336253" r="3" fill="hsl(85, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="0.10000000000000009" cx="478.4362843127411" cy="260.05526476412064" r="3" fill="hsl(85, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U3.2
-x+" data-x="1.4" data-y="-0.09999999999999998" cx="461.9725106115543" cy="313.28554646091703" r="3" fill="hsl(82, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="-0.09999999999999998" cx="478.4362843127411" cy="280.0368431760804" r="3" fill="hsl(82, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U3.3
-x+" data-x="1.4" data-y="-0.3" cx="461.9725106115543" cy="331.1907558984716" r="3" fill="hsl(83, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="-0.3" cx="478.4362843127411" cy="300.0184215880402" r="3" fill="hsl(83, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U3.7
-x+" data-x="1.4" data-y="-0.5" cx="461.9725106115543" cy="349.0959653360261" r="3" fill="hsl(87, 100%, 50%, 0.8)" />
+x+" data-x="1.4" data-y="-0.5" cx="478.4362843127411" cy="320" r="3" fill="hsl(87, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C20.1
-y+" data-x="-2.3148566499999994" data-y="0.5512093000000002" cx="129.39607886784347" cy="254.98535194000064" r="3" fill="hsl(140, 100%, 50%, 0.8)" />
+y+" data-x="-2.3148566499999994" data-y="0.5512093000000002" cx="107.29278710691517" cy="214.97589472334323" r="3" fill="hsl(140, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C20.2
-y-" data-x="-2.31430995" data-y="-0.5512093000000002" cx="129.44502275784095" cy="353.6805315442789" r="3" fill="hsl(141, 100%, 50%, 0.8)" />
+y-" data-x="-2.31430995" data-y="-0.5512093000000002" cx="107.3474067515042" cy="325.1162132168579" r="3" fill="hsl(141, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R11.1
-y+" data-x="1.7580660749999977" data-y="2.3025814000000002" cx="494.0287509383446" cy="98.19193067205222" r="3" fill="hsl(125, 100%, 50%, 0.8)" />
+y+" data-x="1.7580660749999977" data-y="2.3025814000000002" cx="514.2099110841168" cy="39.99999999999997" r="3" fill="hsl(125, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R11.2
-y-" data-x="1.757519574999999" data-y="1.2" cx="493.97982495355666" cy="196.90168511681264" r="3" fill="hsl(126, 100%, 50%, 0.8)" />
+y-" data-x="1.757519574999999" data-y="1.2" cx="514.1553114211063" cy="150.15658349834192" r="3" fill="hsl(126, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R12.1
-y-" data-x="-1.7580660749999977" data-y="-3.3025814000000002" cx="179.24333815900067" cy="600" r="3" fill="hsl(6, 100%, 50%, 0.8)" />
+y-" data-x="-1.7580660749999977" data-y="-3.3025814000000002" cx="162.9205597739287" cy="600" r="3" fill="hsl(6, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R12.2
-y+" data-x="-1.757519574999999" data-y="-2.2" cx="179.29226414378866" cy="501.29024555523955" r="3" fill="hsl(7, 100%, 50%, 0.8)" />
+y+" data-x="-1.757519574999999" data-y="-2.2" cx="162.97515943693924" cy="489.8434165016581" r="3" fill="hsl(7, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R13.1
-y-" data-x="1.7580660749999977" data-y="-3.3025814000000002" cx="494.0287509383446" cy="600" r="3" fill="hsl(247, 100%, 50%, 0.8)" />
+y-" data-x="1.7580660749999977" data-y="-3.3025814000000002" cx="514.2099110841168" cy="600" r="3" fill="hsl(247, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R13.2
-y+" data-x="1.757519574999999" data-y="-2.2" cx="493.97982495355666" cy="501.29024555523955" r="3" fill="hsl(248, 100%, 50%, 0.8)" />
+y+" data-x="1.757519574999999" data-y="-2.2" cx="514.1553114211063" cy="489.8434165016581" r="3" fill="hsl(248, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-1.8574283249999997" data-y="0.7512093000000004" cx="170.34782867681724" cy="237.0801425024461" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.8574283249999997" data-y="0.7512093000000004" cx="152.99348682610974" cy="194.99431631138344" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="1.5790330374999988" data-y="2.5025814000000004" cx="478.0006307749495" cy="80.28672123449769" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.5790330374999988" data-y="-0.3" cx="496.3230976984289" cy="300.0184215880402" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-2.31430995" data-y="-0.7512093000000004" cx="129.44502275784095" cy="371.58574098183345" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-2.31430995" data-y="-0.7512093000000004" cx="107.3474067515042" cy="345.0977916288177" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="1.757519574999999" data-y="0.85" cx="493.97982495355666" cy="228.23580163253305" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.757519574999999" data-y="0.85" cx="514.1553114211063" cy="185.1243457192715" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="1.757519574999999" data-y="-2" cx="493.97982495355666" cy="483.385036117685" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.757519574999999" data-y="-2" cx="514.1553114211063" cy="469.86183808969827" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="-2.3148566499999994,0.5512093000000002 -1.4,0.42500000000000004" data-type="line" data-label="" points="129.39607886784347,254.98535194000064 211.29957848579102,266.28437168733643" fill="none" stroke="hsl(256, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="-2.3148566499999994,0.5512093000000002 -1.4,0.42500000000000004" data-type="line" data-label="" points="107.29278710691517,214.97589472334323 198.69418654530432,227.58519984468603" fill="none" stroke="hsl(256, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-2.31430995,-0.5512093000000002 -1.4,-0.42500000000000004" data-type="line" data-label="" points="129.44502275784095,353.6805315442789 211.29957848579102,342.38151179694313" fill="none" stroke="hsl(256, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="-2.31430995,-0.5512093000000002 -1.4,-0.42500000000000004" data-type="line" data-label="" points="107.3474067515042,325.1162132168579 198.69418654530432,312.5069080955151" fill="none" stroke="hsl(256, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.757519574999999,1.2 1.4,0.5" data-type="line" data-label="" points="493.97982495355666,196.90168511681264 461.9725106115543,259.56991814825346" fill="none" stroke="hsl(144, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="1.757519574999999,1.2 1.4,0.5" data-type="line" data-label="" points="514.1553114211063,150.15658349834192 478.4362843127411,220.09210794020112" fill="none" stroke="hsl(144, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.757519574999999,-2.2 -1.757519574999999,-2.2" data-type="line" data-label="" points="493.97982495355666,501.29024555523955 179.29226414378866,501.29024555523955" fill="none" stroke="hsl(144, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="1.757519574999999,-2.2 -1.757519574999999,-2.2" data-type="line" data-label="" points="514.1553114211063,489.8434165016581 162.97515943693924,489.8434165016581" fill="none" stroke="hsl(144, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.42500000000000004 1.4,-0.3" data-type="line" data-label="" points="211.29957848579102,266.28437168733643 461.9725106115543,331.1907558984716" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.42500000000000004 1.4,-0.3" data-type="line" data-label="" points="198.69418654530432,227.58519984468603 478.4362843127411,300.0184215880402" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.42500000000000004 1.4,-0.5" data-type="line" data-label="" points="211.29957848579102,266.28437168733643 461.9725106115543,349.0959653360261" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.42500000000000004 1.4,-0.5" data-type="line" data-label="" points="198.69418654530432,227.58519984468603 478.4362843127411,320" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.42500000000000004 -2.3148566499999994,0.5512093000000002" data-type="line" data-label="" points="211.29957848579102,266.28437168733643 129.39607886784347,254.98535194000064" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.42500000000000004 -2.3148566499999994,0.5512093000000002" data-type="line" data-label="" points="198.69418654530432,227.58519984468603 107.29278710691517,214.97589472334323" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.42500000000000004 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="211.29957848579102,266.28437168733643 494.0287509383446,98.19193067205222" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,0.42500000000000004 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="198.69418654530432,227.58519984468603 514.2099110841168,39.99999999999997" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.3 1.4,-0.5" data-type="line" data-label="" points="461.9725106115543,331.1907558984716 461.9725106115543,349.0959653360261" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.3 1.4,-0.5" data-type="line" data-label="" points="478.4362843127411,300.0184215880402 478.4362843127411,320" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.3 -2.3148566499999994,0.5512093000000002" data-type="line" data-label="" points="461.9725106115543,331.1907558984716 129.39607886784347,254.98535194000064" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.3 -2.3148566499999994,0.5512093000000002" data-type="line" data-label="" points="478.4362843127411,300.0184215880402 107.29278710691517,214.97589472334323" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.3 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="461.9725106115543,331.1907558984716 494.0287509383446,98.19193067205222" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.3 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="478.4362843127411,300.0184215880402 514.2099110841168,39.99999999999997" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.5 -2.3148566499999994,0.5512093000000002" data-type="line" data-label="" points="461.9725106115543,349.0959653360261 129.39607886784347,254.98535194000064" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.5 -2.3148566499999994,0.5512093000000002" data-type="line" data-label="" points="478.4362843127411,320 107.29278710691517,214.97589472334323" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.5 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="461.9725106115543,349.0959653360261 494.0287509383446,98.19193067205222" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,-0.5 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="478.4362843127411,320 514.2099110841168,39.99999999999997" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-2.3148566499999994,0.5512093000000002 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="129.39607886784347,254.98535194000064 494.0287509383446,98.19193067205222" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-2.3148566499999994,0.5512093000000002 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="107.29278710691517,214.97589472334323 514.2099110841168,39.99999999999997" fill="none" stroke="hsl(73, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,-0.42500000000000004 -2.31430995,-0.5512093000000002" data-type="line" data-label="" points="211.29957848579102,342.38151179694313 129.44502275784095,353.6805315442789" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.4,-0.42500000000000004 -2.31430995,-0.5512093000000002" data-type="line" data-label="" points="198.69418654530432,312.5069080955151 107.3474067515042,325.1162132168579" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.4,0.5 1.757519574999999,1.2" data-type="line" data-label="" points="461.9725106115543,259.56991814825346 493.97982495355666,196.90168511681264" fill="none" stroke="hsl(304, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.4,0.5 1.757519574999999,1.2" data-type="line" data-label="" points="478.4362843127411,220.09210794020112 514.1553114211063,150.15658349834192" fill="none" stroke="hsl(304, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.4,0.42500000000000004 -1.8574283249999997,0.42500000000000004 -1.8574283249999997,0.7512093000000004 -2.3148566499999994,0.7512093000000004 -2.3148566499999994,0.5512093000000002" data-type="line" data-label="" points="211.29957848579102,266.28437168733643 170.34782867681724,266.28437168733643 170.34782867681724,237.0801425024461 129.39607886784347,237.0801425024461 129.39607886784347,254.98535194000064" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-1.4,0.42500000000000004 -1.8574283249999997,0.42500000000000004 -1.8574283249999997,0.7512093000000004 -2.3148566499999994,0.7512093000000004 -2.3148566499999994,0.5512093000000002" data-type="line" data-label="" points="198.69418654530432,227.58519984468603 152.99348682610974,227.58519984468603 152.99348682610974,194.99431631138344 107.29278710691517,194.99431631138344 107.29278710691517,214.97589472334323" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.3 1.5790330374999988,-0.3 1.5790330374999988,2.5025814000000004 1.7580660749999977,2.5025814000000004 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="461.9725106115543,331.1907558984716 478.0006307749495,331.1907558984716 478.0006307749495,80.28672123449769 494.0287509383446,80.28672123449769 494.0287509383446,98.19193067205222" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.4,-0.3 1.7580660749999977,-0.3 1.7580660749999977,2.3025814000000002" data-type="line" data-label="" points="478.4362843127411,300.0184215880402 514.2099110841168,300.0184215880402 514.2099110841168,39.99999999999997" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.4,-0.5 1.5999999999999999,-0.5 1.5999999999999999,-0.3 1.4,-0.3" data-type="line" data-label="" points="461.9725106115543,349.0959653360261 479.8777200491088,349.0959653360261 479.8777200491088,331.1907558984716 461.9725106115543,331.1907558984716" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.4,-0.5 1.5999999999999999,-0.5 1.5999999999999999,-0.3 1.4,-0.3" data-type="line" data-label="" points="478.4362843127411,320 498.4178627247009,320 498.4178627247009,300.0184215880402 478.4362843127411,300.0184215880402" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-2.31430995,-0.5512093000000002 -2.31430995,-0.7512093000000004 -1.857154975,-0.7512093000000004 -1.857154975,-0.42500000000000004 -1.4,-0.42500000000000004" data-type="line" data-label="" points="129.44502275784095,353.6805315442789 129.44502275784095,371.58574098183345 170.37230062181598,371.58574098183345 170.37230062181598,342.38151179694313 211.29957848579102,342.38151179694313" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-2.31430995,-0.5512093000000002 -2.31430995,-0.7512093000000004 -1.857154975,-0.7512093000000004 -1.857154975,-0.42500000000000004 -1.4,-0.42500000000000004" data-type="line" data-label="" points="107.3474067515042,325.1162132168579 107.3474067515042,345.0977916288177 153.02079664840426,345.0977916288177 153.02079664840426,312.5069080955151 198.69418654530432,312.5069080955151" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.757519574999999,1.2 1.757519574999999,0.5 1.4,0.5" data-type="line" data-label="" points="493.97982495355666,196.90168511681264 493.97982495355666,259.56991814825346 461.9725106115543,259.56991814825346" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.757519574999999,1.2 1.757519574999999,0.5 1.4,0.5" data-type="line" data-label="" points="514.1553114211063,150.15658349834192 514.1553114211063,220.09210794020112 478.4362843127411,220.09210794020112" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.757519574999999,-2.2 1.757519574999999,-2 -1.757519574999999,-2 -1.757519574999999,-2.2" data-type="line" data-label="" points="493.97982495355666,501.29024555523955 493.97982495355666,483.385036117685 179.29226414378866,483.385036117685 179.29226414378866,501.29024555523955" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.757519574999999,-2.2 1.757519574999999,-2 -1.757519574999999,-2 -1.757519574999999,-2.2" data-type="line" data-label="" points="514.1553114211063,489.8434165016581 514.1553114211063,469.86183808969827 162.97515943693924,469.86183808969827 162.97515943693924,489.8434165016581" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="211.29957848579102" y="241.66470871069896" width="250.67293212576328" height="125.33646606288164" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.011169933571428573" />
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="198.69418654530432" y="200.11052952824136" width="279.7420977674368" height="139.87104888371837" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.010009219285714285" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="-2.3145833" data-y="0" x="105.73345381194562" y="254.98535194000064" width="47.37419400179317" height="98.69517960427825" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.011169933571428573" />
+    <rect data-type="rect" data-label="schematic_component_1" data-x="-2.3145833" data-y="0" x="80.88613715198431" y="214.97589472334323" width="52.86791955445074" height="110.14031849351466" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.010009219285714285" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_2" data-x="1.7577928249999983" data-y="1.7512907000000002" x="479.87772004910886" y="98.19193067205222" width="28.25313579368361" height="98.70975444476042" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.011169933571428573" />
+    <rect data-type="rect" data-label="schematic_component_2" data-x="1.7577928249999983" data-y="1.7512907000000002" x="498.4178627247009" y="39.99999999999997" width="31.529497055821082" height="110.15658349834194" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.010009219285714285" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_3" data-x="-1.7577928249999983" data-y="-2.7512907" x="165.14123325455287" y="501.29024555523955" width="28.253135793683583" height="98.70975444476045" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.011169933571428573" />
+    <rect data-type="rect" data-label="schematic_component_3" data-x="-1.7577928249999983" data-y="-2.7512907" x="147.18311107752342" y="489.8434165016581" width="31.52949705582111" height="110.15658349834189" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.010009219285714285" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_4" data-x="1.7577928249999983" data-y="-2.7512907" x="479.87772004910886" y="501.29024555523955" width="28.25313579368361" height="98.70975444476045" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.011169933571428573" />
+    <rect data-type="rect" data-label="schematic_component_4" data-x="1.7577928249999983" data-y="-2.7512907" x="498.4178627247009" y="489.8434165016581" width="31.529497055821082" height="110.15658349834189" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.010009219285714285" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: V3_3
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="-1.8574283249999997" data-y="0.9762093000000004" x="161.39522395803996" y="196.79342126794842" width="17.905209437554532" height="40.28672123449769" fill="#ef444466" stroke="#ef4444" stroke-width="0.011169933571428573" />
+globalConnNetId: connectivity_net0" data-x="-1.8574283249999997" data-y="0.9762093000000004" x="143.00269762012985" y="150.03576488447396" width="19.981578411959788" height="44.95855142690948" fill="#ef444466" stroke="#ef4444" stroke-width="0.010009219285714285" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: V3_3
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="1.5790330374999988" data-y="2.7275814000000005" x="469.0480260561722" y="40" width="17.90520943755456" height="40.28672123449769" fill="#ef444466" stroke="#ef4444" stroke-width="0.011169933571428573" />
+globalConnNetId: connectivity_net0" data-x="1.5790330374999988" data-y="-0.07499999999999998" x="486.33230849244904" y="255.05987016113073" width="19.981578411959788" height="44.95855142690948" fill="#ef444466" stroke="#ef4444" stroke-width="0.010009219285714285" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net1
-available orientations: y-" data-x="-2.31430995" data-y="-0.9762093000000004" x="120.4924180390637" y="371.58574098183345" width="17.905209437554532" height="40.28672123449769" fill="#00000066" stroke="#000000" stroke-width="0.011169933571428573" />
+globalConnNetId: connectivity_net1" data-x="-2.31430995" data-y="-0.9762093000000004" x="97.3566175455243" y="345.0977916288177" width="19.981578411959788" height="44.95855142690948" fill="#00000066" stroke="#000000" stroke-width="0.010009219285714285" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: FLASH_N_CS
-globalConnNetId: connectivity_net2
-available orientations: any" data-x="1.982519574999999" data-y="0.85" x="493.97982495355666" y="219.2831969137558" width="40.28672123449769" height="17.905209437554532" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011169933571428573" />
+globalConnNetId: connectivity_net2" data-x="1.532519574999999" data-y="0.85" x="469.19675999419667" y="175.13355651329164" width="44.958551426909594" height="19.981578411959788" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.010009219285714285" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: resistor.R11 &gt; port.pin1 to resistor.R12 &gt; port.pin1
-globalConnNetId: connectivity_net3
-available orientations: any" data-x="1.982519574999999" data-y="-2" x="493.97982495355666" y="474.43243139890774" width="40.28672123449769" height="17.90520943755456" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011169933571428573" />
+globalConnNetId: connectivity_net3" data-x="1.982519574999999" data-y="-2" x="514.1553114211063" y="459.8710488837184" width="44.95855142690948" height="19.981578411959788" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.010009219285714285" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -218,12 +208,12 @@ available orientations: any" data-x="1.982519574999999" data-y="-2" x="493.97982
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 89.52604718777262,
+        "a": 99.90789205979887,
         "c": 0,
-        "e": 336.63604454867266,
+        "e": 338.5652354290227,
         "b": 0,
-        "d": -89.52604718777262,
-        "f": 304.3329417421398
+        "d": -99.90789205979887,
+        "f": 270.04605397010056
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/solvers/TraceCleanupSolver/combineSameNetTraceSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/combineSameNetTraceSegments.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test"
+import { combineSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/combineSameNetTraceSegments"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: SolvedTracePath["tracePath"],
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [] as any,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+    tracePath,
+  }) as SolvedTracePath
+
+test("combines close overlapping same-net segments without moving endpoints", () => {
+  const traces = combineSameNetTraceSegments({
+    maxDistance: 0.1,
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 2, y: 0 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 0 },
+      ]),
+    ],
+  })
+
+  expect(traces[0]!.tracePath).toEqual([
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+  ])
+  expect(traces[1]!.tracePath).toEqual([
+    { x: 2, y: 0 },
+    { x: 8, y: 0 },
+  ])
+})
+
+test("does not combine close segments from different nets", () => {
+  const traces = combineSameNetTraceSegments({
+    maxDistance: 0.1,
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ]),
+      makeTrace("b", "net2", [
+        { x: 2, y: 0 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 0 },
+      ]),
+    ],
+  })
+
+  expect(traces[1]!.tracePath).toEqual([
+    { x: 2, y: 0 },
+    { x: 2, y: 0.08 },
+    { x: 8, y: 0.08 },
+    { x: 8, y: 0 },
+  ])
+})
+
+test("combines close overlapping segments within a single same-net trace", () => {
+  const traces = combineSameNetTraceSegments({
+    maxDistance: 0.1,
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 0.08 },
+        { x: 2, y: 0.08 },
+        { x: 2, y: 0 },
+      ]),
+    ],
+  })
+
+  expect(traces[0]!.tracePath).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+  ])
+})
+
+test("does not move segments that are anchored to endpoints", () => {
+  const traces = combineSameNetTraceSegments({
+    maxDistance: 0.1,
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 0, y: 0.08 },
+        { x: 10, y: 0.08 },
+      ]),
+    ],
+  })
+
+  expect(traces[1]!.tracePath).toEqual([
+    { x: 0, y: 0.08 },
+    { x: 10, y: 0.08 },
+  ])
+})


### PR DESCRIPTION
/claim #29

## Summary

- Adds a TraceCleanup pipeline phase that combines close, overlapping same-net segments before turn minimization.
- Snaps only movable segments onto a same-net target segment, preserving trace endpoints so pin anchors are not moved.
- Covers cross-trace merging, same-trace loop cleanup, different-net skips, and endpoint-anchored segment skips.
- Updates the two visual snapshots that intentionally change because duplicate/nearby same-net segments are now combined.
- Adds `typescript` as a dev dependency so the existing `tsup` build can resolve its peer dependency with npm.

## Testing

- `npm run format:check`
- `npm run build`
- `npx tsup lib/solvers/TraceCleanupSolver/combineSameNetTraceSegments.ts --format esm --out-dir /private/tmp/trace-combine-test --no-dts`
- `node --input-type=module -e "<helper assertions>"`
- GitHub CI: Bun Test, Format Check, Type Check, Vercel
