### PR TITLE
fix: merge close same-net trace lines

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -6,6 +6,7 @@ import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { mergeSameNetCloseTraceLines } from "./mergeSameNetCloseTraceLines"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "merging_same_net_close_lines"
   | "untangling_traces"
 
 /**
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "merging_same_net_close_lines":
+        this._runMergeSameNetCloseLinesStep()
+        break
     }
   }
 
@@ -108,11 +113,19 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "merging_same_net_close_lines"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runMergeSameNetCloseLinesStep() {
+    this.outputTraces = mergeSameNetCloseTraceLines(
+      Array.from(this.tracesMap.values()),
+    )
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraceLines.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraceLines.ts
@@ -1,0 +1,218 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+type SegmentOrientation = "horizontal" | "vertical"
+
+interface SegmentRef {
+  traceIndex: number
+  segmentIndex: number
+  orientation: SegmentOrientation
+  axisCoord: number
+  rangeMin: number
+  rangeMax: number
+  length: number
+}
+
+export interface MergeSameNetCloseTraceLinesOptions {
+  closeThreshold?: number
+  eps?: number
+  maxIterations?: number
+}
+
+const DEFAULT_CLOSE_THRESHOLD = 0.3
+const DEFAULT_EPS = 1e-6
+const DEFAULT_MAX_ITERATIONS = 1000
+
+const pointsEqual = (a: Point, b: Point, eps: number) =>
+  Math.abs(a.x - b.x) <= eps && Math.abs(a.y - b.y) <= eps
+
+const clonePoint = (p: Point): Point => ({ x: p.x, y: p.y })
+
+const cloneTraces = (traces: SolvedTracePath[]): SolvedTracePath[] =>
+  traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map(clonePoint),
+  }))
+
+const getSegmentsForTrace = (
+  trace: SolvedTracePath,
+  traceIndex: number,
+  eps: number,
+): SegmentRef[] => {
+  const segments: SegmentRef[] = []
+
+  for (let i = 0; i < trace.tracePath.length - 1; i++) {
+    const p1 = trace.tracePath[i]!
+    const p2 = trace.tracePath[i + 1]!
+    const dx = Math.abs(p1.x - p2.x)
+    const dy = Math.abs(p1.y - p2.y)
+
+    if (dx <= eps && dy <= eps) continue
+
+    if (dy <= eps) {
+      segments.push({
+        traceIndex,
+        segmentIndex: i,
+        orientation: "horizontal",
+        axisCoord: (p1.y + p2.y) / 2,
+        rangeMin: Math.min(p1.x, p2.x),
+        rangeMax: Math.max(p1.x, p2.x),
+        length: dx,
+      })
+    } else if (dx <= eps) {
+      segments.push({
+        traceIndex,
+        segmentIndex: i,
+        orientation: "vertical",
+        axisCoord: (p1.x + p2.x) / 2,
+        rangeMin: Math.min(p1.y, p2.y),
+        rangeMax: Math.max(p1.y, p2.y),
+        length: dy,
+      })
+    }
+  }
+
+  return segments
+}
+
+const projectedRangesOverlap = (a: SegmentRef, b: SegmentRef, eps: number) =>
+  Math.min(a.rangeMax, b.rangeMax) - Math.max(a.rangeMin, b.rangeMin) > eps
+
+const chooseAnchor = (a: SegmentRef, b: SegmentRef): SegmentRef => {
+  if (a.length !== b.length) return a.length > b.length ? a : b
+  if (a.traceIndex !== b.traceIndex) return a.traceIndex < b.traceIndex ? a : b
+  return a.segmentIndex <= b.segmentIndex ? a : b
+}
+
+const setSegmentAxisCoord = (
+  trace: SolvedTracePath,
+  segmentIndex: number,
+  orientation: SegmentOrientation,
+  axisCoord: number,
+) => {
+  const p1 = trace.tracePath[segmentIndex]!
+  const p2 = trace.tracePath[segmentIndex + 1]!
+
+  if (orientation === "horizontal") {
+    p1.y = axisCoord
+    p2.y = axisCoord
+  } else {
+    p1.x = axisCoord
+    p2.x = axisCoord
+  }
+}
+
+const removeConsecutiveDuplicatePoints = (path: Point[], eps: number) => {
+  const deduped: Point[] = []
+  for (const point of path) {
+    if (
+      !deduped.length ||
+      !pointsEqual(deduped[deduped.length - 1]!, point, eps)
+    ) {
+      deduped.push(point)
+    }
+  }
+  return deduped
+}
+
+const restoreOriginalEndpoints = (
+  trace: SolvedTracePath,
+  originalTrace: SolvedTracePath,
+  eps: number,
+) => {
+  const path = trace.tracePath
+  if (path.length < 2) return
+
+  const originalStart = originalTrace.tracePath[0]!
+  const originalEnd =
+    originalTrace.tracePath[originalTrace.tracePath.length - 1]!
+  const shiftedStart = path[0]!
+  const shiftedEnd = path[path.length - 1]!
+
+  let restoredPath = path
+
+  if (!pointsEqual(shiftedStart, originalStart, eps)) {
+    restoredPath = [
+      clonePoint(originalStart),
+      clonePoint(shiftedStart),
+      ...restoredPath.slice(1),
+    ]
+  }
+
+  if (!pointsEqual(shiftedEnd, originalEnd, eps)) {
+    restoredPath = [
+      ...restoredPath.slice(0, -1),
+      clonePoint(shiftedEnd),
+      clonePoint(originalEnd),
+    ]
+  }
+
+  trace.tracePath = simplifyPath(
+    removeConsecutiveDuplicatePoints(restoredPath, eps),
+  )
+}
+
+export const mergeSameNetCloseTraceLines = (
+  traces: SolvedTracePath[],
+  opts: MergeSameNetCloseTraceLinesOptions = {},
+): SolvedTracePath[] => {
+  const closeThreshold = opts.closeThreshold ?? DEFAULT_CLOSE_THRESHOLD
+  const eps = opts.eps ?? DEFAULT_EPS
+  const maxIterations = opts.maxIterations ?? DEFAULT_MAX_ITERATIONS
+  const outputTraces = cloneTraces(traces)
+  const originalTraces = cloneTraces(traces)
+
+  for (let iteration = 0; iteration < maxIterations; iteration++) {
+    let mergedThisIteration = false
+
+    const segmentsByNet = new Map<string, SegmentRef[]>()
+    for (let traceIndex = 0; traceIndex < outputTraces.length; traceIndex++) {
+      const trace = outputTraces[traceIndex]!
+      const segments = getSegmentsForTrace(trace, traceIndex, eps)
+      const existing = segmentsByNet.get(trace.globalConnNetId) ?? []
+      existing.push(...segments)
+      segmentsByNet.set(trace.globalConnNetId, existing)
+    }
+
+    for (const segments of segmentsByNet.values()) {
+      for (let i = 0; i < segments.length && !mergedThisIteration; i++) {
+        for (let j = i + 1; j < segments.length; j++) {
+          const a = segments[i]!
+          const b = segments[j]!
+
+          if (a.traceIndex === b.traceIndex) continue
+          if (a.orientation !== b.orientation) continue
+          if (Math.abs(a.axisCoord - b.axisCoord) > closeThreshold) continue
+          if (!projectedRangesOverlap(a, b, eps)) continue
+
+          const anchor = chooseAnchor(a, b)
+          const target = anchor === a ? b : a
+
+          if (Math.abs(target.axisCoord - anchor.axisCoord) <= eps) continue
+
+          setSegmentAxisCoord(
+            outputTraces[target.traceIndex]!,
+            target.segmentIndex,
+            target.orientation,
+            anchor.axisCoord,
+          )
+          mergedThisIteration = true
+          break
+        }
+      }
+      if (mergedThisIteration) break
+    }
+
+    if (!mergedThisIteration) break
+  }
+
+  for (let i = 0; i < outputTraces.length; i++) {
+    restoreOriginalEndpoints(outputTraces[i]!, originalTraces[i]!, eps)
+    outputTraces[i]!.tracePath = simplifyPath(
+      removeConsecutiveDuplicatePoints(outputTraces[i]!.tracePath, eps),
+    )
+  }
+
+  return outputTraces
+}

--- a/tests/examples/__snapshots__/example14.snap.svg
+++ b/tests/examples/__snapshots__/example14.snap.svg
@@ -73,36 +73,28 @@ y-" data-x="1.2000000000000002" data-y="1.1500000000000001" cx="419.076923076923
 y+" data-x="1.2000000000000002" data-y="2.25" cx="419.07692307692315" cy="98.15384615384613" r="3" fill="hsl(349, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.3510000000000002" data-y="-0.35100000000000003" cx="432.08615384615393" cy="322.24" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.3510000000000002" data-y="-0.35100000000000003" cx="432.08615384615393" cy="322.24" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-1.2000000000000002" data-y="-2.45" cx="212.30769230769232" cy="503.0769230769231" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.2000000000000002" data-y="-2.45" cx="212.30769230769232" cy="503.0769230769231" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-1.4000000000000001" data-y="-0.30000000000000004" cx="195.0769230769231" cy="317.84615384615387" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.4000000000000001" data-y="-0.30000000000000004" cx="195.0769230769231" cy="317.84615384615387" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="1.4000000000000001" data-y="0.09999999999999998" cx="436.3076923076924" cy="283.38461538461536" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.4000000000000001" data-y="0.09999999999999998" cx="436.3076923076924" cy="283.38461538461536" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-1.3010000000000002" data-y="0.5010000000000001" cx="203.60615384615386" cy="248.83692307692306" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.3010000000000002" data-y="0.5010000000000001" cx="203.60615384615386" cy="248.83692307692306" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="3.2" data-y="0.30000000000000004" cx="591.3846153846155" cy="266.15384615384613" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="3.2" data-y="0.30000000000000004" cx="591.3846153846155" cy="266.15384615384613" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-1.5500000000000003" data-y="0.10000000000000003" cx="182.15384615384616" cy="283.38461538461536" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.5500000000000003" data-y="0.10000000000000003" cx="182.15384615384616" cy="283.38461538461536" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="1.4755000000000003" data-y="-1.2944553500000002" cx="442.81230769230774" cy="403.5223070769231" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="1.4755000000000003" data-y="-1.2944553500000002" cx="442.81230769230774" cy="403.5223070769231" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <polyline data-points="-1.2000000000000002,0.10000000000000003 -1.9000000000000004,0.10000000000000002" data-type="line" data-label="" points="212.30769230769232,283.38461538461536 152,283.38461538461536" fill="none" stroke="hsl(296, 100%, 50%, 0.8)" stroke-width="1" />
@@ -150,7 +142,7 @@ orientation: y+" data-x="1.4755000000000003" data-y="-1.2944553500000002" cx="44
     <polyline data-points="-1.2000000000000002,-0.30000000000000004 -1.4000000000000001,-0.30000000000000004 -1.4000000000000001,-0.7250000000000001 -1.2000000000000002,-0.7250000000000001 -1.2000000000000002,-1.1500000000000001" data-type="line" data-label="" points="212.30769230769232,317.84615384615387 195.0769230769231,317.84615384615387 195.0769230769231,354.46153846153845 212.30769230769232,354.46153846153845 212.30769230769232,391.0769230769231" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.2000000000000002,-0.09999999999999998 -1.4000000000000001,-0.09999999999999998 -1.4000000000000001,-0.30000000000000004 -1.2000000000000002,-0.30000000000000004" data-type="line" data-label="" points="212.30769230769232,300.61538461538464 195.0769230769231,300.61538461538464 195.0769230769231,317.84615384615387 212.30769230769232,317.84615384615387" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-1.2000000000000002,-0.09999999999999998 -1.2000000000000002,-0.30000000000000004" data-type="line" data-label="" points="212.30769230769232,300.61538461538464 212.30769230769232,317.84615384615387" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="0.09999999999999987,-1.2944553500000002 -0.55,-1.2944553500000002 -0.55,-0.9500000000000002 -1.2000000000000002,-0.9500000000000002 -1.2000000000000002,-1.1500000000000001" data-type="line" data-label="" points="324.3076923076923,403.5223070769231 268.3076923076923,403.5223070769231 268.3076923076923,373.84615384615387 212.30769230769232,373.84615384615387 212.30769230769232,391.0769230769231" fill="none" stroke="purple" stroke-width="1" />
@@ -196,43 +188,35 @@ orientation: y+" data-x="1.4755000000000003" data-y="-1.2944553500000002" cx="44
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net4
-available orientations: y-" data-x="1.3510000000000002" data-y="-0.5760000000000001" x="423.4707692307693" y="322.24" width="17.230769230769226" height="38.769230769230774" fill="#00000066" stroke="#000000" stroke-width="0.011607142857142856" />
+globalConnNetId: connectivity_net4" data-x="1.3510000000000002" data-y="-0.5760000000000001" x="423.4707692307693" y="322.24" width="17.230769230769226" height="38.769230769230774" fill="#00000066" stroke="#000000" stroke-width="0.011607142857142856" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net4
-available orientations: y-" data-x="-1.2000000000000002" data-y="-2.6750000000000003" x="203.6923076923077" y="503.0769230769231" width="17.230769230769255" height="38.76923076923083" fill="#00000066" stroke="#000000" stroke-width="0.011607142857142856" />
+globalConnNetId: connectivity_net4" data-x="-1.2000000000000002" data-y="-2.6750000000000003" x="203.6923076923077" y="503.0769230769231" width="17.230769230769255" height="38.76923076923083" fill="#00000066" stroke="#000000" stroke-width="0.011607142857142856" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: U1.THRES to U1.TRIG
-globalConnNetId: connectivity_net1
-available orientations: any" data-x="-1.6250000000000002" data-y="-0.30000000000000004" x="156.30769230769232" y="309.2307692307692" width="38.769230769230774" height="17.230769230769226" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011607142857142856" />
+globalConnNetId: connectivity_net1" data-x="-1.6250000000000002" data-y="-0.30000000000000004" x="156.30769230769232" y="309.2307692307692" width="38.769230769230774" height="17.230769230769226" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011607142857142856" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: U1.OUT to R3.pin1
-globalConnNetId: connectivity_net3
-available orientations: any" data-x="1.6250000000000002" data-y="0.09999999999999998" x="436.3076923076924" y="274.7692307692308" width="38.769230769230774" height="17.230769230769226" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011607142857142856" />
+globalConnNetId: connectivity_net3" data-x="1.6250000000000002" data-y="0.09999999999999998" x="436.3076923076924" y="274.7692307692308" width="38.769230769230774" height="17.230769230769226" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011607142857142856" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net5
-available orientations: y+" data-x="-1.3010000000000002" data-y="0.7260000000000001" x="194.99076923076925" y="210.0676923076923" width="17.230769230769255" height="38.769230769230745" fill="#ef444466" stroke="#ef4444" stroke-width="0.011607142857142856" />
+globalConnNetId: connectivity_net5" data-x="-1.3010000000000002" data-y="0.7260000000000001" x="194.99076923076925" y="210.0676923076923" width="17.230769230769255" height="38.769230769230745" fill="#ef444466" stroke="#ef4444" stroke-width="0.011607142857142856" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net5
-available orientations: y+" data-x="3.2" data-y="0.525" x="582.7692307692308" y="227.3846153846154" width="17.230769230769283" height="38.769230769230745" fill="#ef444466" stroke="#ef4444" stroke-width="0.011607142857142856" />
+globalConnNetId: connectivity_net5" data-x="3.2" data-y="0.525" x="582.7692307692308" y="227.3846153846154" width="17.230769230769283" height="38.769230769230745" fill="#ef444466" stroke="#ef4444" stroke-width="0.011607142857142856" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: U1.CTRL to C2.pin1
-globalConnNetId: connectivity_net0
-available orientations: any" data-x="-1.5500000000000003" data-y="0.32500000000000007" x="173.53846153846155" y="244.6153846153846" width="17.230769230769226" height="38.769230769230745" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011607142857142856" />
+globalConnNetId: connectivity_net0" data-x="-1.5500000000000003" data-y="0.32500000000000007" x="173.53846153846155" y="244.6153846153846" width="17.230769230769226" height="38.769230769230745" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011607142857142856" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: U1.DISCH to R2.pin1
-globalConnNetId: connectivity_net2
-available orientations: any" data-x="1.4755000000000003" data-y="-1.0694553500000001" x="434.19692307692316" y="364.7530763076923" width="17.230769230769226" height="38.769230769230774" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011607142857142856" />
+globalConnNetId: connectivity_net2" data-x="1.4755000000000003" data-y="-1.0694553500000001" x="434.19692307692316" y="364.7530763076923" width="17.230769230769226" height="38.769230769230774" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.011607142857142856" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/examples/__snapshots__/example15.snap.svg
+++ b/tests/examples/__snapshots__/example15.snap.svg
@@ -317,40 +317,31 @@ y+" data-x="-2.025" data-y="-1.6000000000000003" cx="318.5204755614267" cy="471.
 y-" data-x="-2.025" data-y="-2.7" cx="318.5204755614267" cy="526.0237780713342" r="3" fill="hsl(111, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-1.3099999999999998" data-y="1.2000000000000015" cx="353.7824746807574" cy="333.6856010568031" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.3099999999999998" data-y="1.2000000000000015" cx="353.7824746807574" cy="333.6856010568031" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="0.29250000000000076" data-y="6.705000000000002" cx="432.8137384412153" cy="62.19286657859976" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="0.29250000000000076" data-y="6.705000000000002" cx="432.8137384412153" cy="62.19286657859976" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-1.3099999999999998" data-y="2.8000000000000016" cx="353.7824746807574" cy="254.77763099955962" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-1.3099999999999998" data-y="2.8000000000000016" cx="353.7824746807574" cy="254.77763099955962" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-3.7550000000000003" data-y="3.9683333333333355" cx="233.2012329370322" cy="197.15837369734325" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-3.7550000000000003" data-y="3.9683333333333355" cx="233.2012329370322" cy="197.15837369734325" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-2.025" data-y="-1.4000000000000004" cx="318.5204755614267" cy="461.9110523998238" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-2.025" data-y="-1.4000000000000004" cx="318.5204755614267" cy="461.9110523998238" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="-2.025" data-y="2.200000000000001" cx="318.5204755614267" cy="284.36811977102593" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-2.025" data-y="2.200000000000001" cx="318.5204755614267" cy="284.36811977102593" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="0.29250000000000076" data-y="5.205000000000002" cx="432.8137384412153" cy="136.16908850726549" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="0.29250000000000076" data-y="5.205000000000002" cx="432.8137384412153" cy="136.16908850726549" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-3.7550000000000003" data-y="2.4683333333333346" cx="233.2012329370322" cy="271.13459562600906" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-3.7550000000000003" data-y="2.4683333333333346" cx="233.2012329370322" cy="271.13459562600906" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-2.49" data-y="-2.9000000000000004" cx="295.5878467635403" cy="535.8872743284896" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="" data-x="-2.49" data-y="-2.9000000000000004" cx="295.5878467635403" cy="535.8872743284896" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <polyline data-points="-1.1099999999999999,1.2000000000000015 -1.5675,6.505000000000002" data-type="line" data-label="" points="363.6459709379128,333.6856010568031 341.08322324966974,72.05636283575518" fill="none" stroke="hsl(280, 100%, 50%, 0.8)" stroke-width="1" />
@@ -794,10 +785,10 @@ orientation: y-" data-x="-2.49" data-y="-2.9000000000000004" cx="295.58784676354
     <polyline data-points="-1.1099999999999999,1.0000000000000013 -1.3099999999999998,1.0000000000000013 -1.3099999999999998,1.2000000000000015 -1.1099999999999999,1.2000000000000015" data-type="line" data-label="" points="363.6459709379128,343.54909731395855 353.7824746807574,343.54909731395855 353.7824746807574,333.6856010568031 363.6459709379128,333.6856010568031" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.1099999999999999,0.8000000000000012 -1.3099999999999998,0.8000000000000012 -1.3099999999999998,1.0000000000000013 -1.1099999999999999,1.0000000000000013" data-type="line" data-label="" points="363.6459709379128,353.412593571114 353.7824746807574,353.412593571114 353.7824746807574,343.54909731395855 363.6459709379128,343.54909731395855" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-1.1099999999999999,0.8000000000000012 -1.1099999999999999,1.0000000000000013" data-type="line" data-label="" points="363.6459709379128,353.412593571114 363.6459709379128,343.54909731395855" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.1099999999999999,0.600000000000001 -1.3099999999999998,0.600000000000001 -1.3099999999999998,0.8000000000000012 -1.1099999999999999,0.8000000000000012" data-type="line" data-label="" points="363.6459709379128,363.2760898282694 353.7824746807574,363.2760898282694 353.7824746807574,353.412593571114 363.6459709379128,353.412593571114" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-1.1099999999999999,0.600000000000001 -1.3099999999999998,0.600000000000001 -1.3099999999999998,1.0000000000000013 -1.1099999999999999,1.0000000000000013 -1.1099999999999999,0.8000000000000012" data-type="line" data-label="" points="363.6459709379128,363.2760898282694 353.7824746807574,363.2760898282694 353.7824746807574,343.54909731395855 363.6459709379128,343.54909731395855 363.6459709379128,353.412593571114" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-1.1099999999999999,0.4000000000000008 -1.3099999999999998,0.4000000000000008 -1.3099999999999998,0.600000000000001 -1.1099999999999999,0.600000000000001" data-type="line" data-label="" points="363.6459709379128,373.13958608542487 353.7824746807574,373.13958608542487 353.7824746807574,363.2760898282694 363.6459709379128,363.2760898282694" fill="none" stroke="purple" stroke-width="1" />
@@ -882,48 +873,39 @@ orientation: y-" data-x="-2.49" data-y="-2.9000000000000004" cx="295.58784676354
   </g>
   <g>
     <rect data-type="rect" data-label="netId: V3_3
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="-1.3099999999999998" data-y="1.4250000000000016" x="348.85072655217965" y="311.4927344782034" width="9.863496257155475" height="22.192866578599705" fill="#ef444466" stroke="#ef4444" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net0" data-x="-1.3099999999999998" data-y="1.4250000000000016" x="348.85072655217965" y="311.4927344782034" width="9.863496257155475" height="22.192866578599705" fill="#ef444466" stroke="#ef4444" stroke-width="0.020276785714285723" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: V3_3
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="0.29250000000000076" data-y="6.9300000000000015" x="427.8819903126376" y="40.00000000000006" width="9.863496257155475" height="22.192866578599705" fill="#ef444466" stroke="#ef4444" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net0" data-x="0.29250000000000076" data-y="6.9300000000000015" x="427.8819903126376" y="40.00000000000006" width="9.863496257155475" height="22.192866578599705" fill="#ef444466" stroke="#ef4444" stroke-width="0.020276785714285723" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: V1_1
-globalConnNetId: connectivity_net6
-available orientations: y+" data-x="-1.3099999999999998" data-y="3.0250000000000017" x="348.85072655217965" y="232.58476442095986" width="9.863496257155475" height="22.192866578599762" fill="#ef444466" stroke="#ef4444" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net6" data-x="-1.3099999999999998" data-y="3.0250000000000017" x="348.85072655217965" y="232.58476442095986" width="9.863496257155475" height="22.192866578599762" fill="#ef444466" stroke="#ef4444" stroke-width="0.020276785714285723" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: V1_1
-globalConnNetId: connectivity_net6
-available orientations: y+" data-x="-3.7550000000000003" data-y="4.193333333333335" x="228.26948480845445" y="174.96550711874357" width="9.863496257155447" height="22.192866578599705" fill="#ef444466" stroke="#ef4444" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net6" data-x="-3.7550000000000003" data-y="4.193333333333335" x="228.26948480845445" y="174.96550711874357" width="9.863496257155447" height="22.192866578599705" fill="#ef444466" stroke="#ef4444" stroke-width="0.020276785714285723" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: capacitor.C11 &gt; port.pin1 to U3.ADC_AVDD
-globalConnNetId: connectivity_net9
-available orientations: any" data-x="-2.25" data-y="-1.4000000000000004" x="296.327608982827" y="456.97930427124606" width="22.192866578599705" height="9.863496257155475" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net9" data-x="-2.25" data-y="-1.4000000000000004" x="296.327608982827" y="456.97930427124606" width="22.192866578599705" height="9.863496257155475" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020276785714285723" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: capacitor.C10 &gt; port.pin1 to U3.VREG_VIN
-globalConnNetId: connectivity_net8
-available orientations: any" data-x="-2.25" data-y="2.200000000000001" x="296.327608982827" y="279.4363716424482" width="22.192866578599705" height="9.863496257155475" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net8" data-x="-2.25" data-y="2.200000000000001" x="296.327608982827" y="279.4363716424482" width="22.192866578599705" height="9.863496257155475" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.020276785714285723" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net10
-available orientations: y-" data-x="0.29250000000000076" data-y="4.980000000000002" x="427.8819903126376" y="136.16908850726549" width="9.863496257155475" height="22.192866578599705" fill="#00000066" stroke="#000000" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net10" data-x="0.29250000000000076" data-y="4.980000000000002" x="427.8819903126376" y="136.16908850726549" width="9.863496257155475" height="22.192866578599705" fill="#00000066" stroke="#000000" stroke-width="0.020276785714285723" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net10
-available orientations: y-" data-x="-3.7550000000000003" data-y="2.2433333333333345" x="228.26948480845445" y="271.13459562600906" width="9.863496257155447" height="22.192866578599705" fill="#00000066" stroke="#000000" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net10" data-x="-3.7550000000000003" data-y="2.2433333333333345" x="228.26948480845445" y="271.13459562600906" width="9.863496257155447" height="22.192866578599705" fill="#00000066" stroke="#000000" stroke-width="0.020276785714285723" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net10
-available orientations: y-" data-x="-2.49" data-y="-3.1250000000000004" x="290.6560986349626" y="535.8872743284896" width="9.863496257155418" height="22.192866578599705" fill="#00000066" stroke="#000000" stroke-width="0.020276785714285723" />
+globalConnNetId: connectivity_net10" data-x="-2.49" data-y="-3.1250000000000004" x="290.6560986349626" y="535.8872743284896" width="9.863496257155418" height="22.192866578599705" fill="#00000066" stroke="#000000" stroke-width="0.020276785714285723" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/functions/mergeSameNetCloseTraceLines.test.ts
+++ b/tests/functions/mergeSameNetCloseTraceLines.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "bun:test"
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { mergeSameNetCloseTraceLines } from "lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraceLines"
+
+const trace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Point[],
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [] as any,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}.1`, `${mspPairId}.2`],
+  }) as SolvedTracePath
+
+test("mergeSameNetCloseTraceLines snaps close horizontal same-net segments to the same y", () => {
+  const [baseTrace, branchTrace] = mergeSameNetCloseTraceLines([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+    ]),
+    trace("b", "net1", [
+      { x: 1, y: -1 },
+      { x: 1, y: 0.2 },
+      { x: 3, y: 0.2 },
+      { x: 3, y: -1 },
+    ]),
+  ])
+
+  expect(baseTrace!.tracePath).toEqual([
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+  ])
+  expect(branchTrace!.tracePath).toEqual([
+    { x: 1, y: -1 },
+    { x: 1, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: -1 },
+  ])
+})
+
+test("mergeSameNetCloseTraceLines snaps close vertical same-net segments to the same x", () => {
+  const [, branchTrace] = mergeSameNetCloseTraceLines([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 4 },
+    ]),
+    trace("b", "net1", [
+      { x: -1, y: 1 },
+      { x: 0.2, y: 1 },
+      { x: 0.2, y: 3 },
+      { x: -1, y: 3 },
+    ]),
+  ])
+
+  expect(branchTrace!.tracePath).toEqual([
+    { x: -1, y: 1 },
+    { x: 0, y: 1 },
+    { x: 0, y: 3 },
+    { x: -1, y: 3 },
+  ])
+})
+
+test("mergeSameNetCloseTraceLines preserves terminal pin endpoints", () => {
+  const [, terminalTrace] = mergeSameNetCloseTraceLines([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+    ]),
+    trace("b", "net1", [
+      { x: 1, y: 0.2 },
+      { x: 3, y: 0.2 },
+    ]),
+  ])
+
+  expect(terminalTrace!.tracePath).toEqual([
+    { x: 1, y: 0.2 },
+    { x: 1, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: 0.2 },
+  ])
+})
+
+test("mergeSameNetCloseTraceLines does not snap different-net or far same-net segments", () => {
+  const [, differentNetTrace, farTrace] = mergeSameNetCloseTraceLines([
+    trace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+    ]),
+    trace("b", "net2", [
+      { x: 1, y: 0.2 },
+      { x: 3, y: 0.2 },
+    ]),
+    trace("c", "net1", [
+      { x: 1, y: 0.31 },
+      { x: 3, y: 0.31 },
+    ]),
+  ])
+
+  expect(differentNetTrace!.tracePath).toEqual([
+    { x: 1, y: 0.2 },
+    { x: 3, y: 0.2 },
+  ])
+  expect(farTrace!.tracePath).toEqual([
+    { x: 1, y: 0.31 },
+    { x: 3, y: 0.31 },
+  ])
+})


### PR DESCRIPTION
Fixes #34.\n\n## Summary\n- add TraceCleanupSolver post-step to snap close collinear same-net segments onto the same axis\n- preserve terminal endpoints while inserting short connector segments\n- add focused horizontal/vertical/safety regression tests\n- update affected SVG snapshots\n\n## Tests\n- `bun test tests/functions/mergeSameNetCloseTraceLines.test.ts tests/solvers/TraceCleanupSolver/TraceCleanupSolver.test.ts`\n- `bun test`\n- `bunx tsc --noEmit`\n- `git diff --check`