### PR TITLE
Align close same-net trace segments during cleanup

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -6,6 +6,7 @@ import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { alignNearbySameNetSegments } from "./alignNearbySameNetSegments"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "aligning_nearby_same_net_segments"
   | "untangling_traces"
 
 /**
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "aligning_nearby_same_net_segments":
+        this._runAlignNearbySameNetSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +113,17 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "aligning_nearby_same_net_segments"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runAlignNearbySameNetSegmentsStep() {
+    this.outputTraces = alignNearbySameNetSegments(this.outputTraces)
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -121,7 +121,9 @@ export class TraceCleanupSolver extends BaseSolver {
   }
 
   private _runAlignNearbySameNetSegmentsStep() {
-    this.outputTraces = alignNearbySameNetSegments(this.outputTraces)
+    this.outputTraces = alignNearbySameNetSegments(this.outputTraces, {
+      inputProblem: this.input.inputProblem,
+    })
     this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
     this.solved = true
   }

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -123,6 +123,9 @@ export class TraceCleanupSolver extends BaseSolver {
   private _runAlignNearbySameNetSegmentsStep() {
     this.outputTraces = alignNearbySameNetSegments(this.outputTraces, {
       inputProblem: this.input.inputProblem,
+      allLabelPlacements: this.input.allLabelPlacements,
+      mergedLabelNetIdMap: this.input.mergedLabelNetIdMap,
+      paddingBuffer: this.input.paddingBuffer,
     })
     this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
     this.solved = true

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -1,9 +1,12 @@
 import type { Point } from "@tscircuit/math-utils"
-import { doSegmentsIntersect } from "@tscircuit/math-utils"
+import {
+  doSegmentsIntersect,
+  getSegmentIntersection,
+} from "@tscircuit/math-utils"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import {
-  isPathCollidingWithObstacles,
   isHorizontal,
+  segmentIntersectsRect,
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
@@ -35,8 +38,8 @@ interface SegmentPair {
 const EPS = 1e-9
 const DEFAULT_ALIGNMENT_TOLERANCE = 0.15
 const MIN_OVERLAP = 0.05
-const MAX_ALIGNMENT_PASSES = 5
 const STATIC_OBSTACLE_TOLERANCE = 1e-5
+const COLLISION_KEY_PRECISION = 1e6
 
 export const alignNearbySameNetSegments = (
   traces: SolvedTracePath[],
@@ -53,8 +56,10 @@ export const alignNearbySameNetSegments = (
       }))
     : []
   let outputTraces = traces
+  const seenTraceStates = new Set<string>()
 
-  for (let pass = 0; pass < MAX_ALIGNMENT_PASSES; pass++) {
+  while (true) {
+    seenTraceStates.add(getTraceStateKey(outputTraces))
     const pairs = findAlignmentPairs(outputTraces, tolerance)
     let aligned = false
 
@@ -82,9 +87,14 @@ export const alignNearbySameNetSegments = (
         continue
       }
 
-      outputTraces = outputTraces.map((trace, index) =>
+      const candidateTraces = outputTraces.map((trace, index) =>
         index === pair.moving.traceIndex ? updatedTrace : trace,
       )
+      if (seenTraceStates.has(getTraceStateKey(candidateTraces))) {
+        continue
+      }
+
+      outputTraces = candidateTraces
       aligned = true
       break
     }
@@ -240,15 +250,15 @@ const introducesDifferentNetCollision = (
     if (traceIndex === updatedTraceIndex) continue
     if (updatedTrace.globalConnNetId === otherTrace.globalConnNetId) continue
 
-    const hadCollision = pathsIntersect(
+    const originalCollisions = getPathCollisionKeys(
       originalTrace.tracePath,
       otherTrace.tracePath,
     )
-    const hasCollision = pathsIntersect(
+    const updatedCollisions = getPathCollisionKeys(
       updatedTrace.tracePath,
       otherTrace.tracePath,
     )
-    if (!hadCollision && hasCollision) {
+    if (hasNewCollision(originalCollisions, updatedCollisions)) {
       return true
     }
   }
@@ -262,14 +272,16 @@ const introducesStaticObstacleCollision = (
   staticObstacles: ChipWithBounds[],
 ) => {
   for (const obstacle of staticObstacles) {
-    const hadCollision = isPathCollidingWithObstacles(originalTrace.tracePath, [
+    const originalCollisions = getObstacleCollisionKeys(
+      originalTrace.tracePath,
       obstacle,
-    ])
-    const hasCollision = isPathCollidingWithObstacles(updatedTrace.tracePath, [
+    )
+    const updatedCollisions = getObstacleCollisionKeys(
+      updatedTrace.tracePath,
       obstacle,
-    ])
+    )
 
-    if (!hadCollision && hasCollision) {
+    if (hasNewCollision(originalCollisions, updatedCollisions)) {
       return true
     }
   }
@@ -277,21 +289,152 @@ const introducesStaticObstacleCollision = (
   return false
 }
 
-const pathsIntersect = (firstPath: Point[], secondPath: Point[]) => {
-  for (let i = 0; i < firstPath.length - 1; i++) {
-    for (let j = 0; j < secondPath.length - 1; j++) {
-      if (
-        doSegmentsIntersect(
-          firstPath[i],
-          firstPath[i + 1],
-          secondPath[j],
-          secondPath[j + 1],
-        )
-      ) {
-        return true
-      }
+const hasNewCollision = (
+  originalCollisions: Set<string>,
+  updatedCollisions: Set<string>,
+) => {
+  for (const collision of updatedCollisions) {
+    if (!originalCollisions.has(collision)) {
+      return true
     }
   }
 
   return false
+}
+
+const getPathCollisionKeys = (firstPath: Point[], secondPath: Point[]) => {
+  const collisions = new Set<string>()
+  for (let i = 0; i < firstPath.length - 1; i++) {
+    for (let j = 0; j < secondPath.length - 1; j++) {
+      const collisionKey = getSegmentCollisionKey(
+        firstPath[i],
+        firstPath[i + 1],
+        secondPath[j],
+        secondPath[j + 1],
+      )
+      if (collisionKey) {
+        collisions.add(collisionKey)
+      }
+    }
+  }
+
+  return collisions
+}
+
+const getSegmentCollisionKey = (
+  firstStart: Point,
+  firstEnd: Point,
+  secondStart: Point,
+  secondEnd: Point,
+) => {
+  const intersection = getSegmentIntersection(
+    firstStart,
+    firstEnd,
+    secondStart,
+    secondEnd,
+  )
+  if (intersection) {
+    return `point:${pointKey(intersection)}`
+  }
+
+  if (!doSegmentsIntersect(firstStart, firstEnd, secondStart, secondEnd)) {
+    return null
+  }
+
+  return (
+    getCollinearOverlapKey(firstStart, firstEnd, secondStart, secondEnd) ??
+    [
+      "segment-pair",
+      segmentKey(firstStart, firstEnd),
+      segmentKey(secondStart, secondEnd),
+    ].join(":")
+  )
+}
+
+const getCollinearOverlapKey = (
+  firstStart: Point,
+  firstEnd: Point,
+  secondStart: Point,
+  secondEnd: Point,
+) => {
+  if (
+    isHorizontal(firstStart, firstEnd) &&
+    isHorizontal(secondStart, secondEnd) &&
+    Math.abs(firstStart.y - secondStart.y) <= EPS
+  ) {
+    const minX = Math.max(
+      Math.min(firstStart.x, firstEnd.x),
+      Math.min(secondStart.x, secondEnd.x),
+    )
+    const maxX = Math.min(
+      Math.max(firstStart.x, firstEnd.x),
+      Math.max(secondStart.x, secondEnd.x),
+    )
+    return `horizontal-overlap:${formatNumber(firstStart.y)}:${formatNumber(minX)}:${formatNumber(maxX)}`
+  }
+
+  if (
+    isVertical(firstStart, firstEnd) &&
+    isVertical(secondStart, secondEnd) &&
+    Math.abs(firstStart.x - secondStart.x) <= EPS
+  ) {
+    const minY = Math.max(
+      Math.min(firstStart.y, firstEnd.y),
+      Math.min(secondStart.y, secondEnd.y),
+    )
+    const maxY = Math.min(
+      Math.max(firstStart.y, firstEnd.y),
+      Math.max(secondStart.y, secondEnd.y),
+    )
+    return `vertical-overlap:${formatNumber(firstStart.x)}:${formatNumber(minY)}:${formatNumber(maxY)}`
+  }
+
+  return null
+}
+
+const getObstacleCollisionKeys = (path: Point[], obstacle: ChipWithBounds) => {
+  const collisions = new Set<string>()
+  for (let i = 0; i < path.length - 1; i++) {
+    const start = path[i]
+    const end = path[i + 1]
+    if (!segmentIntersectsRect(start, end, obstacle)) {
+      continue
+    }
+
+    if (isHorizontal(start, end)) {
+      const minX = Math.max(Math.min(start.x, end.x), obstacle.minX)
+      const maxX = Math.min(Math.max(start.x, end.x), obstacle.maxX)
+      collisions.add(
+        `horizontal-obstacle:${formatNumber(start.y)}:${formatNumber(minX)}:${formatNumber(maxX)}`,
+      )
+    } else if (isVertical(start, end)) {
+      const minY = Math.max(Math.min(start.y, end.y), obstacle.minY)
+      const maxY = Math.min(Math.max(start.y, end.y), obstacle.maxY)
+      collisions.add(
+        `vertical-obstacle:${formatNumber(start.x)}:${formatNumber(minY)}:${formatNumber(maxY)}`,
+      )
+    }
+  }
+
+  return collisions
+}
+
+const getTraceStateKey = (traces: SolvedTracePath[]) => {
+  return traces
+    .map((trace) => trace.tracePath.map(pointKey).join(";"))
+    .join("|")
+}
+
+const segmentKey = (start: Point, end: Point) => {
+  return `${pointKey(start)}>${pointKey(end)}`
+}
+
+const pointKey = (point: Point) => {
+  return `${formatNumber(point.x)},${formatNumber(point.y)}`
+}
+
+const formatNumber = (value: number) => {
+  return String(
+    Math.round(value * COLLISION_KEY_PRECISION) / COLLISION_KEY_PRECISION,
+  )
 }

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -7,6 +7,7 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
+import type { ChipWithBounds } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import type { InputProblem } from "lib/types/InputProblem"
 import { simplifyPath } from "./simplifyPath"
 
@@ -66,13 +67,17 @@ export const alignNearbySameNetSegments = (
       )
 
       if (
-        traceHasDifferentNetCollision(
+        introducesDifferentNetCollision(
+          pair.moving.trace,
           updatedTrace,
           outputTraces,
           pair.moving.traceIndex,
         ) ||
-        (staticObstacles.length > 0 &&
-          isPathCollidingWithObstacles(updatedTrace.tracePath, staticObstacles))
+        introducesStaticObstacleCollision(
+          pair.moving.trace,
+          updatedTrace,
+          staticObstacles,
+        )
       ) {
         continue
       }
@@ -225,7 +230,8 @@ const alignSegmentToCoordinate = (
   }
 }
 
-const traceHasDifferentNetCollision = (
+const introducesDifferentNetCollision = (
+  originalTrace: SolvedTracePath,
   updatedTrace: SolvedTracePath,
   allTraces: SolvedTracePath[],
   updatedTraceIndex: number,
@@ -234,7 +240,36 @@ const traceHasDifferentNetCollision = (
     if (traceIndex === updatedTraceIndex) continue
     if (updatedTrace.globalConnNetId === otherTrace.globalConnNetId) continue
 
-    if (pathsIntersect(updatedTrace.tracePath, otherTrace.tracePath)) {
+    const hadCollision = pathsIntersect(
+      originalTrace.tracePath,
+      otherTrace.tracePath,
+    )
+    const hasCollision = pathsIntersect(
+      updatedTrace.tracePath,
+      otherTrace.tracePath,
+    )
+    if (!hadCollision && hasCollision) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const introducesStaticObstacleCollision = (
+  originalTrace: SolvedTracePath,
+  updatedTrace: SolvedTracePath,
+  staticObstacles: ChipWithBounds[],
+) => {
+  for (const obstacle of staticObstacles) {
+    const hadCollision = isPathCollidingWithObstacles(originalTrace.tracePath, [
+      obstacle,
+    ])
+    const hasCollision = isPathCollidingWithObstacles(updatedTrace.tracePath, [
+      obstacle,
+    ])
+
+    if (!hadCollision && hasCollision) {
       return true
     }
   }

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -82,7 +82,8 @@ export const alignNearbySameNetSegments = (
           pair.moving.trace,
           updatedTrace,
           staticObstacles,
-        )
+        ) ||
+        introducesSelfCollision(pair.moving.trace, updatedTrace)
       ) {
         continue
       }
@@ -103,6 +104,16 @@ export const alignNearbySameNetSegments = (
   }
 
   return outputTraces
+}
+
+const introducesSelfCollision = (
+  originalTrace: SolvedTracePath,
+  updatedTrace: SolvedTracePath,
+) => {
+  return hasNewCollision(
+    getSelfCollisionKeys(originalTrace.tracePath),
+    getSelfCollisionKeys(updatedTrace.tracePath),
+  )
 }
 
 const findAlignmentPairs = (
@@ -311,6 +322,25 @@ const getPathCollisionKeys = (firstPath: Point[], secondPath: Point[]) => {
         firstPath[i + 1],
         secondPath[j],
         secondPath[j + 1],
+      )
+      if (collisionKey) {
+        collisions.add(collisionKey)
+      }
+    }
+  }
+
+  return collisions
+}
+
+const getSelfCollisionKeys = (path: Point[]) => {
+  const collisions = new Set<string>()
+  for (let i = 0; i < path.length - 1; i++) {
+    for (let j = i + 2; j < path.length - 1; j++) {
+      const collisionKey = getSegmentCollisionKey(
+        path[i],
+        path[i + 1],
+        path[j],
+        path[j + 1],
       )
       if (collisionKey) {
         collisions.add(collisionKey)

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -2,9 +2,12 @@ import type { Point } from "@tscircuit/math-utils"
 import { doSegmentsIntersect } from "@tscircuit/math-utils"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import {
+  isPathCollidingWithObstacles,
   isHorizontal,
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
+import type { InputProblem } from "lib/types/InputProblem"
 import { simplifyPath } from "./simplifyPath"
 
 type Axis = "horizontal" | "vertical"
@@ -32,12 +35,22 @@ const EPS = 1e-9
 const DEFAULT_ALIGNMENT_TOLERANCE = 0.15
 const MIN_OVERLAP = 0.05
 const MAX_ALIGNMENT_PASSES = 5
+const STATIC_OBSTACLE_TOLERANCE = 1e-5
 
 export const alignNearbySameNetSegments = (
   traces: SolvedTracePath[],
-  opts: { tolerance?: number } = {},
+  opts: { tolerance?: number; inputProblem?: InputProblem } = {},
 ): SolvedTracePath[] => {
   const tolerance = opts.tolerance ?? DEFAULT_ALIGNMENT_TOLERANCE
+  const staticObstacles = opts.inputProblem
+    ? getObstacleRects(opts.inputProblem).map((obs) => ({
+        ...obs,
+        minX: obs.minX + STATIC_OBSTACLE_TOLERANCE,
+        maxX: obs.maxX - STATIC_OBSTACLE_TOLERANCE,
+        minY: obs.minY + STATIC_OBSTACLE_TOLERANCE,
+        maxY: obs.maxY - STATIC_OBSTACLE_TOLERANCE,
+      }))
+    : []
   let outputTraces = traces
 
   for (let pass = 0; pass < MAX_ALIGNMENT_PASSES; pass++) {
@@ -57,7 +70,9 @@ export const alignNearbySameNetSegments = (
           updatedTrace,
           outputTraces,
           pair.moving.traceIndex,
-        )
+        ) ||
+        (staticObstacles.length > 0 &&
+          isPathCollidingWithObstacles(updatedTrace.tracePath, staticObstacles))
       ) {
         continue
       }

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -13,6 +13,7 @@ import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/Schemati
 import type { ChipWithBounds } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import type { InputProblem } from "lib/types/InputProblem"
 import { simplifyPath } from "./simplifyPath"
+import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 
 type Axis = "horizontal" | "vertical"
 
@@ -43,9 +44,18 @@ const COLLISION_KEY_PRECISION = 1e6
 
 export const alignNearbySameNetSegments = (
   traces: SolvedTracePath[],
-  opts: { tolerance?: number; inputProblem?: InputProblem } = {},
+  opts: {
+    tolerance?: number
+    inputProblem?: InputProblem
+    allLabelPlacements?: NetLabelPlacement[]
+    mergedLabelNetIdMap?: Record<string, Set<string>>
+    paddingBuffer?: number
+  } = {},
 ): SolvedTracePath[] => {
   const tolerance = opts.tolerance ?? DEFAULT_ALIGNMENT_TOLERANCE
+  const labelPlacements = opts.allLabelPlacements ?? []
+  const mergedLabelNetIdMap = opts.mergedLabelNetIdMap ?? {}
+  const paddingBuffer = opts.paddingBuffer ?? 0
   const staticObstacles = opts.inputProblem
     ? getObstacleRects(opts.inputProblem).map((obs) => ({
         ...obs,
@@ -82,6 +92,13 @@ export const alignNearbySameNetSegments = (
           pair.moving.trace,
           updatedTrace,
           staticObstacles,
+        ) ||
+        introducesNetLabelCollision(
+          pair.moving.trace,
+          updatedTrace,
+          labelPlacements,
+          mergedLabelNetIdMap,
+          paddingBuffer,
         ) ||
         introducesSelfCollision(pair.moving.trace, updatedTrace)
       ) {
@@ -298,6 +315,50 @@ const introducesStaticObstacleCollision = (
   }
 
   return false
+}
+
+const introducesNetLabelCollision = (
+  originalTrace: SolvedTracePath,
+  updatedTrace: SolvedTracePath,
+  allLabelPlacements: NetLabelPlacement[],
+  mergedLabelNetIdMap: Record<string, Set<string>>,
+  paddingBuffer: number,
+) => {
+  const labelBounds = getLabelBoundsForTrace(
+    updatedTrace,
+    allLabelPlacements,
+    mergedLabelNetIdMap,
+    paddingBuffer,
+  )
+
+  return introducesStaticObstacleCollision(
+    originalTrace,
+    updatedTrace,
+    labelBounds,
+  )
+}
+
+const getLabelBoundsForTrace = (
+  trace: SolvedTracePath,
+  allLabelPlacements: NetLabelPlacement[],
+  mergedLabelNetIdMap: Record<string, Set<string>>,
+  paddingBuffer: number,
+): ChipWithBounds[] => {
+  return allLabelPlacements
+    .filter((label) => {
+      const originalNetIds = mergedLabelNetIdMap[label.globalConnNetId]
+      if (originalNetIds) {
+        return !originalNetIds.has(trace.globalConnNetId)
+      }
+      return label.globalConnNetId !== trace.globalConnNetId
+    })
+    .map((label, index) => ({
+      chipId: `net-label-${label.globalConnNetId}-${index}`,
+      minX: label.center.x - label.width / 2 - paddingBuffer,
+      maxX: label.center.x + label.width / 2 + paddingBuffer,
+      minY: label.center.y - label.height / 2 - paddingBuffer,
+      maxY: label.center.y + label.height / 2 + paddingBuffer,
+    }))
 }
 
 const hasNewCollision = (

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -1,0 +1,247 @@
+import type { Point } from "@tscircuit/math-utils"
+import { doSegmentsIntersect } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import {
+  isHorizontal,
+  isVertical,
+} from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+import { simplifyPath } from "./simplifyPath"
+
+type Axis = "horizontal" | "vertical"
+
+interface TraceSegment {
+  traceIndex: number
+  segmentIndex: number
+  trace: SolvedTracePath
+  axis: Axis
+  coordinate: number
+  min: number
+  max: number
+  length: number
+  isEndpointSegment: boolean
+}
+
+interface SegmentPair {
+  moving: TraceSegment
+  anchor: TraceSegment
+  distance: number
+  overlap: number
+}
+
+const EPS = 1e-9
+const DEFAULT_ALIGNMENT_TOLERANCE = 0.15
+const MIN_OVERLAP = 0.05
+const MAX_ALIGNMENT_PASSES = 5
+
+export const alignNearbySameNetSegments = (
+  traces: SolvedTracePath[],
+  opts: { tolerance?: number } = {},
+): SolvedTracePath[] => {
+  const tolerance = opts.tolerance ?? DEFAULT_ALIGNMENT_TOLERANCE
+  let outputTraces = traces
+
+  for (let pass = 0; pass < MAX_ALIGNMENT_PASSES; pass++) {
+    const pairs = findAlignmentPairs(outputTraces, tolerance)
+    let aligned = false
+
+    for (const pair of pairs) {
+      const updatedTrace = alignSegmentToCoordinate(
+        pair.moving.trace,
+        pair.moving.segmentIndex,
+        pair.moving.axis,
+        pair.anchor.coordinate,
+      )
+
+      if (
+        traceHasDifferentNetCollision(
+          updatedTrace,
+          outputTraces,
+          pair.moving.traceIndex,
+        )
+      ) {
+        continue
+      }
+
+      outputTraces = outputTraces.map((trace, index) =>
+        index === pair.moving.traceIndex ? updatedTrace : trace,
+      )
+      aligned = true
+      break
+    }
+
+    if (!aligned) break
+  }
+
+  return outputTraces
+}
+
+const findAlignmentPairs = (
+  traces: SolvedTracePath[],
+  tolerance: number,
+): SegmentPair[] => {
+  const segments = traces.flatMap((trace, traceIndex) =>
+    extractTraceSegments(trace, traceIndex).filter(
+      (segment) => !segment.isEndpointSegment,
+    ),
+  )
+  const pairs: SegmentPair[] = []
+
+  for (let i = 0; i < segments.length; i++) {
+    const first = segments[i]
+    for (let j = i + 1; j < segments.length; j++) {
+      const second = segments[j]
+      if (first.trace.globalConnNetId !== second.trace.globalConnNetId) {
+        continue
+      }
+      if (first.traceIndex === second.traceIndex) {
+        continue
+      }
+      if (first.axis !== second.axis) {
+        continue
+      }
+
+      const distance = Math.abs(first.coordinate - second.coordinate)
+      if (distance <= EPS || distance > tolerance) {
+        continue
+      }
+
+      const overlap = getOverlap(first, second)
+      if (overlap < MIN_OVERLAP) {
+        continue
+      }
+
+      const anchor =
+        first.length > second.length ||
+        (Math.abs(first.length - second.length) <= EPS &&
+          first.traceIndex < second.traceIndex)
+          ? first
+          : second
+      const moving = anchor === first ? second : first
+
+      pairs.push({
+        moving,
+        anchor,
+        distance,
+        overlap,
+      })
+    }
+  }
+
+  pairs.sort((a, b) => {
+    if (Math.abs(a.distance - b.distance) > EPS) {
+      return a.distance - b.distance
+    }
+    return b.overlap - a.overlap
+  })
+
+  return pairs
+}
+
+const extractTraceSegments = (
+  trace: SolvedTracePath,
+  traceIndex: number,
+): TraceSegment[] => {
+  const segments: TraceSegment[] = []
+  for (let i = 0; i < trace.tracePath.length - 1; i++) {
+    const start = trace.tracePath[i]
+    const end = trace.tracePath[i + 1]
+    const axis = isHorizontal(start, end)
+      ? "horizontal"
+      : isVertical(start, end)
+        ? "vertical"
+        : null
+
+    if (!axis) continue
+
+    const min =
+      axis === "horizontal"
+        ? Math.min(start.x, end.x)
+        : Math.min(start.y, end.y)
+    const max =
+      axis === "horizontal"
+        ? Math.max(start.x, end.x)
+        : Math.max(start.y, end.y)
+
+    segments.push({
+      traceIndex,
+      segmentIndex: i,
+      trace,
+      axis,
+      coordinate: axis === "horizontal" ? start.y : start.x,
+      min,
+      max,
+      length: max - min,
+      isEndpointSegment: i === 0 || i === trace.tracePath.length - 2,
+    })
+  }
+
+  return segments
+}
+
+const getOverlap = (a: TraceSegment, b: TraceSegment) => {
+  return Math.min(a.max, b.max) - Math.max(a.min, b.min)
+}
+
+const alignSegmentToCoordinate = (
+  trace: SolvedTracePath,
+  segmentIndex: number,
+  axis: Axis,
+  coordinate: number,
+): SolvedTracePath => {
+  const tracePath = trace.tracePath.map((point) => ({ ...point }))
+
+  if (axis === "horizontal") {
+    tracePath[segmentIndex] = { ...tracePath[segmentIndex], y: coordinate }
+    tracePath[segmentIndex + 1] = {
+      ...tracePath[segmentIndex + 1],
+      y: coordinate,
+    }
+  } else {
+    tracePath[segmentIndex] = { ...tracePath[segmentIndex], x: coordinate }
+    tracePath[segmentIndex + 1] = {
+      ...tracePath[segmentIndex + 1],
+      x: coordinate,
+    }
+  }
+
+  return {
+    ...trace,
+    tracePath: simplifyPath(tracePath),
+  }
+}
+
+const traceHasDifferentNetCollision = (
+  updatedTrace: SolvedTracePath,
+  allTraces: SolvedTracePath[],
+  updatedTraceIndex: number,
+) => {
+  for (const [traceIndex, otherTrace] of allTraces.entries()) {
+    if (traceIndex === updatedTraceIndex) continue
+    if (updatedTrace.globalConnNetId === otherTrace.globalConnNetId) continue
+
+    if (pathsIntersect(updatedTrace.tracePath, otherTrace.tracePath)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const pathsIntersect = (firstPath: Point[], secondPath: Point[]) => {
+  for (let i = 0; i < firstPath.length - 1; i++) {
+    for (let j = 0; j < secondPath.length - 1; j++) {
+      if (
+        doSegmentsIntersect(
+          firstPath[i],
+          firstPath[i + 1],
+          secondPath[j],
+          secondPath[j + 1],
+        )
+      ) {
+        return true
+      }
+    }
+  }
+
+  return false
+}

--- a/tests/solvers/TraceCleanupSolver/__snapshots__/before-after.snap.svg
+++ b/tests/solvers/TraceCleanupSolver/__snapshots__/before-after.snap.svg
@@ -1,0 +1,72 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <polyline data-points="0,-2 0,0 10,0 10,2" data-type="line" data-label="" points="40,350.8 40,306 264,306 264,261.2" fill="none" stroke="#1d4ed8" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="2,-2 2,0.08 8,0.08 8,2" data-type="line" data-label="" points="84.8,350.8 84.8,304.208 219.2,304.208 219.2,261.2" fill="none" stroke="#dc2626" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="15,-2 15,0 25,0 25,2" data-type="line" data-label="" points="376,350.8 376,306 600,306 600,261.2" fill="none" stroke="#1d4ed8" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="17,-2 17,0 23,0 23,2" data-type="line" data-label="" points="420.79999999999995,350.8 420.79999999999995,306 555.1999999999999,306 555.1999999999999,261.2" fill="none" stroke="#dc2626" stroke-width="1" />
+  </g><text data-type="text" data-label="Before" data-x="5" data-y="-3" x="152" y="373.2" fill="black" font-size="11.2" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">Before</text><text data-type="text" data-label="After" data-x="20" data-y="-3" x="488" y="373.2" fill="black" font-size="11.2" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">After</text>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 22.4,
+        "c": 0,
+        "e": 40,
+        "b": 0,
+        "d": -22.4,
+        "f": 306
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { alignNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments"
+
+const trace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+    pins: [] as any,
+  }) as SolvedTracePath
+
+describe("alignNearbySameNetSegments", () => {
+  test("aligns close overlapping horizontal segments on the same net", () => {
+    const [anchor, moved] = alignNearbySameNetSegments([
+      trace("a", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 2 },
+      ]),
+      trace("b", "net1", [
+        { x: 2, y: -2 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 2 },
+      ]),
+    ])
+
+    expect(anchor.tracePath[1].y).toBe(0)
+    expect(anchor.tracePath[2].y).toBe(0)
+    expect(moved.tracePath[1].y).toBe(0)
+    expect(moved.tracePath[2].y).toBe(0)
+  })
+
+  test("aligns close overlapping vertical segments on the same net", () => {
+    const [, moved] = alignNearbySameNetSegments([
+      trace("a", "net1", [
+        { x: -2, y: 0 },
+        { x: 0, y: 0 },
+        { x: 0, y: 10 },
+        { x: 2, y: 10 },
+      ]),
+      trace("b", "net1", [
+        { x: -2, y: 2 },
+        { x: 0.08, y: 2 },
+        { x: 0.08, y: 8 },
+        { x: 2, y: 8 },
+      ]),
+    ])
+
+    expect(moved.tracePath[1].x).toBe(0)
+    expect(moved.tracePath[2].x).toBe(0)
+  })
+
+  test("does not move endpoint-only segments", () => {
+    const [, endpointTrace] = alignNearbySameNetSegments([
+      trace("a", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 2 },
+      ]),
+      trace("b", "net1", [
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 2 },
+      ]),
+    ])
+
+    expect(endpointTrace.tracePath[0].y).toBe(0.08)
+    expect(endpointTrace.tracePath[1].y).toBe(0.08)
+  })
+
+  test("does not align different nets", () => {
+    const [, otherNet] = alignNearbySameNetSegments([
+      trace("a", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 2 },
+      ]),
+      trace("b", "net2", [
+        { x: 2, y: -2 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 2 },
+      ]),
+    ])
+
+    expect(otherNet.tracePath[1].y).toBe(0.08)
+    expect(otherNet.tracePath[2].y).toBe(0.08)
+  })
+
+  test("rejects alignments that would collide with a different net", () => {
+    const [, blockedTrace] = alignNearbySameNetSegments([
+      trace("a", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 2 },
+      ]),
+      trace("b", "net1", [
+        { x: 2, y: -2 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 2 },
+      ]),
+      trace("c", "net2", [
+        { x: 5, y: -0.02 },
+        { x: 5, y: 0.02 },
+      ]),
+    ])
+
+    expect(blockedTrace.tracePath[1].y).toBe(0.08)
+    expect(blockedTrace.tracePath[2].y).toBe(0.08)
+  })
+})

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { getSvgFromGraphicsObject, type GraphicsObject } from "graphics-debug"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { alignNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments"
 import type { InputProblem } from "lib/types/InputProblem"
@@ -227,6 +228,37 @@ describe("alignNearbySameNetSegments", () => {
     expect(blockedTrace.tracePath[2].y).toBe(0.08)
   })
 
+  test("rejects alignments that would collide with a different-net label", () => {
+    const [, blockedTrace] = alignNearbySameNetSegments(
+      [
+        trace("a", "net1", [
+          { x: 0, y: -2 },
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 10, y: 2 },
+        ]),
+        trace("b", "net1", [
+          { x: 2, y: -2 },
+          { x: 2, y: 0.08 },
+          { x: 8, y: 0.08 },
+          { x: 8, y: 2 },
+        ]),
+      ],
+      {
+        allLabelPlacements: [
+          labelPlacement("net2", {
+            center: { x: 5, y: 0 },
+            width: 1,
+            height: 0.1,
+          }),
+        ],
+      },
+    )
+
+    expect(blockedTrace.tracePath[1].y).toBe(0.08)
+    expect(blockedTrace.tracePath[2].y).toBe(0.08)
+  })
+
   test("allows alignments that keep an existing chip obstacle collision", () => {
     const [, movedTrace] = alignNearbySameNetSegments(
       [
@@ -374,4 +406,22 @@ const problemWithChipObstacle = ({
   directConnections: [],
   netConnections: [],
   availableNetLabelOrientations: {},
+})
+
+const labelPlacement = (
+  globalConnNetId: string,
+  bounds: {
+    center: { x: number; y: number }
+    width: number
+    height: number
+  },
+): NetLabelPlacement => ({
+  globalConnNetId,
+  mspConnectionPairIds: [],
+  pinIds: [],
+  orientation: "x+",
+  anchorPoint: bounds.center,
+  center: bounds.center,
+  width: bounds.width,
+  height: bounds.height,
 })

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -125,6 +125,30 @@ describe("alignNearbySameNetSegments", () => {
     expect(blockedTrace.tracePath[2].y).toBe(0.08)
   })
 
+  test("allows alignments that keep an existing different-net collision", () => {
+    const [, movedTrace] = alignNearbySameNetSegments([
+      trace("a", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 2 },
+      ]),
+      trace("b", "net1", [
+        { x: 2, y: -2 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 2 },
+      ]),
+      trace("c", "net2", [
+        { x: 5, y: -0.1 },
+        { x: 5, y: 0.1 },
+      ]),
+    ])
+
+    expect(movedTrace.tracePath[1].y).toBe(0)
+    expect(movedTrace.tracePath[2].y).toBe(0)
+  })
+
   test("rejects alignments that would collide with a chip obstacle", () => {
     const [, blockedTrace] = alignNearbySameNetSegments(
       [
@@ -152,6 +176,35 @@ describe("alignNearbySameNetSegments", () => {
 
     expect(blockedTrace.tracePath[1].y).toBe(0.08)
     expect(blockedTrace.tracePath[2].y).toBe(0.08)
+  })
+
+  test("allows alignments that keep an existing chip obstacle collision", () => {
+    const [, movedTrace] = alignNearbySameNetSegments(
+      [
+        trace("a", "net1", [
+          { x: 0, y: -2 },
+          { x: 0, y: 0 },
+          { x: 5, y: 0 },
+          { x: 5, y: 2 },
+        ]),
+        trace("b", "net1", [
+          { x: 3, y: -2 },
+          { x: 3, y: 0.08 },
+          { x: 8, y: 0.08 },
+          { x: 8, y: 2 },
+        ]),
+      ],
+      {
+        inputProblem: problemWithChipObstacle({
+          center: { x: 6, y: 0.04 },
+          width: 1,
+          height: 0.2,
+        }),
+      },
+    )
+
+    expect(movedTrace.tracePath[1].y).toBe(0)
+    expect(movedTrace.tracePath[2].y).toBe(0)
   })
 
   test("renders before and after proof for the nearby same-net alignment", () => {

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -175,6 +175,29 @@ describe("alignNearbySameNetSegments", () => {
     expect(blockedTrace.tracePath[2].y).toBe(0.08)
   })
 
+  test("rejects alignments that introduce a self-intersection", () => {
+    const [, blockedTrace] = alignNearbySameNetSegments([
+      trace("a", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 2 },
+      ]),
+      trace("b", "net1", [
+        { x: 2, y: -2 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: -2 },
+        { x: 5, y: -2 },
+        { x: 5, y: 0.02 },
+        { x: 9, y: 0.02 },
+      ]),
+    ])
+
+    expect(blockedTrace.tracePath[1].y).toBe(0.08)
+    expect(blockedTrace.tracePath[2].y).toBe(0.08)
+  })
+
   test("rejects alignments that would collide with a chip obstacle", () => {
     const [, blockedTrace] = alignNearbySameNetSegments(
       [

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { getSvgFromGraphicsObject, type GraphicsObject } from "graphics-debug"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { alignNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments"
+import type { InputProblem } from "lib/types/InputProblem"
 
 const trace = (
   mspPairId: string,
@@ -124,6 +125,35 @@ describe("alignNearbySameNetSegments", () => {
     expect(blockedTrace.tracePath[2].y).toBe(0.08)
   })
 
+  test("rejects alignments that would collide with a chip obstacle", () => {
+    const [, blockedTrace] = alignNearbySameNetSegments(
+      [
+        trace("a", "net1", [
+          { x: 0, y: -2 },
+          { x: 0, y: 0 },
+          { x: 5, y: 0 },
+          { x: 5, y: 2 },
+        ]),
+        trace("b", "net1", [
+          { x: 3, y: -2 },
+          { x: 3, y: 0.08 },
+          { x: 8, y: 0.08 },
+          { x: 8, y: 2 },
+        ]),
+      ],
+      {
+        inputProblem: problemWithChipObstacle({
+          center: { x: 6, y: 0 },
+          width: 1,
+          height: 0.1,
+        }),
+      },
+    )
+
+    expect(blockedTrace.tracePath[1].y).toBe(0.08)
+    expect(blockedTrace.tracePath[2].y).toBe(0.08)
+  })
+
   test("renders before and after proof for the nearby same-net alignment", () => {
     const inputTraces = [
       trace("a", "net1", [
@@ -196,3 +226,26 @@ const addTraceLines = (
     })
   }
 }
+
+const problemWithChipObstacle = ({
+  center,
+  width,
+  height,
+}: {
+  center: { x: number; y: number }
+  width: number
+  height: number
+}): InputProblem => ({
+  chips: [
+    {
+      chipId: "obstacle",
+      center,
+      width,
+      height,
+      pins: [],
+    },
+  ],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+})

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -140,13 +140,39 @@ describe("alignNearbySameNetSegments", () => {
         { x: 8, y: 2 },
       ]),
       trace("c", "net2", [
-        { x: 5, y: -0.1 },
-        { x: 5, y: 0.1 },
+        { x: 1, y: -1 },
+        { x: 3, y: -1 },
       ]),
     ])
 
     expect(movedTrace.tracePath[1].y).toBe(0)
     expect(movedTrace.tracePath[2].y).toBe(0)
+  })
+
+  test("rejects alignments that add a collision with an already-colliding trace", () => {
+    const [, blockedTrace] = alignNearbySameNetSegments([
+      trace("a", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 2 },
+      ]),
+      trace("b", "net1", [
+        { x: 2, y: -2 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 2 },
+      ]),
+      trace("c", "net2", [
+        { x: 1, y: -1 },
+        { x: 3, y: -1 },
+        { x: 6, y: -1 },
+        { x: 6, y: 0.02 },
+      ]),
+    ])
+
+    expect(blockedTrace.tracePath[1].y).toBe(0.08)
+    expect(blockedTrace.tracePath[2].y).toBe(0.08)
   })
 
   test("rejects alignments that would collide with a chip obstacle", () => {
@@ -196,8 +222,8 @@ describe("alignNearbySameNetSegments", () => {
       ],
       {
         inputProblem: problemWithChipObstacle({
-          center: { x: 6, y: 0.04 },
-          width: 1,
+          center: { x: 3, y: -1 },
+          width: 0.2,
           height: 0.2,
         }),
       },
@@ -205,6 +231,30 @@ describe("alignNearbySameNetSegments", () => {
 
     expect(movedTrace.tracePath[1].y).toBe(0)
     expect(movedTrace.tracePath[2].y).toBe(0)
+  })
+
+  test("aligns more than five independent same-net segment pairs", () => {
+    const traces = alignNearbySameNetSegments([
+      trace("anchor", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 20, y: 0 },
+        { x: 20, y: 2 },
+      ]),
+      ...Array.from({ length: 6 }, (_, index) =>
+        trace(`moved-${index}`, "net1", [
+          { x: index * 2 + 1, y: -2 },
+          { x: index * 2 + 1, y: 0.03 + index * 0.01 },
+          { x: index * 2 + 2, y: 0.03 + index * 0.01 },
+          { x: index * 2 + 2, y: 2 },
+        ]),
+      ),
+    ])
+
+    for (const alignedTrace of traces.slice(1)) {
+      expect(alignedTrace.tracePath[1].y).toBe(0)
+      expect(alignedTrace.tracePath[2].y).toBe(0)
+    }
   })
 
   test("renders before and after proof for the nearby same-net alignment", () => {

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { getSvgFromGraphicsObject, type GraphicsObject } from "graphics-debug"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { alignNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments"
 
@@ -122,4 +123,76 @@ describe("alignNearbySameNetSegments", () => {
     expect(blockedTrace.tracePath[1].y).toBe(0.08)
     expect(blockedTrace.tracePath[2].y).toBe(0.08)
   })
+
+  test("renders before and after proof for the nearby same-net alignment", () => {
+    const inputTraces = [
+      trace("a", "net1", [
+        { x: 0, y: -2 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 2 },
+      ]),
+      trace("b", "net1", [
+        { x: 2, y: -2 },
+        { x: 2, y: 0.08 },
+        { x: 8, y: 0.08 },
+        { x: 8, y: 2 },
+      ]),
+    ]
+    const outputTraces = alignNearbySameNetSegments(inputTraces)
+    const svg = getSvgFromGraphicsObject(
+      renderBeforeAfterProof(inputTraces, outputTraces),
+      {
+        backgroundColor: "white",
+      },
+    )
+
+    expect(svg).toMatchSvgSnapshot(import.meta.path, "before-after")
+  })
 })
+
+const renderBeforeAfterProof = (
+  before: SolvedTracePath[],
+  after: SolvedTracePath[],
+): GraphicsObject => {
+  const graphics: GraphicsObject = {
+    lines: [],
+    texts: [
+      {
+        text: "Before",
+        x: 5,
+        y: -3,
+        fontSize: 0.5,
+      },
+      {
+        text: "After",
+        x: 20,
+        y: -3,
+        fontSize: 0.5,
+      },
+    ],
+  }
+
+  addTraceLines(graphics, before, 0)
+  addTraceLines(graphics, after, 15)
+
+  return graphics
+}
+
+const addTraceLines = (
+  graphics: GraphicsObject,
+  traces: SolvedTracePath[],
+  xOffset: number,
+) => {
+  const colors = ["#1d4ed8", "#dc2626"]
+
+  for (const [index, trace] of traces.entries()) {
+    graphics.lines!.push({
+      points: trace.tracePath.map((point) => ({
+        x: point.x + xOffset,
+        y: point.y,
+      })),
+      strokeColor: colors[index] ?? "#374151",
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- add a final TraceCleanupSolver phase that aligns nearby overlapping internal same-net horizontal/vertical segments onto a shared axis
- preserve endpoint/pin legs and ignore different-net candidates
- reject alignments that would introduce different-net, chip-obstacle, self-intersection, or different-net label collisions
- add focused before/after-style coverage for horizontal, vertical, endpoint, different-net, obstacle, self-collision, label-collision, and collision-guard behavior

/claim #29
/claim #34

## Verification
- bun test tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts tests/examples/example29.test.ts tests/examples/example34.test.ts
- bun test -> 72 pass, 4 skip, 0 fail
- bunx tsc --noEmit
- bun run format:check
- bun run build
- git diff --check