### PR TITLE
fix(post-processing): remove zero-length segments left by diagonal fix

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,6 +4,15 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+const EPS = 1e-6
+
+/**
+ * Returns true when two points are at the same location (zero-length segment).
+ * These arise when the diagonal-fix elbow coincides with an existing point.
+ */
+const isSamePoint = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) < EPS && Math.abs(a.y - b.y) < EPS
+
 export const simplifyPath = (path: Point[]): Point[] => {
   if (path.length < 3) return path
   const newPath: Point[] = [path[0]]
@@ -11,6 +20,10 @@ export const simplifyPath = (path: Point[]): Point[] => {
     const p1 = newPath[newPath.length - 1]
     const p2 = path[i]
     const p3 = path[i + 1]
+    // Drop zero-length points (duplicate consecutive coords)
+    if (isSamePoint(p1, p2) || isSamePoint(p2, p3)) {
+      continue
+    }
     if (
       (isVertical(p1, p2) && isVertical(p2, p3)) ||
       (isHorizontal(p1, p2) && isHorizontal(p2, p3))
@@ -27,6 +40,9 @@ export const simplifyPath = (path: Point[]): Point[] => {
     const p1 = finalPath[finalPath.length - 1]
     const p2 = newPath[i]
     const p3 = newPath[i + 1]
+    if (isSamePoint(p1, p2) || isSamePoint(p2, p3)) {
+      continue
+    }
     if (
       (isVertical(p1, p2) && isVertical(p2, p3)) ||
       (isHorizontal(p1, p2) && isHorizontal(p2, p3))

--- a/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
+++ b/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
@@ -264,6 +264,25 @@ export class TraceOverlapShiftSolver extends BaseSolver {
 
     const elbowPoint = score1 < score2 ? elbow1 : elbow2
 
+    // Skip if the elbow coincides with an existing endpoint -- inserting it
+    // would produce a zero-length segment that confuses downstream solvers.
+    const EPS2 = 2e-3
+    const elbowEqualsP1 =
+      Math.abs(elbowPoint.x - p1.x) < EPS2 &&
+      Math.abs(elbowPoint.y - p1.y) < EPS2
+    const elbowEqualsP2 =
+      Math.abs(elbowPoint.x - p2.x) < EPS2 &&
+      Math.abs(elbowPoint.y - p2.y) < EPS2
+
+    if (elbowEqualsP1 || elbowEqualsP2) {
+      if (elbowEqualsP1) {
+        tracePath[i + 1] = { ...p2, x: p1.x }
+      } else {
+        tracePath[i] = { ...p1, y: p2.y }
+      }
+      return true
+    }
+
     // Replace [p1, p2] with [p1, elbowPoint, p2]
     tracePath.splice(i + 1, 0, elbowPoint)
     return true // Fixed one diagonal, return true to re-evaluate in next step

--- a/tests/solvers/TraceCleanupSolver/simplifyPath-zero-length.test.ts
+++ b/tests/solvers/TraceCleanupSolver/simplifyPath-zero-length.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+test("simplifyPath: removes zero-length segments (duplicate consecutive points)", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ]
+  const result = simplifyPath(path)
+  expect(result.length).toBe(3)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("simplifyPath: removes zero-length segments within tolerance (1e-7)", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 1e-7 },
+    { x: 2, y: 3 },
+  ]
+  const result = simplifyPath(path)
+  expect(result.length).toBeLessThanOrEqual(3)
+})
+
+test("simplifyPath: normal L-shaped path is preserved", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: 4 },
+  ]
+  const result = simplifyPath(path)
+  expect(result).toEqual(path)
+})
+
+test("simplifyPath: collinear middle point is removed", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 1 },
+  ]
+  const result = simplifyPath(path)
+  expect(result.length).toBe(3)
+  expect(result[1]).toEqual({ x: 2, y: 0 })
+})
+
+test("simplifyPath: multiple zero-length duplicates all removed", () => {
+  const path = [
+    { x: 0, y: 0 },
+    { x: 5, y: 0 },
+    { x: 5, y: 0 },
+    { x: 5, y: 0 },
+    { x: 5, y: 3 },
+  ]
+  const result = simplifyPath(path)
+  expect(result.length).toBe(3)
+})


### PR DESCRIPTION
Closes #78

## Root cause

`TraceOverlapShiftSolver.findAndFixNextDiagonalSegment` fixes diagonal
segments by inserting an `elbowPoint` via `splice()`. When the diagonal
is near-zero length, the chosen elbow can coincide with `p1` or `p2`,
producing a **zero-length segment**. `simplifyPath` only removed
collinear points — it never checked for duplicate consecutive coords —
so the spurious segment survived into the final output as an extra trace
line.

## Fix

**Fix 1 — `simplifyPath.ts`**: added `isSamePoint()` guard (tolerance
`1e-6`) that drops zero-length points in both simplification passes.

**Fix 2 — `TraceOverlapShiftSolver.ts`**: before calling `splice()`,
detect when the elbow equals `p1` or `p2` and snap the existing
endpoint instead of inserting a duplicate.

## Tests added

5 unit tests in `tests/solvers/TraceCleanupSolver/simplifyPath-zero-length.test.ts`:
- duplicate consecutive points removed ✅
- near-zero tolerance (1e-7) handled ✅
- valid L-shaped path preserved ✅
- collinear middle point removed ✅
- multiple consecutive duplicates removed ✅