### PR TITLE
Add same-net trace segment alignment

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,6 +20,7 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { alignNearbySameNetSegments } from "./alignNearbySameNetSegments"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "aligning_same_net_segments"
   | "untangling_traces"
 
 /**
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "aligning_same_net_segments":
+        this._runAlignSameNetSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +113,20 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "aligning_same_net_segments"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runAlignSameNetSegmentsStep() {
+    this.outputTraces = alignNearbySameNetSegments(
+      Array.from(this.tracesMap.values()),
+      { tolerance: this.input.paddingBuffer * 1.5 },
+    )
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -123,7 +123,11 @@ export class TraceCleanupSolver extends BaseSolver {
   private _runAlignSameNetSegmentsStep() {
     this.outputTraces = alignNearbySameNetSegments(
       Array.from(this.tracesMap.values()),
-      { tolerance: this.input.paddingBuffer * 1.5 },
+      {
+        tolerance: this.input.paddingBuffer * 1.5,
+        inputProblem: this.input.inputProblem,
+        allLabelPlacements: this.input.allLabelPlacements,
+      },
     )
     this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
     this.solved = true

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -1,5 +1,7 @@
 import type { Point } from "@tscircuit/math-utils"
 import { doSegmentsIntersect } from "@tscircuit/math-utils"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { simplifyPath } from "./simplifyPath"
 
@@ -11,6 +13,13 @@ type SegmentInfo = {
   min: number
   max: number
   length: number
+}
+
+type Rect = {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
 }
 
 const EPS = 1e-6
@@ -109,6 +118,99 @@ const moveSegmentToFixedCoord = (
   return simplifyPath(path)
 }
 
+const isPointInsideRect = (point: Point, rect: Rect): boolean =>
+  point.x > rect.minX + EPS &&
+  point.x < rect.maxX - EPS &&
+  point.y > rect.minY + EPS &&
+  point.y < rect.maxY - EPS
+
+const segmentIntersectsRectInterior = (
+  a: Point,
+  b: Point,
+  rect: Rect,
+): boolean => {
+  if (isPointInsideRect(a, rect) || isPointInsideRect(b, rect)) return true
+
+  const left = rect.minX
+  const right = rect.maxX
+  const top = rect.minY
+  const bottom = rect.maxY
+
+  if (Math.abs(a.y - b.y) < EPS) {
+    const y = a.y
+    if (y <= top + EPS || y >= bottom - EPS) return false
+    return Math.max(Math.min(a.x, b.x), left) < Math.min(Math.max(a.x, b.x), right) - EPS
+  }
+
+  if (Math.abs(a.x - b.x) < EPS) {
+    const x = a.x
+    if (x <= left + EPS || x >= right - EPS) return false
+    return Math.max(Math.min(a.y, b.y), top) < Math.min(Math.max(a.y, b.y), bottom) - EPS
+  }
+
+  return false
+}
+
+const pathIntersectsBlocker = (path: Point[], blockers: Rect[]): boolean => {
+  if (blockers.length === 0) return false
+
+  for (let i = 0; i < path.length - 1; i++) {
+    const a = path[i]!
+    const b = path[i + 1]!
+    for (const blocker of blockers) {
+      if (segmentIntersectsRectInterior(a, b, blocker)) return true
+    }
+  }
+
+  return false
+}
+
+const pathSelfIntersects = (path: Point[]): boolean => {
+  for (let i = 0; i < path.length - 1; i++) {
+    const a1 = path[i]!
+    const a2 = path[i + 1]!
+
+    for (let j = i + 2; j < path.length - 1; j++) {
+      const b1 = path[j]!
+      const b2 = path[j + 1]!
+      if (doSegmentsIntersect(a1, a2, b1, b2)) return true
+    }
+  }
+
+  return false
+}
+
+const blockerRectsFromInput = (
+  inputProblem?: InputProblem,
+  allLabelPlacements: NetLabelPlacement[] = [],
+): Rect[] => {
+  const rects: Rect[] = []
+
+  for (const chip of inputProblem?.chips ?? []) {
+    const halfWidth = chip.width / 2
+    const halfHeight = chip.height / 2
+    rects.push({
+      minX: chip.center.x - halfWidth,
+      maxX: chip.center.x + halfWidth,
+      minY: chip.center.y - halfHeight,
+      maxY: chip.center.y + halfHeight,
+    })
+  }
+
+  for (const label of allLabelPlacements) {
+    const halfWidth = label.width / 2
+    const halfHeight = label.height / 2
+    rects.push({
+      minX: label.center.x - halfWidth,
+      maxX: label.center.x + halfWidth,
+      minY: label.center.y - halfHeight,
+      maxY: label.center.y + halfHeight,
+    })
+  }
+
+  return rects
+}
+
 const intersectsDifferentNet = (
   candidateTrace: SolvedTracePath,
   allTraces: SolvedTracePath[],
@@ -145,10 +247,20 @@ const intersectsDifferentNet = (
 
 export const alignNearbySameNetSegments = (
   traces: SolvedTracePath[],
-  opts: { tolerance?: number; maxPasses?: number } = {},
+  opts: {
+    tolerance?: number
+    maxPasses?: number
+    inputProblem?: InputProblem
+    allLabelPlacements?: NetLabelPlacement[]
+    blockers?: Rect[]
+  } = {},
 ): SolvedTracePath[] => {
   const tolerance = opts.tolerance ?? 0.15
   const maxPasses = opts.maxPasses ?? 8
+  const blockers = [
+    ...blockerRectsFromInput(opts.inputProblem, opts.allLabelPlacements),
+    ...(opts.blockers ?? []),
+  ]
   let output = traces.map((trace) => ({
     ...trace,
     tracePath: clonePath(trace.tracePath),
@@ -183,6 +295,8 @@ export const alignNearbySameNetSegments = (
         )
 
         if (!isOrthogonalPath(candidatePath)) continue
+        if (pathSelfIntersects(candidatePath)) continue
+        if (pathIntersectsBlocker(candidatePath, blockers)) continue
 
         const candidateTrace = {
           ...movingTrace,

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -1,0 +1,205 @@
+import type { Point } from "@tscircuit/math-utils"
+import { doSegmentsIntersect } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+type SegmentInfo = {
+  traceIndex: number
+  pointIndex: number
+  orientation: "horizontal" | "vertical"
+  fixedCoord: number
+  min: number
+  max: number
+  length: number
+}
+
+const EPS = 1e-6
+
+const getSegmentInfo = (
+  traceIndex: number,
+  trace: SolvedTracePath,
+  pointIndex: number,
+): SegmentInfo | null => {
+  const a = trace.tracePath[pointIndex]
+  const b = trace.tracePath[pointIndex + 1]
+  if (!a || !b) return null
+
+  const isHorizontal = Math.abs(a.y - b.y) < EPS
+  const isVertical = Math.abs(a.x - b.x) < EPS
+  if (!isHorizontal && !isVertical) return null
+
+  if (isHorizontal) {
+    return {
+      traceIndex,
+      pointIndex,
+      orientation: "horizontal",
+      fixedCoord: a.y,
+      min: Math.min(a.x, b.x),
+      max: Math.max(a.x, b.x),
+      length: Math.abs(a.x - b.x),
+    }
+  }
+
+  return {
+    traceIndex,
+    pointIndex,
+    orientation: "vertical",
+    fixedCoord: a.x,
+    min: Math.min(a.y, b.y),
+    max: Math.max(a.y, b.y),
+    length: Math.abs(a.y - b.y),
+  }
+}
+
+const getInternalAxisAlignedSegments = (
+  traces: SolvedTracePath[],
+): SegmentInfo[] => {
+  const segments: SegmentInfo[] = []
+
+  for (let traceIndex = 0; traceIndex < traces.length; traceIndex++) {
+    const trace = traces[traceIndex]!
+    for (
+      let pointIndex = 1;
+      pointIndex < trace.tracePath.length - 2;
+      pointIndex++
+    ) {
+      const segment = getSegmentInfo(traceIndex, trace, pointIndex)
+      if (segment && segment.length > EPS) {
+        segments.push(segment)
+      }
+    }
+  }
+
+  return segments
+}
+
+const rangesOverlap = (a: SegmentInfo, b: SegmentInfo): boolean =>
+  Math.min(a.max, b.max) - Math.max(a.min, b.min) > EPS
+
+const clonePath = (path: Point[]): Point[] => path.map((p) => ({ ...p }))
+
+const isOrthogonalPath = (path: Point[]): boolean => {
+  for (let i = 0; i < path.length - 1; i++) {
+    const a = path[i]!
+    const b = path[i + 1]!
+    if (Math.abs(a.x - b.x) >= EPS && Math.abs(a.y - b.y) >= EPS) {
+      return false
+    }
+  }
+  return true
+}
+
+const moveSegmentToFixedCoord = (
+  trace: SolvedTracePath,
+  segment: SegmentInfo,
+  fixedCoord: number,
+): Point[] => {
+  const path = clonePath(trace.tracePath)
+  const a = path[segment.pointIndex]!
+  const b = path[segment.pointIndex + 1]!
+
+  if (segment.orientation === "horizontal") {
+    a.y = fixedCoord
+    b.y = fixedCoord
+  } else {
+    a.x = fixedCoord
+    b.x = fixedCoord
+  }
+
+  return simplifyPath(path)
+}
+
+const intersectsDifferentNet = (
+  candidateTrace: SolvedTracePath,
+  allTraces: SolvedTracePath[],
+): boolean => {
+  for (let i = 0; i < candidateTrace.tracePath.length - 1; i++) {
+    const a1 = candidateTrace.tracePath[i]!
+    const a2 = candidateTrace.tracePath[i + 1]!
+
+    for (const otherTrace of allTraces) {
+      if (
+        otherTrace.mspPairId === candidateTrace.mspPairId ||
+        otherTrace.globalConnNetId === candidateTrace.globalConnNetId
+      ) {
+        continue
+      }
+
+      for (let j = 0; j < otherTrace.tracePath.length - 1; j++) {
+        if (
+          doSegmentsIntersect(
+            a1,
+            a2,
+            otherTrace.tracePath[j]!,
+            otherTrace.tracePath[j + 1]!,
+          )
+        ) {
+          return true
+        }
+      }
+    }
+  }
+
+  return false
+}
+
+export const alignNearbySameNetSegments = (
+  traces: SolvedTracePath[],
+  opts: { tolerance?: number; maxPasses?: number } = {},
+): SolvedTracePath[] => {
+  const tolerance = opts.tolerance ?? 0.15
+  const maxPasses = opts.maxPasses ?? 8
+  let output = traces.map((trace) => ({
+    ...trace,
+    tracePath: clonePath(trace.tracePath),
+  }))
+
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let changed = false
+    const segments = getInternalAxisAlignedSegments(output)
+
+    for (let i = 0; i < segments.length; i++) {
+      for (let j = i + 1; j < segments.length; j++) {
+        const a = segments[i]!
+        const b = segments[j]!
+        const traceA = output[a.traceIndex]!
+        const traceB = output[b.traceIndex]!
+
+        if (traceA.mspPairId === traceB.mspPairId) continue
+        if (traceA.globalConnNetId !== traceB.globalConnNetId) continue
+        if (a.orientation !== b.orientation) continue
+        if (!rangesOverlap(a, b)) continue
+
+        const distance = Math.abs(a.fixedCoord - b.fixedCoord)
+        if (distance < EPS || distance > tolerance) continue
+
+        const [movingSegment, anchorSegment] =
+          a.length <= b.length ? [a, b] : [b, a]
+        const movingTrace = output[movingSegment.traceIndex]!
+        const candidatePath = moveSegmentToFixedCoord(
+          movingTrace,
+          movingSegment,
+          anchorSegment.fixedCoord,
+        )
+
+        if (!isOrthogonalPath(candidatePath)) continue
+
+        const candidateTrace = {
+          ...movingTrace,
+          tracePath: candidatePath,
+        }
+
+        if (intersectsDifferentNet(candidateTrace, output)) continue
+
+        output[movingSegment.traceIndex] = candidateTrace
+        changed = true
+        break
+      }
+      if (changed) break
+    }
+
+    if (!changed) break
+  }
+
+  return output
+}

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -139,13 +139,19 @@ const segmentIntersectsRectInterior = (
   if (Math.abs(a.y - b.y) < EPS) {
     const y = a.y
     if (y <= top + EPS || y >= bottom - EPS) return false
-    return Math.max(Math.min(a.x, b.x), left) < Math.min(Math.max(a.x, b.x), right) - EPS
+    return (
+      Math.max(Math.min(a.x, b.x), left) <
+      Math.min(Math.max(a.x, b.x), right) - EPS
+    )
   }
 
   if (Math.abs(a.x - b.x) < EPS) {
     const x = a.x
     if (x <= left + EPS || x >= right - EPS) return false
-    return Math.max(Math.min(a.y, b.y), top) < Math.min(Math.max(a.y, b.y), bottom) - EPS
+    return (
+      Math.max(Math.min(a.y, b.y), top) <
+      Math.min(Math.max(a.y, b.y), bottom) - EPS
+    )
   }
 
   return false

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "bun:test"
+import { alignNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  id: string,
+  netId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [] as any,
+    pinIds: [],
+    mspConnectionPairIds: [id],
+    tracePath,
+  }) as SolvedTracePath
+
+test("alignNearbySameNetSegments aligns close overlapping same-net internal segments", () => {
+  const traces = [
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 2 },
+    ]),
+    makeTrace("b", "net1", [
+      { x: 1, y: 3 },
+      { x: 1, y: 1.08 },
+      { x: 3, y: 1.08 },
+      { x: 3, y: 4 },
+    ]),
+  ]
+
+  const output = alignNearbySameNetSegments(traces, { tolerance: 0.1 })
+
+  expect(output[1]!.tracePath[1]!.y).toBe(1)
+  expect(output[1]!.tracePath[2]!.y).toBe(1)
+})
+
+test("alignNearbySameNetSegments does not align different nets", () => {
+  const traces = [
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 2 },
+    ]),
+    makeTrace("b", "net2", [
+      { x: 1, y: 3 },
+      { x: 1, y: 1.08 },
+      { x: 3, y: 1.08 },
+      { x: 3, y: 4 },
+    ]),
+  ]
+
+  const output = alignNearbySameNetSegments(traces, { tolerance: 0.1 })
+
+  expect(output[1]!.tracePath[1]!.y).toBe(1.08)
+  expect(output[1]!.tracePath[2]!.y).toBe(1.08)
+})
+
+test("alignNearbySameNetSegments leaves endpoint-only segments anchored", () => {
+  const traces = [
+    makeTrace("a", "net1", [
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 2 },
+    ]),
+    makeTrace("b", "net1", [
+      { x: 1, y: 1.08 },
+      { x: 3, y: 1.08 },
+      { x: 3, y: 4 },
+    ]),
+  ]
+
+  const output = alignNearbySameNetSegments(traces, { tolerance: 0.1 })
+
+  expect(output[1]!.tracePath[0]!.y).toBe(1.08)
+  expect(output[1]!.tracePath[1]!.y).toBe(1.08)
+})
+
+test("alignNearbySameNetSegments rejects moves that intersect a different net", () => {
+  const traces = [
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 2 },
+    ]),
+    makeTrace("b", "net1", [
+      { x: 1, y: 3 },
+      { x: 1, y: 1.08 },
+      { x: 3, y: 1.08 },
+      { x: 3, y: 4 },
+    ]),
+    makeTrace("c", "net2", [
+      { x: 2, y: 0.5 },
+      { x: 2, y: 1.04 },
+      { x: 2.5, y: 1.04 },
+    ]),
+  ]
+
+  const output = alignNearbySameNetSegments(traces, { tolerance: 0.1 })
+
+  expect(output[1]!.tracePath[1]!.y).toBe(1.08)
+  expect(output[1]!.tracePath[2]!.y).toBe(1.08)
+})

--- a/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/alignNearbySameNetSegments.test.ts
@@ -107,3 +107,52 @@ test("alignNearbySameNetSegments rejects moves that intersect a different net", 
   expect(output[1]!.tracePath[1]!.y).toBe(1.08)
   expect(output[1]!.tracePath[2]!.y).toBe(1.08)
 })
+
+test("alignNearbySameNetSegments rejects moves through blocker rectangles", () => {
+  const traces = [
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 2 },
+    ]),
+    makeTrace("b", "net1", [
+      { x: 1, y: 3 },
+      { x: 1, y: 1.08 },
+      { x: 3, y: 1.08 },
+      { x: 3, y: 4 },
+    ]),
+  ]
+
+  const output = alignNearbySameNetSegments(traces, {
+    tolerance: 0.1,
+    blockers: [{ minX: 1.5, maxX: 2.5, minY: 0.9, maxY: 1.1 }],
+  })
+
+  expect(output[1]!.tracePath[1]!.y).toBe(1.08)
+  expect(output[1]!.tracePath[2]!.y).toBe(1.08)
+})
+
+test("alignNearbySameNetSegments rejects self-intersecting candidate paths", () => {
+  const traces = [
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 4, y: 1 },
+      { x: 4, y: 2 },
+    ]),
+    makeTrace("b", "net1", [
+      { x: 3, y: 0 },
+      { x: 3, y: 1.08 },
+      { x: 1, y: 1.08 },
+      { x: 1, y: 0.5 },
+      { x: 4, y: 0.5 },
+      { x: 4, y: 2 },
+    ]),
+  ]
+
+  const output = alignNearbySameNetSegments(traces, { tolerance: 0.1 })
+
+  expect(output[1]!.tracePath[1]!.y).toBe(1.08)
+  expect(output[1]!.tracePath[2]!.y).toBe(1.08)
+})


### PR DESCRIPTION
/claim #29
/claim #34

## Summary
- Add a final TraceCleanupSolver phase that aligns nearby overlapping internal H/V segments sharing the same `globalConnNetId`.
- Preserve endpoint-only segments so pin anchors do not drift.
- Reject candidate alignments that would introduce intersections with different-net traces.
- Add focused regression tests for same-net alignment, different-net no-op, endpoint preservation, and collision rejection.

This covers both:
- #29: combine same-net trace segments that are close together
- #34: merge same-net trace lines close together onto the same Y or same X

## Verification
- `bun test tests\solvers\TraceCleanupSolver\alignNearbySameNetSegments.test.ts tests\examples\example29.test.ts tests\examples\example34.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

Note: `bun run format:check` failed locally on the repo-wide baseline CRLF/LF formatting mismatch across existing files; touched files were formatted with Biome directly. Remote CI format-check passes on this PR.