### PR TITLE
TraceCleanupSolver: merge close same-net trace segments (#34)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,6 +20,7 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { mergeCloseSameNetTraces } from "./mergeCloseSameNetTraces"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -28,6 +29,7 @@ type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
+  | "merging_close_same_net_traces"
 
 /**
  * The TraceCleanupSolver is responsible for improving the aesthetics and readability of schematic traces.
@@ -66,10 +68,10 @@ export class TraceCleanupSolver extends BaseSolver {
         this.outputTraces = output.traces
         this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "merging_close_same_net_traces"
       } else if (this.activeSubSolver.failed) {
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "merging_close_same_net_traces"
       }
       return
     }
@@ -78,6 +80,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "untangling_traces":
         this._runUntangleTracesStep()
         break
+      case "merging_close_same_net_traces":
+        this._runMergeCloseSameNetTracesStep()
+        break
       case "minimizing_turns":
         this._runMinimizeTurnsStep()
         break
@@ -85,6 +90,17 @@ export class TraceCleanupSolver extends BaseSolver {
         this._runBalanceLShapesStep()
         break
     }
+  }
+
+  private _runMergeCloseSameNetTracesStep() {
+    const merged = mergeCloseSameNetTraces({
+      traces: Array.from(this.tracesMap.values()),
+      paddingBuffer: this.input.paddingBuffer,
+    })
+    this.outputTraces = merged
+    this.tracesMap = new Map(merged.map((t) => [t.mspPairId, t]))
+    this.traceIdQueue = Array.from(merged.map((e) => e.mspPairId))
+    this.pipelineStep = "minimizing_turns"
   }
 
   private _runUntangleTracesStep() {

--- a/lib/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.ts
@@ -63,12 +63,13 @@ const snapVerticalSegment = (path: Point[], segStart: number, x: number) => {
  * touch chip pins and shifting them would disconnect the trace.
  *
  * @param traces          all SolvedTracePaths in the schematic
- * @param paddingBuffer   the upstream channel-spacing constant; the merge
- *                        threshold defaults to this value because the
- *                        TraceOverlapShiftSolver only ever shifts parallel
- *                        traces by `paddingBuffer`, so any offset ≤ that
- *                        amount is exactly the cosmetic gap we want to
- *                        collapse for same-net traces.
+ * @param paddingBuffer   the upstream channel-spacing constant. The merge
+ *                        threshold defaults to half of this so we only
+ *                        collapse offsets STRICTLY tighter than the
+ *                        intentional channel spacing — anything at or
+ *                        beyond `paddingBuffer` was placed there
+ *                        deliberately by TraceOverlapShiftSolver and must
+ *                        not be reverted.
  * @param mergeDistance   optional explicit override of the threshold
  *
  * @returns               new traces array; inputs are not mutated.
@@ -82,7 +83,7 @@ export const mergeCloseSameNetTraces = ({
   paddingBuffer: number
   mergeDistance?: number
 }): SolvedTracePath[] => {
-  const threshold = mergeDistance ?? paddingBuffer
+  const threshold = mergeDistance ?? paddingBuffer * 0.5
   if (threshold <= 0 || traces.length < 2) return traces
 
   // Deep-copy each tracePath so mutations stay local.

--- a/lib/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.ts
@@ -1,0 +1,171 @@
+import type { Point } from "graphics-debug"
+import {
+  isHorizontal,
+  isVertical,
+} from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+import { simplifyPath } from "./simplifyPath"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const EPS = 1e-5
+
+interface HSegment {
+  orient: "H"
+  y: number
+  xMin: number
+  xMax: number
+  traceIdx: number
+  segStart: number
+}
+
+interface VSegment {
+  orient: "V"
+  x: number
+  yMin: number
+  yMax: number
+  traceIdx: number
+  segStart: number
+}
+
+type Segment = HSegment | VSegment
+
+const snapHorizontalSegment = (path: Point[], segStart: number, y: number) => {
+  path[segStart] = { ...path[segStart], y }
+  path[segStart + 1] = { ...path[segStart + 1], y }
+}
+
+const snapVerticalSegment = (path: Point[], segStart: number, x: number) => {
+  path[segStart] = { ...path[segStart], x }
+  path[segStart + 1] = { ...path[segStart + 1], x }
+}
+
+/**
+ * Collapse parallel same-net trace segments that sit close together onto a
+ * single shared coordinate.
+ *
+ * After the SchematicTraceLinesSolver + TraceOverlapShiftSolver pipeline,
+ * two traces belonging to the same electrical net can end up running
+ * parallel at a small offset — visually this reads as two near-overlapping
+ * wires instead of a single trunk. Since the traces are electrically the
+ * same net, merging them onto a shared X or Y removes the visual
+ * duplication without changing connectivity.
+ *
+ * Algorithm:
+ *   1. Group traces by `dcConnNetId` (the direct-connection net id).
+ *   2. Enumerate every axis-aligned segment in each group.
+ *   3. For each pair of co-net same-orientation segments that
+ *        (a) have a perpendicular offset > EPS but ≤ threshold, and
+ *        (b) overlap in their parallel axis,
+ *      snap both segments to the midpoint between them.
+ *   4. Pass each resulting path through simplifyPath() to collapse
+ *      collinear/duplicate corners produced by the snap.
+ *
+ * Endpoint corners (path[0] and path[length-1]) are never moved — those
+ * touch chip pins and shifting them would disconnect the trace.
+ *
+ * @param traces          all SolvedTracePaths in the schematic
+ * @param paddingBuffer   the upstream channel-spacing constant; the merge
+ *                        threshold defaults to this value because the
+ *                        TraceOverlapShiftSolver only ever shifts parallel
+ *                        traces by `paddingBuffer`, so any offset ≤ that
+ *                        amount is exactly the cosmetic gap we want to
+ *                        collapse for same-net traces.
+ * @param mergeDistance   optional explicit override of the threshold
+ *
+ * @returns               new traces array; inputs are not mutated.
+ */
+export const mergeCloseSameNetTraces = ({
+  traces,
+  paddingBuffer,
+  mergeDistance,
+}: {
+  traces: SolvedTracePath[]
+  paddingBuffer: number
+  mergeDistance?: number
+}): SolvedTracePath[] => {
+  const threshold = mergeDistance ?? paddingBuffer
+  if (threshold <= 0 || traces.length < 2) return traces
+
+  // Deep-copy each tracePath so mutations stay local.
+  const newPaths: Point[][] = traces.map((t) =>
+    t.tracePath.map((p) => ({ x: p.x, y: p.y })),
+  )
+
+  const groups = new Map<string, number[]>()
+  for (let i = 0; i < traces.length; i++) {
+    const key = traces[i].dcConnNetId
+    if (!key) continue
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(i)
+  }
+
+  for (const indices of groups.values()) {
+    if (indices.length < 2) continue
+
+    const segments: Segment[] = []
+    for (const idx of indices) {
+      const path = newPaths[idx]
+      // Skip endpoint segments — those terminate at chip pins.
+      for (let s = 1; s < path.length - 2; s++) {
+        const a = path[s]
+        const b = path[s + 1]
+        if (isHorizontal(a, b)) {
+          segments.push({
+            orient: "H",
+            y: (a.y + b.y) / 2,
+            xMin: Math.min(a.x, b.x),
+            xMax: Math.max(a.x, b.x),
+            traceIdx: idx,
+            segStart: s,
+          })
+        } else if (isVertical(a, b)) {
+          segments.push({
+            orient: "V",
+            x: (a.x + b.x) / 2,
+            yMin: Math.min(a.y, b.y),
+            yMax: Math.max(a.y, b.y),
+            traceIdx: idx,
+            segStart: s,
+          })
+        }
+      }
+    }
+
+    for (let i = 0; i < segments.length; i++) {
+      for (let j = i + 1; j < segments.length; j++) {
+        const s1 = segments[i]
+        const s2 = segments[j]
+        if (s1.orient !== s2.orient) continue
+        if (s1.traceIdx === s2.traceIdx && s1.segStart === s2.segStart) continue
+
+        if (s1.orient === "H" && s2.orient === "H") {
+          const dy = Math.abs(s1.y - s2.y)
+          if (dy < EPS || dy > threshold) continue
+          const overlapMin = Math.max(s1.xMin, s2.xMin)
+          const overlapMax = Math.min(s1.xMax, s2.xMax)
+          if (overlapMax - overlapMin <= EPS) continue
+          const midY = (s1.y + s2.y) / 2
+          snapHorizontalSegment(newPaths[s1.traceIdx], s1.segStart, midY)
+          snapHorizontalSegment(newPaths[s2.traceIdx], s2.segStart, midY)
+          s1.y = midY
+          s2.y = midY
+        } else if (s1.orient === "V" && s2.orient === "V") {
+          const dx = Math.abs(s1.x - s2.x)
+          if (dx < EPS || dx > threshold) continue
+          const overlapMin = Math.max(s1.yMin, s2.yMin)
+          const overlapMax = Math.min(s1.yMax, s2.yMax)
+          if (overlapMax - overlapMin <= EPS) continue
+          const midX = (s1.x + s2.x) / 2
+          snapVerticalSegment(newPaths[s1.traceIdx], s1.segStart, midX)
+          snapVerticalSegment(newPaths[s2.traceIdx], s2.segStart, midX)
+          s1.x = midX
+          s2.x = midX
+        }
+      }
+    }
+  }
+
+  return traces.map((t, i) => ({
+    ...t,
+    tracePath: simplifyPath(newPaths[i]),
+  }))
+}

--- a/tests/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.test.ts
@@ -24,16 +24,16 @@ const stub = (
 
 describe("mergeCloseSameNetTraces", () => {
   test("snaps two same-net horizontal segments offset less than the threshold", () => {
-    // Trace A: pin at (0,0) → corner (5, 0) → corner (5, 4.9) → corner (10, 4.9) → pin (10, 4.9)
-    // Trace B: pin at (0,0.5) → corner (5,0.5) → corner (5, 5.1) → corner (10, 5.1) → pin (10, 5.1)
-    // The middle horizontal segments at y=4.9 and y=5.1 are 0.2 apart, same net.
-    // With paddingBuffer = 0.4, the threshold = 0.4, so they should snap to y=5.0.
+    // Trace A: pin (0,0) -> corner (5,0) -> corner (5,4.9) -> pin (10,4.9)
+    // Trace B: pin (0,0.5) -> corner (5,0.5) -> corner (5,5.1) -> pin (10,5.1)
+    // Middle horizontal segments at y=4.9 and y=5.1 are 0.2 apart, same net.
+    // With paddingBuffer = 0.5, the default threshold = 0.25, so 0.2 < 0.25
+    // and the two segments should snap to the shared midpoint y=5.0.
     const traces = [
       stub("A", "net1", [
         { x: 0, y: 0 },
         { x: 5, y: 0 },
         { x: 5, y: 4.9 },
-        { x: 10, y: 4.9 },
         { x: 10, y: 4.9 },
       ]),
       stub("B", "net1", [
@@ -41,21 +41,17 @@ describe("mergeCloseSameNetTraces", () => {
         { x: 5, y: 0.5 },
         { x: 5, y: 5.1 },
         { x: 10, y: 5.1 },
-        { x: 10, y: 5.1 },
       ]),
     ]
 
-    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.5 })
 
-    // Both interior horizontal segments should now sit at the midpoint y=5.0.
-    const aMid = out[0].tracePath.find((p, i, arr) =>
-      i > 0 && Math.abs(arr[i - 1].y - p.y) < 1e-6 && p.x !== arr[i - 1].x,
-    )
-    const bMid = out[1].tracePath.find((p, i, arr) =>
-      i > 0 && Math.abs(arr[i - 1].y - p.y) < 1e-6 && p.x !== arr[i - 1].x,
-    )
-    expect(aMid?.y).toBeCloseTo(5.0, 6)
-    expect(bMid?.y).toBeCloseTo(5.0, 6)
+    // The third tracePath entry is the start corner of the middle horizontal
+    // segment in each path (path[2]); after snap it sits at y=5.0.
+    expect(out[0].tracePath[2].y).toBeCloseTo(5.0, 6)
+    expect(out[0].tracePath[3].y).toBeCloseTo(5.0, 6)
+    expect(out[1].tracePath[2].y).toBeCloseTo(5.0, 6)
+    expect(out[1].tracePath[3].y).toBeCloseTo(5.0, 6)
   })
 
   test("does NOT snap segments belonging to different nets", () => {
@@ -76,7 +72,7 @@ describe("mergeCloseSameNetTraces", () => {
       ]),
     ]
 
-    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.5 })
 
     // y values of the middle segment should be unchanged.
     expect(out[0].tracePath[2].y).toBeCloseTo(4.9, 6)
@@ -102,7 +98,7 @@ describe("mergeCloseSameNetTraces", () => {
       ]),
     ]
 
-    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.5 })
 
     expect(out[0].tracePath[2].y).toBeCloseTo(2, 6)
     expect(out[1].tracePath[2].y).toBeCloseTo(8, 6)
@@ -127,7 +123,7 @@ describe("mergeCloseSameNetTraces", () => {
       ]),
     ]
 
-    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.5 })
 
     // After snap, the vertical-segment x should be midpoint 5.0.
     expect(out[0].tracePath[2].x).toBeCloseTo(5.0, 6)
@@ -149,7 +145,7 @@ describe("mergeCloseSameNetTraces", () => {
       ]),
     ]
 
-    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.5 })
 
     // Both endpoints touch pins → no snap.
     expect(out[0].tracePath[0].y).toBe(0.0)
@@ -170,7 +166,7 @@ describe("mergeCloseSameNetTraces", () => {
       ]),
     ]
 
-    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.5 })
     expect(out[0].tracePath).toEqual(traces[0].tracePath)
     expect(out[1].tracePath).toEqual(traces[1].tracePath)
   })

--- a/tests/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test"
+import { mergeCloseSameNetTraces } from "lib/solvers/TraceCleanupSolver/mergeCloseSameNetTraces"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+/**
+ * Build a minimal SolvedTracePath stub. The cleanup-pass merge logic only
+ * touches `tracePath` and reads `dcConnNetId`, so we don't need the full
+ * MspConnectionPair to exercise the behaviour.
+ */
+const stub = (
+  id: string,
+  netId: string,
+  tracePath: { x: number; y: number }[],
+): SolvedTracePath =>
+  ({
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [] as any,
+    mspConnectionPairIds: [id],
+    pinIds: [],
+    tracePath,
+  }) as unknown as SolvedTracePath
+
+describe("mergeCloseSameNetTraces", () => {
+  test("snaps two same-net horizontal segments offset less than the threshold", () => {
+    // Trace A: pin at (0,0) → corner (5, 0) → corner (5, 4.9) → corner (10, 4.9) → pin (10, 4.9)
+    // Trace B: pin at (0,0.5) → corner (5,0.5) → corner (5, 5.1) → corner (10, 5.1) → pin (10, 5.1)
+    // The middle horizontal segments at y=4.9 and y=5.1 are 0.2 apart, same net.
+    // With paddingBuffer = 0.4, the threshold = 0.4, so they should snap to y=5.0.
+    const traces = [
+      stub("A", "net1", [
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+        { x: 5, y: 4.9 },
+        { x: 10, y: 4.9 },
+        { x: 10, y: 4.9 },
+      ]),
+      stub("B", "net1", [
+        { x: 0, y: 0.5 },
+        { x: 5, y: 0.5 },
+        { x: 5, y: 5.1 },
+        { x: 10, y: 5.1 },
+        { x: 10, y: 5.1 },
+      ]),
+    ]
+
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+
+    // Both interior horizontal segments should now sit at the midpoint y=5.0.
+    const aMid = out[0].tracePath.find((p, i, arr) =>
+      i > 0 && Math.abs(arr[i - 1].y - p.y) < 1e-6 && p.x !== arr[i - 1].x,
+    )
+    const bMid = out[1].tracePath.find((p, i, arr) =>
+      i > 0 && Math.abs(arr[i - 1].y - p.y) < 1e-6 && p.x !== arr[i - 1].x,
+    )
+    expect(aMid?.y).toBeCloseTo(5.0, 6)
+    expect(bMid?.y).toBeCloseTo(5.0, 6)
+  })
+
+  test("does NOT snap segments belonging to different nets", () => {
+    const traces = [
+      stub("A", "net1", [
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+        { x: 5, y: 4.9 },
+        { x: 10, y: 4.9 },
+        { x: 10, y: 4.9 },
+      ]),
+      stub("B", "net2", [
+        { x: 0, y: 0.5 },
+        { x: 5, y: 0.5 },
+        { x: 5, y: 5.1 },
+        { x: 10, y: 5.1 },
+        { x: 10, y: 5.1 },
+      ]),
+    ]
+
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+
+    // y values of the middle segment should be unchanged.
+    expect(out[0].tracePath[2].y).toBeCloseTo(4.9, 6)
+    expect(out[1].tracePath[2].y).toBeCloseTo(5.1, 6)
+  })
+
+  test("does NOT snap parallel segments that are farther apart than the threshold", () => {
+    // Same net, but segments at y=2 and y=8 — way beyond the merge gap.
+    const traces = [
+      stub("A", "net1", [
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+        { x: 5, y: 2 },
+        { x: 10, y: 2 },
+        { x: 10, y: 2 },
+      ]),
+      stub("B", "net1", [
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+        { x: 5, y: 8 },
+        { x: 10, y: 8 },
+        { x: 10, y: 8 },
+      ]),
+    ]
+
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+
+    expect(out[0].tracePath[2].y).toBeCloseTo(2, 6)
+    expect(out[1].tracePath[2].y).toBeCloseTo(8, 6)
+  })
+
+  test("snaps two same-net vertical segments offset less than the threshold", () => {
+    // Vertical analogue: middle vertical segments at x=4.9 and x=5.1, same net.
+    const traces = [
+      stub("A", "net1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 5 },
+        { x: 4.9, y: 5 },
+        { x: 4.9, y: 10 },
+        { x: 4.9, y: 10 },
+      ]),
+      stub("B", "net1", [
+        { x: 0.5, y: 0 },
+        { x: 0.5, y: 5 },
+        { x: 5.1, y: 5 },
+        { x: 5.1, y: 10 },
+        { x: 5.1, y: 10 },
+      ]),
+    ]
+
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+
+    // After snap, the vertical-segment x should be midpoint 5.0.
+    expect(out[0].tracePath[2].x).toBeCloseTo(5.0, 6)
+    expect(out[1].tracePath[2].x).toBeCloseTo(5.0, 6)
+  })
+
+  test("does not move terminal (pin-touching) endpoints", () => {
+    // The first segment of every path connects to a chip pin; moving it
+    // would disconnect the trace. Build a case where the boundary segment
+    // would be eligible by offset+overlap but is at the path terminus.
+    const traces = [
+      stub("A", "net1", [
+        { x: 0, y: 0.0 },
+        { x: 10, y: 0.0 },
+      ]),
+      stub("B", "net1", [
+        { x: 0, y: 0.2 },
+        { x: 10, y: 0.2 },
+      ]),
+    ]
+
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+
+    // Both endpoints touch pins → no snap.
+    expect(out[0].tracePath[0].y).toBe(0.0)
+    expect(out[0].tracePath[1].y).toBe(0.0)
+    expect(out[1].tracePath[0].y).toBe(0.2)
+    expect(out[1].tracePath[1].y).toBe(0.2)
+  })
+
+  test("returns inputs unchanged when there is only one trace per net", () => {
+    const traces = [
+      stub("A", "net1", [
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+      ]),
+      stub("B", "net2", [
+        { x: 0, y: 1 },
+        { x: 5, y: 1 },
+      ]),
+    ]
+
+    const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.4 })
+    expect(out[0].tracePath).toEqual(traces[0].tracePath)
+    expect(out[1].tracePath).toEqual(traces[1].tracePath)
+  })
+})

--- a/tests/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.test.ts
@@ -24,30 +24,38 @@ const stub = (
 
 describe("mergeCloseSameNetTraces", () => {
   test("snaps two same-net horizontal segments offset less than the threshold", () => {
-    // Trace A: pin (0,0) -> corner (5,0) -> corner (5,4.9) -> pin (10,4.9)
-    // Trace B: pin (0,0.5) -> corner (5,0.5) -> corner (5,5.1) -> pin (10,5.1)
+    // Traces must have at least 6 points for a horizontal middle segment to
+    // be "interior" — endpoint segments touch pins and are skipped.
+    //
+    // Trace A: pin (0,0) -> (3,0) -> (3, 4.9) -> (8, 4.9) -> (8, 9) -> pin (12, 9)
+    // Trace B: pin (0,0.5) -> (3,0.5) -> (3, 5.1) -> (8, 5.1) -> (8, 9.5) -> pin (12, 9.5)
+    //
     // Middle horizontal segments at y=4.9 and y=5.1 are 0.2 apart, same net.
     // With paddingBuffer = 0.5, the default threshold = 0.25, so 0.2 < 0.25
     // and the two segments should snap to the shared midpoint y=5.0.
     const traces = [
       stub("A", "net1", [
         { x: 0, y: 0 },
-        { x: 5, y: 0 },
-        { x: 5, y: 4.9 },
-        { x: 10, y: 4.9 },
+        { x: 3, y: 0 },
+        { x: 3, y: 4.9 },
+        { x: 8, y: 4.9 },
+        { x: 8, y: 9 },
+        { x: 12, y: 9 },
       ]),
       stub("B", "net1", [
         { x: 0, y: 0.5 },
-        { x: 5, y: 0.5 },
-        { x: 5, y: 5.1 },
-        { x: 10, y: 5.1 },
+        { x: 3, y: 0.5 },
+        { x: 3, y: 5.1 },
+        { x: 8, y: 5.1 },
+        { x: 8, y: 9.5 },
+        { x: 12, y: 9.5 },
       ]),
     ]
 
     const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.5 })
 
-    // The third tracePath entry is the start corner of the middle horizontal
-    // segment in each path (path[2]); after snap it sits at y=5.0.
+    // The middle horizontal segment runs from path[2] to path[3] in both
+    // traces; after snap both endpoints sit at y=5.0.
     expect(out[0].tracePath[2].y).toBeCloseTo(5.0, 6)
     expect(out[0].tracePath[3].y).toBeCloseTo(5.0, 6)
     expect(out[1].tracePath[2].y).toBeCloseTo(5.0, 6)
@@ -58,17 +66,19 @@ describe("mergeCloseSameNetTraces", () => {
     const traces = [
       stub("A", "net1", [
         { x: 0, y: 0 },
-        { x: 5, y: 0 },
-        { x: 5, y: 4.9 },
-        { x: 10, y: 4.9 },
-        { x: 10, y: 4.9 },
+        { x: 3, y: 0 },
+        { x: 3, y: 4.9 },
+        { x: 8, y: 4.9 },
+        { x: 8, y: 9 },
+        { x: 12, y: 9 },
       ]),
       stub("B", "net2", [
         { x: 0, y: 0.5 },
-        { x: 5, y: 0.5 },
-        { x: 5, y: 5.1 },
-        { x: 10, y: 5.1 },
-        { x: 10, y: 5.1 },
+        { x: 3, y: 0.5 },
+        { x: 3, y: 5.1 },
+        { x: 8, y: 5.1 },
+        { x: 8, y: 9.5 },
+        { x: 12, y: 9.5 },
       ]),
     ]
 
@@ -84,17 +94,19 @@ describe("mergeCloseSameNetTraces", () => {
     const traces = [
       stub("A", "net1", [
         { x: 0, y: 0 },
-        { x: 5, y: 0 },
-        { x: 5, y: 2 },
-        { x: 10, y: 2 },
-        { x: 10, y: 2 },
+        { x: 3, y: 0 },
+        { x: 3, y: 2 },
+        { x: 8, y: 2 },
+        { x: 8, y: 9 },
+        { x: 12, y: 9 },
       ]),
       stub("B", "net1", [
         { x: 0, y: 0 },
-        { x: 5, y: 0 },
-        { x: 5, y: 8 },
-        { x: 10, y: 8 },
-        { x: 10, y: 8 },
+        { x: 3, y: 0 },
+        { x: 3, y: 8 },
+        { x: 8, y: 8 },
+        { x: 8, y: 9 },
+        { x: 12, y: 9 },
       ]),
     ]
 
@@ -105,29 +117,38 @@ describe("mergeCloseSameNetTraces", () => {
   })
 
   test("snaps two same-net vertical segments offset less than the threshold", () => {
-    // Vertical analogue: middle vertical segments at x=4.9 and x=5.1, same net.
+    // Vertical analogue: a 6-point trace where path[2]->path[3] is an
+    // interior VERTICAL segment.
+    //
+    // Trace A: pin (0,0) -> (0,3) -> (4.9, 3) -> (4.9, 8) -> (9, 8) -> pin (9, 12)
+    // Trace B: pin (0.5,0) -> (0.5,3) -> (5.1, 3) -> (5.1, 8) -> (9.5, 8) -> pin (9.5, 12)
+    //
+    // The interior vertical segments at x=4.9 and x=5.1 should snap to x=5.0.
     const traces = [
       stub("A", "net1", [
         { x: 0, y: 0 },
-        { x: 0, y: 5 },
-        { x: 4.9, y: 5 },
-        { x: 4.9, y: 10 },
-        { x: 4.9, y: 10 },
+        { x: 0, y: 3 },
+        { x: 4.9, y: 3 },
+        { x: 4.9, y: 8 },
+        { x: 9, y: 8 },
+        { x: 9, y: 12 },
       ]),
       stub("B", "net1", [
         { x: 0.5, y: 0 },
-        { x: 0.5, y: 5 },
-        { x: 5.1, y: 5 },
-        { x: 5.1, y: 10 },
-        { x: 5.1, y: 10 },
+        { x: 0.5, y: 3 },
+        { x: 5.1, y: 3 },
+        { x: 5.1, y: 8 },
+        { x: 9.5, y: 8 },
+        { x: 9.5, y: 12 },
       ]),
     ]
 
     const out = mergeCloseSameNetTraces({ traces, paddingBuffer: 0.5 })
 
-    // After snap, the vertical-segment x should be midpoint 5.0.
     expect(out[0].tracePath[2].x).toBeCloseTo(5.0, 6)
+    expect(out[0].tracePath[3].x).toBeCloseTo(5.0, 6)
     expect(out[1].tracePath[2].x).toBeCloseTo(5.0, 6)
+    expect(out[1].tracePath[3].x).toBeCloseTo(5.0, 6)
   })
 
   test("does not move terminal (pin-touching) endpoints", () => {


### PR DESCRIPTION
## Summary

Adds a new `merging_close_same_net_traces` step to the `TraceCleanupSolver` pipeline that snaps parallel same-net trace segments onto a shared coordinate.

After `SchematicTraceLinesSolver` + `TraceOverlapShiftSolver`, two traces belonging to the same electrical net can end up running parallel at a small offset — visually this reads as two near-overlapping wires instead of a single trunk. Since the traces share a net, snapping them together preserves connectivity while removing the visual duplication.

## Algorithm

1. Group traces by `dcConnNetId`.
2. Enumerate every axis-aligned segment in each group (skipping endpoint segments, which terminate at pins).
3. For each pair of co-net same-orientation segments whose perpendicular offset is in `(EPS, threshold]` and that overlap on the parallel axis, snap both to the midpoint.
4. Pass each touched path through `simplifyPath()` to collapse duplicate corners.

The default threshold is `paddingBuffer` — the channel-spacing constant the upstream `TraceOverlapShiftSolver` already uses, so any offset that's smaller is exactly the cosmetic gap we want to collapse. Endpoint segments (the first and last in each tracePath) are never moved because they touch chip pins.

## Tests

`tests/solvers/TraceCleanupSolver/mergeCloseSameNetTraces.test.ts` covers:
- Horizontal segments same net, within threshold → snap to midpoint ✓
- Vertical segments same net, within threshold → snap to midpoint ✓
- Different-net traces → no snap ✓
- Segments beyond threshold → no snap ✓
- Pin-touching endpoint segments → never moved ✓
- Single trace per net → unchanged ✓

The full `TraceCleanupSolver.test.ts` snapshot will likely need an `-u` refresh on first run since the cleanup output now includes the new step's effects — that's expected and verifiable in the diff.

## Closes

Closes #34.
