### PR TITLE
feat(solver): add SameNetMergeSegmentSolver to collapse redundant same-net parallel segments

### DIFF
--- a/lib/solvers/SameNetMergeSegmentSolver/SameNetMergeSegmentSolver.ts
+++ b/lib/solvers/SameNetMergeSegmentSolver/SameNetMergeSegmentSolver.ts
@@ -1,0 +1,193 @@
+/**
+ * SameNetMergeSegmentSolver
+ *
+ * Closes #34 and #29
+ *
+ * When two traces belong to the same net and have parallel axis-aligned
+ * segments that are very close together (within MERGE_THRESHOLD schematic
+ * units) AND whose extents overlap, the segments are redundant—they appear
+ * as two nearly-identical lines stacked on top of each other.
+ *
+ * This solver collapses such pairs: both segments are snapped to the same
+ * coordinate (the midpoint of the two Y-values for horizontal segments, or
+ * the midpoint of the two X-values for vertical segments), and the merged
+ * segment's extent is extended to the union of both extents.
+ *
+ * The solver iterates until no more mergeable pairs are found (fixed-point).
+ */
+
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { Point } from "graphics-debug"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+/** Maximum distance (in schematic units) between parallel segments to merge */
+const MERGE_THRESHOLD = 0.25
+
+/** Minimum overlap length required to consider two segments mergeable */
+const MIN_OVERLAP = 0.01
+
+const EPS = 1e-9
+
+interface Segment {
+  traceIdx: number
+  segIdx: number
+  axis: "h" | "v"
+  fixedCoord: number
+  lo: number
+  hi: number
+}
+
+function extractSegments(traces: SolvedTracePath[]): Segment[] {
+  const segs: Segment[] = []
+  for (let ti = 0; ti < traces.length; ti++) {
+    const path = traces[ti]!.tracePath
+    for (let si = 0; si < path.length - 1; si++) {
+      const p1 = path[si]!
+      const p2 = path[si + 1]!
+      const dx = Math.abs(p2.x - p1.x)
+      const dy = Math.abs(p2.y - p1.y)
+      if (dy < EPS && dx > EPS) {
+        segs.push({
+          traceIdx: ti,
+          segIdx: si,
+          axis: "h",
+          fixedCoord: p1.y,
+          lo: Math.min(p1.x, p2.x),
+          hi: Math.max(p1.x, p2.x),
+        })
+      } else if (dx < EPS && dy > EPS) {
+        segs.push({
+          traceIdx: ti,
+          segIdx: si,
+          axis: "v",
+          fixedCoord: p1.x,
+          lo: Math.min(p1.y, p2.y),
+          hi: Math.max(p1.y, p2.y),
+        })
+      }
+    }
+  }
+  return segs
+}
+
+function segmentsOverlap(a: Segment, b: Segment): boolean {
+  const overlapLo = Math.max(a.lo, b.lo)
+  const overlapHi = Math.min(a.hi, b.hi)
+  return overlapHi - overlapLo > MIN_OVERLAP
+}
+
+function sameNet(a: SolvedTracePath, b: SolvedTracePath): boolean {
+  return (
+    a.dcConnNetId === b.dcConnNetId || a.globalConnNetId === b.globalConnNetId
+  )
+}
+
+function applyMerge(
+  path: Point[],
+  segIdx: number,
+  axis: "h" | "v",
+  newFixed: number,
+  newLo: number,
+  newHi: number,
+): Point[] {
+  const newPath = path.map((p) => ({ ...p }))
+  const p1 = newPath[segIdx]!
+  const p2 = newPath[segIdx + 1]!
+
+  if (axis === "h") {
+    p1.y = newFixed
+    p2.y = newFixed
+    if (path[segIdx]!.x <= path[segIdx + 1]!.x) {
+      p1.x = newLo
+      p2.x = newHi
+    } else {
+      p1.x = newHi
+      p2.x = newLo
+    }
+  } else {
+    p1.x = newFixed
+    p2.x = newFixed
+    if (path[segIdx]!.y <= path[segIdx + 1]!.y) {
+      p1.y = newLo
+      p2.y = newHi
+    } else {
+      p1.y = newHi
+      p2.y = newLo
+    }
+  }
+
+  return simplifyPath(newPath)
+}
+
+export interface SameNetMergeSegmentSolverInput {
+  traces: SolvedTracePath[]
+}
+
+export class SameNetMergeSegmentSolver extends BaseSolver {
+  private inputTraces: SolvedTracePath[]
+  outputTraces: SolvedTracePath[]
+
+  constructor(input: SameNetMergeSegmentSolverInput) {
+    super()
+    this.inputTraces = input.traces
+    this.outputTraces = input.traces.map((t) => ({
+      ...t,
+      tracePath: t.tracePath.map((p) => ({ ...p })),
+    }))
+  }
+
+  private _findAndMergeOne(): boolean {
+    const traces = this.outputTraces
+    const segs = extractSegments(traces)
+
+    for (let i = 0; i < segs.length; i++) {
+      for (let j = i + 1; j < segs.length; j++) {
+        const a = segs[i]!
+        const b = segs[j]!
+
+        if (a.axis !== b.axis) continue
+        if (a.traceIdx === b.traceIdx) continue
+        if (!sameNet(traces[a.traceIdx]!, traces[b.traceIdx]!)) continue
+        if (Math.abs(a.fixedCoord - b.fixedCoord) > MERGE_THRESHOLD) continue
+        if (!segmentsOverlap(a, b)) continue
+
+        const newFixed = (a.fixedCoord + b.fixedCoord) / 2
+        const newLo = Math.min(a.lo, b.lo)
+        const newHi = Math.max(a.hi, b.hi)
+
+        traces[a.traceIdx]!.tracePath = applyMerge(
+          traces[a.traceIdx]!.tracePath,
+          a.segIdx,
+          a.axis,
+          newFixed,
+          newLo,
+          newHi,
+        )
+        traces[b.traceIdx]!.tracePath = applyMerge(
+          traces[b.traceIdx]!.tracePath,
+          b.segIdx,
+          b.axis,
+          newFixed,
+          newLo,
+          newHi,
+        )
+
+        return true
+      }
+    }
+
+    return false
+  }
+
+  override _step() {
+    const merged = this._findAndMergeOne()
+    if (!merged) {
+      this.solved = true
+    }
+  }
+
+  getOutput(): { traces: SolvedTracePath[] } {
+    return { traces: this.outputTraces }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -21,6 +21,7 @@ import { expandChipsToFitPins } from "./expandChipsToFitPins"
 import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import { SameNetMergeSegmentSolver } from "../SameNetMergeSegmentSolver/SameNetMergeSegmentSolver"
 import { Example28Solver } from "../Example28Solver/Example28Solver"
 import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
@@ -75,6 +76,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetMergeSegmentSolver?: SameNetMergeSegmentSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -218,10 +220,21 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetMergeSegmentSolver",
+      SameNetMergeSegmentSolver,
+      (instance) => {
+        const traces =
+          instance.traceCleanupSolver?.getOutput().traces ??
+          instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
+        return [{ traces }]
+      },
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetMergeSegmentSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -237,6 +250,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetMergeSegmentSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/solvers/SameNetMergeSegmentSolver/SameNetMergeSegmentSolver.test.ts
+++ b/tests/solvers/SameNetMergeSegmentSolver/SameNetMergeSegmentSolver.test.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "bun:test"
+import { SameNetMergeSegmentSolver } from "lib/solvers/SameNetMergeSegmentSolver/SameNetMergeSegmentSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+function makeSolvedTrace(
+  id: string,
+  netId: string,
+  path: Array<{ x: number; y: number }>,
+): SolvedTracePath {
+  return {
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [] as any,
+    tracePath: path,
+    mspConnectionPairIds: [id],
+    pinIds: [],
+  }
+}
+
+test("merges two horizontal same-net segments at similar Y", () => {
+  const traceA = makeSolvedTrace("a", "net1", [
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+  ])
+  const traceB = makeSolvedTrace("b", "net1", [
+    { x: 0, y: 0.1 },
+    { x: 3, y: 0.1 },
+  ])
+  const solver = new SameNetMergeSegmentSolver({ traces: [traceA, traceB] })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  const { traces } = solver.getOutput()
+  for (const trace of traces) {
+    for (const pt of trace.tracePath) {
+      expect(Math.abs(pt.y - 0.05)).toBeLessThan(0.01)
+    }
+  }
+})
+
+test("merges two vertical same-net segments at similar X", () => {
+  const traceA = makeSolvedTrace("a", "net2", [
+    { x: 0, y: 0 },
+    { x: 0, y: 5 },
+  ])
+  const traceB = makeSolvedTrace("b", "net2", [
+    { x: 0.15, y: 0 },
+    { x: 0.15, y: 5 },
+  ])
+  const solver = new SameNetMergeSegmentSolver({ traces: [traceA, traceB] })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  const { traces } = solver.getOutput()
+  for (const trace of traces) {
+    for (const pt of trace.tracePath) {
+      expect(Math.abs(pt.x - 0.075)).toBeLessThan(0.01)
+    }
+  }
+})
+
+test("does NOT merge segments from different nets", () => {
+  const traceA = makeSolvedTrace("a", "net1", [
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+  ])
+  const traceB = makeSolvedTrace("b", "net2", [
+    { x: 0, y: 0.1 },
+    { x: 3, y: 0.1 },
+  ])
+  const solver = new SameNetMergeSegmentSolver({ traces: [traceA, traceB] })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  const { traces } = solver.getOutput()
+  expect(traces[0]!.tracePath[0]!.y).toBeCloseTo(0, 5)
+  expect(traces[1]!.tracePath[0]!.y).toBeCloseTo(0.1, 5)
+})
+
+test("does NOT merge segments that are far apart (> threshold)", () => {
+  const traceA = makeSolvedTrace("a", "net1", [
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+  ])
+  const traceB = makeSolvedTrace("b", "net1", [
+    { x: 0, y: 1.0 },
+    { x: 3, y: 1.0 },
+  ])
+  const solver = new SameNetMergeSegmentSolver({ traces: [traceA, traceB] })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  const { traces } = solver.getOutput()
+  expect(traces[0]!.tracePath[0]!.y).toBeCloseTo(0, 5)
+  expect(traces[1]!.tracePath[0]!.y).toBeCloseTo(1.0, 5)
+})
+
+test("extends merged segment to cover union of both extents", () => {
+  const traceA = makeSolvedTrace("a", "net1", [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+  ])
+  const traceB = makeSolvedTrace("b", "net1", [
+    { x: 1, y: 0.1 },
+    { x: 4, y: 0.1 },
+  ])
+  const solver = new SameNetMergeSegmentSolver({ traces: [traceA, traceB] })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  const { traces } = solver.getOutput()
+  for (const trace of traces) {
+    const xs = trace.tracePath.map((p) => p.x)
+    expect(Math.min(...xs)).toBeCloseTo(0, 5)
+    expect(Math.max(...xs)).toBeCloseTo(4, 5)
+  }
+})


### PR DESCRIPTION
Closes #34
Closes #29

## Problem

When two traces belong to the same net, the schematic router sometimes places parallel segments very close together (within ~0.2 schematic units) on the same axis. These appear as two nearly-identical stacked lines—visual clutter that makes the schematic harder to read.

## Solution

New `SameNetMergeSegmentSolver` that runs in the pipeline after `TraceCleanupSolver`:

1. Extracts all horizontal and vertical segments from all traces
2. For each pair of segments on the **same net** and **same axis** whose fixed coordinate differs by less than `MERGE_THRESHOLD` (0.25 su) **and** whose extents overlap — collapses both to the midpoint coordinate and extends to the union of both extents
3. Iterates to fixed-point (handles chains of near-duplicate segments)

## Pipeline change

`TraceCleanupSolver` → **`SameNetMergeSegmentSolver`** → `NetLabelPlacementSolver` → `Example28Solver` → ...

Downstream solvers pick up merged traces via:
```ts
instance.sameNetMergeSegmentSolver?.getOutput().traces ??
instance.traceCleanupSolver?.getOutput().traces
```

## Tests added

5 unit tests in `tests/solvers/SameNetMergeSegmentSolver/SameNetMergeSegmentSolver.test.ts`:
- Horizontal same-net segments snapped to midpoint ✅
- Vertical same-net segments snapped to midpoint ✅
- Different-net segments NOT merged ✅
- Segments farther than threshold NOT merged ✅
- Merged extent covers union of both original extents ✅