### PR TITLE
Merge nearby same-net trace segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,6 +20,7 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { mergeNearbySameNetSegments } from "./mergeNearbySameNetSegments"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "merging_nearby_same_net_segments"
   | "untangling_traces"
 
 /**
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "merging_nearby_same_net_segments":
+        this._runMergeNearbySameNetSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +113,17 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "merging_nearby_same_net_segments"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runMergeNearbySameNetSegmentsStep() {
+    this.outputTraces = mergeNearbySameNetSegments(this.outputTraces)
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/mergeNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeNearbySameNetSegments.ts
@@ -1,0 +1,165 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+type SegmentOrientation = "horizontal" | "vertical"
+
+interface SegmentInfo {
+  id: number
+  traceIndex: number
+  segmentIndex: number
+  globalConnNetId: string
+  orientation: SegmentOrientation
+  coord: number
+  rangeMin: number
+  rangeMax: number
+}
+
+interface MergeNearbySameNetSegmentsOptions {
+  maxDistance?: number
+}
+
+const EPS = 1e-6
+
+const getSegmentInfo = (
+  trace: SolvedTracePath,
+  traceIndex: number,
+  segmentIndex: number,
+  id: number,
+): SegmentInfo | null => {
+  const p1 = trace.tracePath[segmentIndex]!
+  const p2 = trace.tracePath[segmentIndex + 1]!
+  const isHorizontal = Math.abs(p1.y - p2.y) < EPS
+  const isVertical = Math.abs(p1.x - p2.x) < EPS
+
+  if (!isHorizontal && !isVertical) return null
+
+  return {
+    id,
+    traceIndex,
+    segmentIndex,
+    globalConnNetId: trace.globalConnNetId,
+    orientation: isHorizontal ? "horizontal" : "vertical",
+    coord: isHorizontal ? p1.y : p1.x,
+    rangeMin: isHorizontal ? Math.min(p1.x, p2.x) : Math.min(p1.y, p2.y),
+    rangeMax: isHorizontal ? Math.max(p1.x, p2.x) : Math.max(p1.y, p2.y),
+  }
+}
+
+const rangesOverlap = (a: SegmentInfo, b: SegmentInfo) =>
+  Math.min(a.rangeMax, b.rangeMax) - Math.max(a.rangeMin, b.rangeMin) > EPS
+
+const shouldMergeSegments = (
+  a: SegmentInfo,
+  b: SegmentInfo,
+  maxDistance: number,
+) =>
+  a.traceIndex !== b.traceIndex &&
+  a.globalConnNetId === b.globalConnNetId &&
+  a.orientation === b.orientation &&
+  Math.abs(a.coord - b.coord) <= maxDistance &&
+  rangesOverlap(a, b)
+
+const setSegmentCoord = (
+  tracePath: Point[],
+  segmentIndex: number,
+  orientation: SegmentOrientation,
+  coord: number,
+) => {
+  const p1 = tracePath[segmentIndex]!
+  const p2 = tracePath[segmentIndex + 1]!
+
+  if (orientation === "horizontal") {
+    p1.y = coord
+    p2.y = coord
+  } else {
+    p1.x = coord
+    p2.x = coord
+  }
+}
+
+export const mergeNearbySameNetSegments = (
+  traces: SolvedTracePath[],
+  options: MergeNearbySameNetSegmentsOptions = {},
+): SolvedTracePath[] => {
+  const maxDistance = options.maxDistance ?? 0.25
+  const mergedTraces = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  const segments: SegmentInfo[] = []
+  let nextSegmentId = 0
+
+  for (let traceIndex = 0; traceIndex < mergedTraces.length; traceIndex++) {
+    const trace = mergedTraces[traceIndex]!
+    for (
+      let segmentIndex = 1;
+      segmentIndex < trace.tracePath.length - 2;
+      segmentIndex++
+    ) {
+      const segment = getSegmentInfo(
+        trace,
+        traceIndex,
+        segmentIndex,
+        nextSegmentId++,
+      )
+      if (segment) segments.push(segment)
+    }
+  }
+
+  const adjacency = new Map<number, Set<number>>()
+  for (const segment of segments) adjacency.set(segment.id, new Set())
+
+  for (let i = 0; i < segments.length; i++) {
+    for (let j = i + 1; j < segments.length; j++) {
+      const a = segments[i]!
+      const b = segments[j]!
+      if (!shouldMergeSegments(a, b, maxDistance)) continue
+      adjacency.get(a.id)!.add(b.id)
+      adjacency.get(b.id)!.add(a.id)
+    }
+  }
+
+  const segmentById = new Map(segments.map((segment) => [segment.id, segment]))
+  const visited = new Set<number>()
+
+  for (const segment of segments) {
+    if (visited.has(segment.id)) continue
+
+    const component: SegmentInfo[] = []
+    const queue = [segment.id]
+    visited.add(segment.id)
+
+    while (queue.length > 0) {
+      const id = queue.shift()!
+      component.push(segmentById.get(id)!)
+      for (const nextId of adjacency.get(id)!) {
+        if (visited.has(nextId)) continue
+        visited.add(nextId)
+        queue.push(nextId)
+      }
+    }
+
+    if (component.length < 2) continue
+
+    component.sort(
+      (a, b) => a.traceIndex - b.traceIndex || a.segmentIndex - b.segmentIndex,
+    )
+    const targetCoord = component[0]!.coord
+
+    for (const item of component) {
+      setSegmentCoord(
+        mergedTraces[item.traceIndex]!.tracePath,
+        item.segmentIndex,
+        item.orientation,
+        targetCoord,
+      )
+    }
+  }
+
+  return mergedTraces.map((trace) => ({
+    ...trace,
+    tracePath: simplifyPath(trace.tracePath),
+  }))
+}

--- a/tests/solvers/TraceCleanupSolver/mergeNearbySameNetSegments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeNearbySameNetSegments.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test"
+import { mergeNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/mergeNearbySameNetSegments"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    globalConnNetId,
+    dcConnNetId: globalConnNetId,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+    pins: [] as any,
+  }) as SolvedTracePath
+
+test("mergeNearbySameNetSegments snaps close same-net horizontal segments to a shared y", () => {
+  const traces = [
+    makeTrace("a", "net-1", [
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 5, y: 1 },
+      { x: 5, y: 0 },
+    ]),
+    makeTrace("b", "net-1", [
+      { x: 1, y: 3 },
+      { x: 1, y: 1.18 },
+      { x: 6, y: 1.18 },
+      { x: 6, y: 3 },
+    ]),
+  ]
+
+  const merged = mergeNearbySameNetSegments(traces, { maxDistance: 0.25 })
+
+  expect(merged[0]!.tracePath[1]!.y).toBe(1)
+  expect(merged[0]!.tracePath[2]!.y).toBe(1)
+  expect(merged[1]!.tracePath[1]!.y).toBe(1)
+  expect(merged[1]!.tracePath[2]!.y).toBe(1)
+})
+
+test("mergeNearbySameNetSegments snaps close same-net vertical segments to a shared x", () => {
+  const traces = [
+    makeTrace("a", "net-1", [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 5 },
+      { x: 0, y: 5 },
+    ]),
+    makeTrace("b", "net-1", [
+      { x: 3, y: 1 },
+      { x: 1.18, y: 1 },
+      { x: 1.18, y: 6 },
+      { x: 3, y: 6 },
+    ]),
+  ]
+
+  const merged = mergeNearbySameNetSegments(traces, { maxDistance: 0.25 })
+
+  expect(merged[0]!.tracePath[1]!.x).toBe(1)
+  expect(merged[0]!.tracePath[2]!.x).toBe(1)
+  expect(merged[1]!.tracePath[1]!.x).toBe(1)
+  expect(merged[1]!.tracePath[2]!.x).toBe(1)
+})
+
+test("mergeNearbySameNetSegments preserves endpoints and different-net traces", () => {
+  const traces = [
+    makeTrace("a", "net-1", [
+      { x: 0, y: 0 },
+      { x: 5, y: 0 },
+      { x: 5, y: 3 },
+    ]),
+    makeTrace("b", "net-1", [
+      { x: 1, y: 0.18 },
+      { x: 6, y: 0.18 },
+      { x: 6, y: 3 },
+    ]),
+    makeTrace("c", "net-2", [
+      { x: 1, y: 0.2 },
+      { x: 1, y: 2 },
+      { x: 6, y: 2 },
+    ]),
+  ]
+
+  const merged = mergeNearbySameNetSegments(traces, { maxDistance: 0.25 })
+
+  expect(merged[0]!.tracePath).toEqual(traces[0]!.tracePath)
+  expect(merged[1]!.tracePath).toEqual(traces[1]!.tracePath)
+  expect(merged[2]!.tracePath).toEqual(traces[2]!.tracePath)
+})


### PR DESCRIPTION
## Summary
- add a TraceCleanupSolver phase that snaps nearby overlapping same-net trace segments onto a shared X/Y line
- skip endpoint segments so pin attachment points stay fixed
- add focused coverage for horizontal merge, vertical merge, endpoint preservation, and different-net preservation

Closes #34
Closes #29

## Verification
- `npx bun test` — 67 pass, 4 skip, 0 fail
- `npm run build` — ESM and DTS build success

Note: local install required npm's legacy/force peer handling because this repo currently has peer dependency conflicts around `bun-match-svg`/React and TypeScript is a peer dependency for build.