### PR TITLE
fix(post-processing): remove zero-length segments left by diagonal fix

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,13 +4,26 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+const isSamePoint = (a: Point, b: Point, eps = 1e-6): boolean =>
+  Math.abs(a.x - b.x) < eps && Math.abs(a.y - b.y) < eps
+
 export const simplifyPath = (path: Point[]): Point[] => {
   if (path.length < 3) return path
-  const newPath: Point[] = [path[0]]
-  for (let i = 1; i < path.length - 1; i++) {
+
+  const deduped: Point[] = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    if (!isSamePoint(deduped[deduped.length - 1], path[i])) {
+      deduped.push(path[i])
+    }
+  }
+
+  if (deduped.length < 3) return deduped
+
+  const newPath: Point[] = [deduped[0]]
+  for (let i = 1; i < deduped.length - 1; i++) {
     const p1 = newPath[newPath.length - 1]
-    const p2 = path[i]
-    const p3 = path[i + 1]
+    const p2 = deduped[i]
+    const p3 = deduped[i + 1]
     if (
       (isVertical(p1, p2) && isVertical(p2, p3)) ||
       (isHorizontal(p1, p2) && isHorizontal(p2, p3))
@@ -19,7 +32,7 @@ export const simplifyPath = (path: Point[]): Point[] => {
     }
     newPath.push(p2)
   }
-  newPath.push(path[path.length - 1])
+  newPath.push(deduped[deduped.length - 1])
 
   if (newPath.length < 3) return newPath
   const finalPath: Point[] = [newPath[0]]

--- a/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
+++ b/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
@@ -262,11 +262,24 @@ export class TraceOverlapShiftSolver extends BaseSolver {
     if (prevIsHorizontal) score2++
     if (nextIsVertical) score2++
 
-    const elbowPoint = score1 < score2 ? elbow1 : elbow2
+    let elbowPoint = score1 < score2 ? elbow1 : elbow2
 
-    // Replace [p1, p2] with [p1, elbowPoint, p2]
+    const elbowEqP1 =
+      Math.abs(elbowPoint.x - p1.x) < EPS && Math.abs(elbowPoint.y - p1.y) < EPS
+    const elbowEqP2 =
+      Math.abs(elbowPoint.x - p2.x) < EPS && Math.abs(elbowPoint.y - p2.y) < EPS
+
+    if (elbowEqP1) {
+      tracePath[i + 1] = { ...p2, x: p1.x, y: p1.y }
+      return true
+    }
+    if (elbowEqP2) {
+      tracePath[i] = { ...p1, x: p2.x, y: p2.y }
+      return true
+    }
+
     tracePath.splice(i + 1, 0, elbowPoint)
-    return true // Fixed one diagonal, return true to re-evaluate in next step
+    return true
   }
 
   override _step() {


### PR DESCRIPTION
Closes #78

/claim #78

Root cause: when TraceOverlapShiftSolver.findAndFixNextDiagonalSegment
fixes a near-zero diagonal segment it inserts an elbowPoint via splice().
If the chosen elbow coincides with the adjacent endpoint (p1 or p2), a
zero-length segment is produced. simplifyPath did not remove duplicate
consecutive points, so the spurious segment survived into final output.

Fix 1 - simplifyPath.ts: add isSamePoint() guard that drops zero-length
(duplicate) points in both simplification passes.

Fix 2 - TraceOverlapShiftSolver.ts: before splice(), detect when the
elbow equals p1 or p2 and snap the existing endpoint instead of
inserting a duplicate.