### PR TITLE
add net label height to net connections

### DIFF
--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -429,6 +429,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     const { width, height } = getDimsForOrientation({
       orientation,
       netLabelWidth: this.getNetLabelWidth(label),
+      netLabelHeight: this.getNetLabelHeight(label),
     })
 
     return this.getSideOffsetAnchor({
@@ -494,6 +495,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     const { width, height } = getDimsForOrientation({
       orientation,
       netLabelWidth: this.getNetLabelWidth(label),
+      netLabelHeight: this.getNetLabelHeight(label),
     })
     const labelLength =
       orientation === "y+" || orientation === "y-" ? height : width
@@ -534,6 +536,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     const { width, height } = getDimsForOrientation({
       orientation,
       netLabelWidth: this.getNetLabelWidth(label),
+      netLabelHeight: this.getNetLabelHeight(label),
     })
     return {
       orientation,
@@ -565,6 +568,19 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     return this.inputProblem.netConnections.find((nc) =>
       nc.pinIds.some((pid) => label.pinIds.includes(pid)),
     )?.netLabelWidth
+  }
+
+  private getNetLabelHeight(label: NetLabelPlacement) {
+    if (label.netId) {
+      const ncHeight = this.inputProblem.netConnections.find(
+        (connection) => connection.netId === label.netId,
+      )?.netLabelHeight
+      if (ncHeight !== undefined) return ncHeight
+    }
+
+    return this.inputProblem.netConnections.find((nc) =>
+      nc.pinIds.some((pid) => label.pinIds.includes(pid)),
+    )?.netLabelHeight
   }
 
   private getCandidateStatus(

--- a/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
+++ b/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
@@ -170,8 +170,15 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
     return label.height
   }
 
+  private netLabelHeightOf(label: NetLabelPlacement): number | undefined {
+    if (label.orientation === "x+" || label.orientation === "x-")
+      return label.height
+    return label.width
+  }
+
   private buildCandidatesForLabel(label: NetLabelPlacement): Candidate[] {
     const netLabelWidth = this.netLabelWidthOf(label)
+    const netLabelHeight = this.netLabelHeightOf(label)
     const candidates: Candidate[] = []
 
     const buildCandidate = (
@@ -183,6 +190,7 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
       const { width, height } = getDimsForOrientation({
         orientation,
         netLabelWidth,
+        netLabelHeight,
       })
       const baseCenter = getCenterFromAnchor(anchor, orientation, width, height)
       const outwardDir = OUTWARD_DIR[orientation]

--- a/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
@@ -280,6 +280,26 @@ export class NetLabelPlacementSolver extends BaseSolver {
     )?.netLabelWidth
   }
 
+  private getNetLabelHeightForGroup(
+    group: OverlappingSameNetTraceGroup,
+  ): number | undefined {
+    if (group.netId) {
+      const ncHeight = this.inputProblem.netConnections.find(
+        (nc) => nc.netId === group.netId,
+      )?.netLabelHeight
+      if (ncHeight !== undefined) return ncHeight
+    }
+
+    const pinIds = group.overlappingTraces?.pins.map((p) => p.pinId) ?? []
+    if (group.portOnlyPinId) {
+      pinIds.push(group.portOnlyPinId)
+    }
+
+    return this.inputProblem.netConnections.find((nc) =>
+      nc.pinIds.some((pid) => pinIds.includes(pid)),
+    )?.netLabelHeight
+  }
+
   override _step() {
     if (this.activeSubSolver?.solved) {
       this.netLabelPlacements.push(this.activeSubSolver.netLabelPlacement!)
@@ -304,12 +324,14 @@ export class NetLabelPlacementSolver extends BaseSolver {
       ) {
         this.triedAnyOrientationFallbackForCurrentGroup = true
         const netLabelWidth = this.getNetLabelWidthForGroup(this.currentGroup)
+        const netLabelHeight = this.getNetLabelHeightForGroup(this.currentGroup)
         this.activeSubSolver = new SingleNetLabelPlacementSolver({
           inputProblem: this.inputProblem,
           inputTraceMap: this.inputTraceMap,
           overlappingSameNetTraceGroup: this.currentGroup,
           availableOrientations: fullOrients,
           netLabelWidth,
+          netLabelHeight,
         })
         return
       }
@@ -340,6 +362,7 @@ export class NetLabelPlacementSolver extends BaseSolver {
     this.triedAnyOrientationFallbackForCurrentGroup = false
 
     const netLabelWidth = this.getNetLabelWidthForGroup(this.currentGroup)
+    const netLabelHeight = this.getNetLabelHeightForGroup(this.currentGroup)
 
     this.activeSubSolver = new SingleNetLabelPlacementSolver({
       inputProblem: this.inputProblem,
@@ -349,6 +372,7 @@ export class NetLabelPlacementSolver extends BaseSolver {
         netId
       ] ?? ["x+", "x-", "y+", "y-"],
       netLabelWidth,
+      netLabelHeight,
     })
   }
 

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver.ts
@@ -58,8 +58,9 @@ export class SingleNetLabelPlacementSolver extends BaseSolver {
 
   chipObstacleSpatialIndex: ChipObstacleSpatialIndex
 
-  // Optional override for the width of the net label (per netId)
+  // Optional override for the width/height of the net label (per netId)
   netLabelWidth?: number
+  netLabelHeight?: number
 
   netLabelPlacement: NetLabelPlacement | null = null
   testedCandidates: Array<{
@@ -79,6 +80,7 @@ export class SingleNetLabelPlacementSolver extends BaseSolver {
     overlappingSameNetTraceGroup: OverlappingSameNetTraceGroup
     availableOrientations: FacingDirection[]
     netLabelWidth?: number
+    netLabelHeight?: number
   }) {
     super()
     this.inputProblem = params.inputProblem
@@ -86,6 +88,7 @@ export class SingleNetLabelPlacementSolver extends BaseSolver {
     this.overlappingSameNetTraceGroup = params.overlappingSameNetTraceGroup
     this.availableOrientations = params.availableOrientations
     this.netLabelWidth = params.netLabelWidth
+    this.netLabelHeight = params.netLabelHeight
 
     this.chipObstacleSpatialIndex =
       params.inputProblem._chipObstacleSpatialIndex ??
@@ -101,6 +104,7 @@ export class SingleNetLabelPlacementSolver extends BaseSolver {
       overlappingSameNetTraceGroup: this.overlappingSameNetTraceGroup,
       availableOrientations: this.availableOrientations,
       netLabelWidth: this.netLabelWidth,
+      netLabelHeight: this.netLabelHeight,
     }
   }
 
@@ -119,6 +123,7 @@ export class SingleNetLabelPlacementSolver extends BaseSolver {
         overlappingSameNetTraceGroup: this.overlappingSameNetTraceGroup,
         availableOrientations: this.availableOrientations,
         netLabelWidth: this.netLabelWidth,
+        netLabelHeight: this.netLabelHeight,
       })
       this.testedCandidates.push(...res.testedCandidates)
       if (res.placement) {
@@ -230,6 +235,7 @@ export class SingleNetLabelPlacementSolver extends BaseSolver {
             const { width, height } = getDimsForOrientation({
               orientation,
               netLabelWidth: this.netLabelWidth,
+              netLabelHeight: this.netLabelHeight,
             })
             const center = getCenterFromAnchor(
               anchor,

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry.ts
@@ -6,23 +6,28 @@ export const NET_LABEL_HORIZONTAL_HEIGHT = 0.2
 export function getDimsForOrientation(params: {
   orientation: FacingDirection
   netLabelWidth?: number
+  netLabelHeight?: number
 }) {
-  const { orientation, netLabelWidth } = params
+  const { orientation, netLabelWidth, netLabelHeight } = params
   const horizWidth =
     typeof netLabelWidth === "number"
       ? netLabelWidth
       : NET_LABEL_HORIZONTAL_WIDTH
+  const horizHeight =
+    typeof netLabelHeight === "number"
+      ? netLabelHeight
+      : NET_LABEL_HORIZONTAL_HEIGHT
 
   if (orientation === "y+" || orientation === "y-") {
     return {
-      // Rotated, so width/height swap
-      width: NET_LABEL_HORIZONTAL_HEIGHT,
+      // Rotated: horizontal length = netLabelHeight, vertical length = netLabelWidth
+      width: horizHeight,
       height: horizWidth,
     }
   }
   return {
     width: horizWidth,
-    height: NET_LABEL_HORIZONTAL_HEIGHT,
+    height: horizHeight,
   }
 }
 

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/solvePortOnlyPin.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/solvePortOnlyPin.ts
@@ -22,6 +22,7 @@ export function solveNetLabelPlacementForPortOnlyPin(params: {
   overlappingSameNetTraceGroup: OverlappingSameNetTraceGroup
   availableOrientations: FacingDirection[]
   netLabelWidth?: number
+  netLabelHeight?: number
 }): {
   placement: NetLabelPlacement | null
   testedCandidates: Array<{
@@ -43,6 +44,7 @@ export function solveNetLabelPlacementForPortOnlyPin(params: {
     overlappingSameNetTraceGroup,
     availableOrientations,
     netLabelWidth,
+    netLabelHeight,
   } = params
 
   const pinId = overlappingSameNetTraceGroup.portOnlyPinId
@@ -103,6 +105,7 @@ export function solveNetLabelPlacementForPortOnlyPin(params: {
     const { width, height } = getDimsForOrientation({
       orientation,
       netLabelWidth,
+      netLabelHeight,
     })
     // Place label fully outside the chip: shift center slightly outward
     const baseCenter = getCenterFromAnchor(anchor, orientation, width, height)

--- a/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
+++ b/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
@@ -30,6 +30,7 @@ export const generateCandidatesAlongTrace = (params: {
     getTraceVertexDistances(traceLocation.trace),
   )
   const netLabelWidth = getNetLabelWidth(inputProblem, label)
+  const netLabelHeight = getNetLabelHeight(inputProblem, label)
   const candidates: LabelCandidate[] = []
   const seenCandidateKeys = new Set<string>()
 
@@ -55,6 +56,7 @@ export const generateCandidatesAlongTrace = (params: {
           point,
           orientation,
           netLabelWidth,
+          netLabelHeight,
           traceLocation,
           pathDistance,
           label,
@@ -109,6 +111,7 @@ const createCandidate = (params: {
   point: Point
   orientation: FacingDirection
   netLabelWidth: number
+  netLabelHeight?: number
   traceLocation: TraceLocation
   pathDistance: number
   label: NetLabelPlacement
@@ -117,6 +120,7 @@ const createCandidate = (params: {
     point,
     orientation,
     netLabelWidth,
+    netLabelHeight,
     traceLocation,
     pathDistance,
     label,
@@ -124,6 +128,7 @@ const createCandidate = (params: {
   const { width, height } = getDimsForOrientation({
     orientation,
     netLabelWidth,
+    netLabelHeight,
   })
 
   return {
@@ -358,6 +363,20 @@ const getNetLabelWidth = (
   }
 
   return label.width
+}
+
+const getNetLabelHeight = (
+  inputProblem: InputProblem,
+  label: NetLabelPlacement,
+): number | undefined => {
+  const ncHeightByNetId = inputProblem.netConnections.find(
+    (connection) => connection.netId === label.netId,
+  )?.netLabelHeight
+  if (ncHeightByNetId !== undefined) return ncHeightByNetId
+
+  return inputProblem.netConnections.find((nc) =>
+    nc.pinIds.some((pid) => label.pinIds.includes(pid)),
+  )?.netLabelHeight
 }
 
 const roundDistance = (distance: number) => Number(distance.toFixed(6))

--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -31,6 +31,7 @@ export interface InputNetConnection {
   netId: string
   pinIds: Array<PinId>
   netLabelWidth?: number
+  netLabelHeight?: number
 }
 
 export interface InputProblem {

--- a/tests/assets/example41.json
+++ b/tests/assets/example41.json
@@ -65,7 +65,8 @@
     {
       "netId": "SWD",
       "pinIds": ["U3.25", "R5.2"],
-      "netLabelWidth": 0.48
+      "netLabelWidth": 0.48,
+      "netLabelHeight": 0.48
     },
     {
       "netId": "CLK",

--- a/tests/examples/__snapshots__/example41.snap.svg
+++ b/tests/examples/__snapshots__/example41.snap.svg
@@ -26,7 +26,7 @@ orientation: x-" data-x="-7.65" data-y="-0.22999999999999998" cx="325.9574468085
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="-8.549999999999999" data-y="-0.4299999999999998" cx="218.72340425531945" cy="331.9148936170212" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="-8.65" data-y="-0.4299999999999998" cx="206.808510638298" cy="331.9148936170212" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -53,7 +53,7 @@ globalConnNetId: connectivity_net1" data-x="-8.011" data-y="-0.22999999999999998
   </g>
   <g>
     <rect data-type="rect" data-label="netId: SWD
-globalConnNetId: connectivity_net0" data-x="-8.549999999999999" data-y="-0.18989999999999985" x="206.80851063829823" y="274.7114893617021" width="23.829787234042442" height="57.19148936170211" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008392857142857145" />
+globalConnNetId: connectivity_net0" data-x="-8.65" data-y="-0.18989999999999985" x="178.2127659574469" y="274.7114893617021" width="57.191489361702224" height="57.19148936170211" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008392857142857145" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: CLK


### PR DESCRIPTION
added to avoid collision when the labels are in y+/y- orientation

<img width="100" height="112" alt="Screenshot 2026-06-01 at 2 29 10 PM" src="https://github.com/user-attachments/assets/7517893f-21c4-4d62-9fd6-658feb0b1bf3" />
