### PR TITLE
fix: clone netMap to prevent extra traces for net-label-only connections

### DIFF
--- a/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
+++ b/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
@@ -14,7 +14,7 @@ export const getConnectivityMapsFromInputProblem = (
     ])
   }
 
-  const netConnMap = new ConnectivityMap(directConnMap.netMap)
+  const netConnMap = new ConnectivityMap({ ...directConnMap.netMap })
 
   for (const netConn of inputProblem.netConnections) {
     netConnMap.addConnections([[netConn.netId, ...netConn.pinIds]])


### PR DESCRIPTION
Summary:
Fixes issue where pins connected only via netConnections (net-label-only connections) incorrectly generate physical trace lines.

Root cause:
`directConnMap.netMap` was passed by reference to the `ConnectivityMap` constructor for `netConnMap`. When `netConnMap.addConnections()` added net-label-only connections, it mutated the shared `netMap`, causing `queuedDcNetIds` to include nets with zero direct connections.

Fix:
Shallow-clone `netMap`: `new ConnectivityMap({...directConnMap.netMap})`

Closes #79

/claim #79