### PR TITLE
Merge close same-net trace segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,6 +20,7 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { mergeSameNetTraceSegments } from "./mergeSameNetTraceSegments"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "merging_same_net_segments"
   | "untangling_traces"
 
 /**
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "merging_same_net_segments":
+        this._runMergeSameNetSegmentsStep()
+        break
     }
   }
 
@@ -108,11 +113,17 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "merging_same_net_segments"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runMergeSameNetSegmentsStep() {
+    this.outputTraces = mergeSameNetTraceSegments(this.outputTraces)
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetTraceSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetTraceSegments.ts
@@ -1,0 +1,137 @@
+import type { Point } from "graphics-debug"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+const DEFAULT_MERGE_TOLERANCE = 0.1
+
+type EndpointRef = {
+  point: Point
+  side: "start" | "end"
+}
+
+const distance = (a: Point, b: Point) =>
+  Math.hypot(Math.abs(a.x - b.x), Math.abs(a.y - b.y))
+
+const sameAxisBridge = (
+  a: Point,
+  b: Point,
+  tolerance: number,
+): Point[] | null => {
+  if (Math.abs(a.y - b.y) <= tolerance) {
+    const y = (a.y + b.y) / 2
+    return [
+      { x: a.x, y },
+      { x: b.x, y },
+    ]
+  }
+
+  if (Math.abs(a.x - b.x) <= tolerance) {
+    const x = (a.x + b.x) / 2
+    return [
+      { x, y: a.y },
+      { x, y: b.y },
+    ]
+  }
+
+  return null
+}
+
+const endpointsForTrace = (trace: SolvedTracePath): EndpointRef[] => [
+  { point: trace.tracePath[0]!, side: "start" },
+  { point: trace.tracePath[trace.tracePath.length - 1]!, side: "end" },
+]
+
+const orientPathToEndpoint = (
+  tracePath: Point[],
+  endpoint: EndpointRef,
+  position: "left" | "right",
+) => {
+  const path =
+    (position === "left" && endpoint.side === "end") ||
+    (position === "right" && endpoint.side === "start")
+      ? tracePath
+      : [...tracePath].reverse()
+
+  return path.map((point) => ({ ...point }))
+}
+
+const tryMergePair = (
+  a: SolvedTracePath,
+  b: SolvedTracePath,
+  tolerance: number,
+): SolvedTracePath | null => {
+  if (a.globalConnNetId !== b.globalConnNetId) return null
+
+  let best:
+    | {
+        aEndpoint: EndpointRef
+        bEndpoint: EndpointRef
+        bridge: Point[]
+        distance: number
+      }
+    | null = null
+
+  for (const aEndpoint of endpointsForTrace(a)) {
+    for (const bEndpoint of endpointsForTrace(b)) {
+      const bridge = sameAxisBridge(aEndpoint.point, bEndpoint.point, tolerance)
+      if (!bridge) continue
+
+      const endpointDistance = distance(aEndpoint.point, bEndpoint.point)
+      if (endpointDistance > tolerance) continue
+
+      if (!best || endpointDistance < best.distance) {
+        best = { aEndpoint, bEndpoint, bridge, distance: endpointDistance }
+      }
+    }
+  }
+
+  if (!best) return null
+
+  const leftPath = orientPathToEndpoint(a.tracePath, best.aEndpoint, "left")
+  const rightPath = orientPathToEndpoint(b.tracePath, best.bEndpoint, "right")
+  const mergedPath = simplifyPath([
+    ...leftPath.slice(0, -1),
+    ...best.bridge,
+    ...rightPath.slice(1),
+  ])
+
+  return {
+    ...a,
+    mspPairId: `${a.mspPairId}+${b.mspPairId}`,
+    tracePath: mergedPath,
+    mspConnectionPairIds: [
+      ...a.mspConnectionPairIds,
+      ...b.mspConnectionPairIds,
+    ],
+    pinIds: [...a.pinIds, ...b.pinIds],
+  }
+}
+
+export const mergeSameNetTraceSegments = (
+  traces: SolvedTracePath[],
+  tolerance = DEFAULT_MERGE_TOLERANCE,
+): SolvedTracePath[] => {
+  const pending = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  let didMerge = true
+  while (didMerge) {
+    didMerge = false
+
+    outer: for (let i = 0; i < pending.length; i++) {
+      for (let j = i + 1; j < pending.length; j++) {
+        const merged = tryMergePair(pending[i]!, pending[j]!, tolerance)
+        if (!merged) continue
+
+        pending.splice(j, 1)
+        pending[i] = merged
+        didMerge = true
+        break outer
+      }
+    }
+  }
+
+  return pending
+}

--- a/tests/examples/__snapshots__/example29.snap.svg
+++ b/tests/examples/__snapshots__/example29.snap.svg
@@ -494,11 +494,23 @@ orientation: y+" data-x="-6.262500000000001" data-y="0" cx="236.56668982417676" 
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="0.2999999999999998" data-y="1.9000000000000015" cx="353.9996331011397" cy="61.47345248493036" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="-3.7249999999999996" data-y="0" cx="281.9740945579358" cy="95.47308558607014" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.9500000000000006" data-y="1.7000000000000017" cx="383.525630267919" cy="65.05236123241875" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: x-" data-x="3.5999999999999996" data-y="1.9000000000000012" cx="413.0516274346982" cy="61.47345248493037" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-4" data-y="-2.225" cx="277.0530950301392" cy="135.28844540187853" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-4" data-y="-2" cx="277.0530950301392" cy="131.2621730609541" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="3.5999999999999996" data-y="1.7000000000000013" cx="413.0516274346982" cy="65.05236123241876" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -506,7 +518,11 @@ orientation: y+" data-x="-5.750000000000001" data-y="-1.9999999999999998" cx="24
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-3" data-y="-4.225" cx="294.9476387675812" cy="171.07753287676246" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: x+" data-x="-4" data-y="-3.775" cx="277.0530950301392" cy="163.0249881949136" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-3" data-y="-4.449999999999999" cx="294.9476387675812" cy="175.1038052176869" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -518,7 +534,11 @@ orientation: y+" data-x="-6.262500000000001" data-y="-4" cx="236.56668982417676"
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-6.225" cx="277.0530950301392" cy="206.86662035164642" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: x+" data-x="-3" data-y="-5.775" cx="294.9476387675812" cy="198.81407566979755" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-4.449999999999999" data-y="-6" cx="269.00055034829035" cy="202.84034801072198" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -530,7 +550,11 @@ orientation: y-" data-x="-5.750000000000001" data-y="-6" cx="245.73764348961578"
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-4.225" data-y="-8" cx="273.0268226892148" cy="238.62943548560594" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y-" data-x="-3.7249999999999996" data-y="-8" cx="281.9740945579358" cy="238.62943548560594" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-3" data-y="-8.45" cx="294.9476387675812" cy="246.6819801674548" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -542,7 +566,11 @@ orientation: y+" data-x="-6.262500000000001" data-y="-8" cx="236.56668982417676"
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-10.225" cx="277.0530950301392" cy="278.44479530141433" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: x+" data-x="-3" data-y="-9.775" cx="294.9476387675812" cy="270.39225061956546" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-4.449999999999999" data-y="-10" cx="269.00055034829035" cy="274.4185229604899" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -554,7 +582,11 @@ orientation: y-" data-x="-5.750000000000001" data-y="-10" cx="245.73764348961578
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-11.775" cx="277.0530950301392" cy="306.1813380944494" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: x+" data-x="-3" data-y="-12.225" cx="294.9476387675812" cy="314.2338827762983" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-4.449999999999999" data-y="-12" cx="269.00055034829035" cy="310.2076104353738" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -566,7 +598,11 @@ orientation: y+" data-x="-6.112500000000001" data-y="-12" cx="239.25087138479304
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-14.225" cx="277.0530950301392" cy="350.0229702511822" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: x+" data-x="-3" data-y="-13.775" cx="294.9476387675812" cy="341.9704255693333" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-4.449999999999999" data-y="-14" cx="269.00055034829035" cy="345.9966979102578" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -578,7 +614,11 @@ orientation: y+" data-x="-6.162500000000001" data-y="-14" cx="238.35614419792094
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-4.225" data-y="-16" cx="273.0268226892148" cy="381.7857853851417" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: y-" data-x="-3.7249999999999996" data-y="-16" cx="281.9740945579358" cy="381.7857853851417" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-3" data-y="-16.45" cx="294.9476387675812" cy="389.8383300669906" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -590,7 +630,11 @@ orientation: y+" data-x="-6.2125" data-y="-16" cx="237.46141701104887" cy="381.7
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-18.225" cx="277.0530950301392" cy="421.6011452009501" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: x+" data-x="-3" data-y="-17.775" cx="294.9476387675812" cy="413.5486005191012" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-4.449999999999999" data-y="-18" cx="269.00055034829035" cy="417.5748728600257" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -606,7 +650,11 @@ orientation: x+" data-x="-8.4" data-y="-10.4" cx="198.31710258539454" cy="281.57
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-4.225" data-y="-20" cx="273.0268226892148" cy="453.3639603349096" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: y-" data-x="-3.7249999999999996" data-y="-20" cx="281.9740945579358" cy="453.3639603349096" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-3" data-y="-20.45" cx="294.9476387675812" cy="461.4165050167585" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -622,7 +670,11 @@ orientation: x+" data-x="-8.4" data-y="-10.8" cx="198.31710258539454" cy="288.73
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-22.225" cx="277.0530950301392" cy="493.179320150718" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: x+" data-x="-3" data-y="-21.775" cx="294.9476387675812" cy="485.12677546886914" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-4.449999999999999" data-y="-22" cx="269.00055034829035" cy="489.15304780979363" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -634,7 +686,11 @@ orientation: y+" data-x="-6.262500000000001" data-y="-22" cx="236.56668982417676
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="-4.225" data-y="-24" cx="273.0268226892148" cy="524.9421352846775" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: y-" data-x="-3.7249999999999996" data-y="-24" cx="281.9740945579358" cy="524.9421352846775" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-3" data-y="-24.45" cx="294.9476387675812" cy="532.9946799665264" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -650,7 +706,11 @@ orientation: x+" data-x="-8.4" data-y="-15.4" cx="198.31710258539454" cy="371.04
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="-4" data-y="-26.225" cx="277.0530950301392" cy="564.7574951004859" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+orientation: x+" data-x="-3" data-y="-25.775" cx="294.9476387675812" cy="556.704950418637" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-4.449999999999999" data-y="-26" cx="269.00055034829035" cy="560.7312227595614" r="3" fill="hsl(80, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
@@ -844,118 +904,73 @@ orientation: x+" data-x="-8.4" data-y="-16.2" cx="198.31710258539454" cy="385.36
     <polyline data-points="-5.550000000000001,0 -6.9750000000000005,0 -6.9750000000000005,-3 -8.4,-3" data-type="line" data-label="" points="249.31655223710416,95.47308558607014 223.81682741124934,95.47308558607014 223.81682741124934,149.15671679839608 198.31710258539454,149.15671679839608" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4.449999999999999,0 -3,0 -3,-0.44999999999999996" data-type="line" data-label="" points="269.00055034829035,95.47308558607014 294.9476387675812,95.47308558607014 294.9476387675812,103.52563026791903" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-4.449999999999999,0 -3,0 -3,1.9000000000000015 3.5999999999999996,1.9000000000000015" data-type="line" data-label="" points="269.00055034829035,95.47308558607014 294.9476387675812,95.47308558607014 294.9476387675812,61.47345248493036 413.0516274346982,61.47345248493036" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="3.5999999999999996,1.9000000000000015 -3,1.9000000000000015 -3,-0.44999999999999996" data-type="line" data-label="" points="413.0516274346982,61.47345248493036 294.9476387675812,61.47345248493036 294.9476387675812,103.52563026791903" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4.449999999999999,-1.9999999999999998 -3,-1.9999999999999998 -3,-1.55" data-type="line" data-label="" points="269.00055034829035,131.26217306095407 294.9476387675812,131.26217306095407 294.9476387675812,123.2096283791052" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4,-2.45 -4,-1.9999999999999998 -4.449999999999999,-1.9999999999999998" data-type="line" data-label="" points="277.0530950301392,139.314717742803 277.0530950301392,131.26217306095407 269.00055034829035,131.26217306095407" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="3.6000000000000005,1.7000000000000017 0.3000000000000007,1.7000000000000017 0.3000000000000007,-1.7500000000000002 -3,-1.7500000000000002 -3,-1.55" data-type="line" data-label="" points="413.0516274346983,65.05236123241875 353.99963310113975,65.05236123241875 353.99963310113975,126.7885371265936 294.9476387675812,126.7885371265936 294.9476387675812,123.2096283791052" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-4,-2.45 -4,-1.9999999999999998 -3,-1.9999999999999998 -3,-1.7500000000000002 0.3000000000000007,-1.7500000000000002 0.3000000000000007,1.7000000000000017 3.6000000000000005,1.7000000000000017" data-type="line" data-label="" points="277.0530950301392,139.314717742803 277.0530950301392,131.26217306095407 294.9476387675812,131.26217306095407 294.9476387675812,126.7885371265936 353.99963310113975,126.7885371265936 353.99963310113975,65.05236123241875 413.0516274346983,65.05236123241875" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-1.9999999999999998 -5.750000000000001,-1.9999999999999998 -5.750000000000001,-3.4 -8.4,-3.4" data-type="line" data-label="" points="249.31655223710416,131.26217306095407 245.73764348961578,131.26217306095407 245.73764348961578,156.31453429337284 198.31710258539454,156.31453429337284" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4.449999999999999,-4 -4,-4 -4,-3.55" data-type="line" data-label="" points="269.00055034829035,167.05126053583803 277.0530950301392,167.05126053583803 277.0530950301392,158.99871585398915" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-3,-4.449999999999999 -3,-4 -4.449999999999999,-4" data-type="line" data-label="" points="294.9476387675812,175.1038052176869 294.9476387675812,167.05126053583803 269.00055034829035,167.05126053583803" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-4,-3.55 -4,-4 -3,-4 -3,-4.449999999999999" data-type="line" data-label="" points="277.0530950301392,158.99871585398915 277.0530950301392,167.05126053583803 294.9476387675812,167.05126053583803 294.9476387675812,175.1038052176869" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-4 -6.9750000000000005,-4 -6.9750000000000005,-3.8 -8.4,-3.8" data-type="line" data-label="" points="249.31655223710416,167.05126053583803 223.81682741124934,167.05126053583803 223.81682741124934,163.47235178834964 198.31710258539454,163.47235178834964" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4,-6.449999999999999 -4,-6 -3,-6 -3,-5.550000000000001" data-type="line" data-label="" points="277.0530950301392,210.89289269257085 277.0530950301392,202.84034801072198 294.9476387675812,202.84034801072198 294.9476387675812,194.7878033288731" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4.449999999999999,-6 -4,-6 -4,-6.449999999999999" data-type="line" data-label="" points="269.00055034829035,202.84034801072198 277.0530950301392,202.84034801072198 277.0530950301392,210.89289269257085" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3,-5.550000000000001 -3,-6 -4.449999999999999,-6" data-type="line" data-label="" points="294.9476387675812,194.7878033288731 294.9476387675812,202.84034801072198 269.00055034829035,202.84034801072198" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-6 -5.750000000000001,-6 -5.750000000000001,-4.2 -8.4,-4.2" data-type="line" data-label="" points="249.31655223710416,202.84034801072198 245.73764348961578,202.84034801072198 245.73764348961578,170.63016928332644 198.31710258539454,170.63016928332644" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4.449999999999999,-8 -4,-8 -4,-7.550000000000001" data-type="line" data-label="" points="269.00055034829035,238.62943548560594 277.0530950301392,238.62943548560594 277.0530950301392,230.57689080375707" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-3,-8.45 -3,-8 -4,-8 -4,-7.550000000000001" data-type="line" data-label="" points="294.9476387675812,246.6819801674548 294.9476387675812,238.62943548560594 277.0530950301392,238.62943548560594 277.0530950301392,230.57689080375707" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-4.449999999999999,-8 -3,-8 -3,-8.45" data-type="line" data-label="" points="269.00055034829035,238.62943548560594 294.9476387675812,238.62943548560594 294.9476387675812,246.6819801674548" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-8 -6.9750000000000005,-8 -6.9750000000000005,-4.6 -8.4,-4.6" data-type="line" data-label="" points="249.31655223710416,238.62943548560594 223.81682741124934,238.62943548560594 223.81682741124934,177.7879867783032 198.31710258539454,177.7879867783032" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4,-10.45 -4,-10 -3,-10 -3,-9.55" data-type="line" data-label="" points="277.0530950301392,282.47106764233877 277.0530950301392,274.4185229604899 294.9476387675812,274.4185229604899 294.9476387675812,266.365978278641" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4.449999999999999,-10 -4,-10 -4,-10.45" data-type="line" data-label="" points="269.00055034829035,274.4185229604899 277.0530950301392,274.4185229604899 277.0530950301392,282.47106764233877" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3,-9.55 -3,-10 -4.449999999999999,-10" data-type="line" data-label="" points="294.9476387675812,266.365978278641 294.9476387675812,274.4185229604899 269.00055034829035,274.4185229604899" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-10 -5.750000000000001,-10 -5.750000000000001,-9 -8.200000000000001,-9 -8.200000000000001,-5 -8.4,-5" data-type="line" data-label="" points="249.31655223710416,274.4185229604899 245.73764348961578,274.4185229604899 245.73764348961578,256.52397922304795 201.89601133288292,256.52397922304795 201.89601133288292,184.94580427328003 198.31710258539454,184.94580427328003" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4,-11.55 -4,-12 -3,-12 -3,-12.45" data-type="line" data-label="" points="277.0530950301392,302.1550657535249 277.0530950301392,310.2076104353738 294.9476387675812,310.2076104353738 294.9476387675812,318.2601551172227" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4.449999999999999,-12 -4,-12 -4,-11.55" data-type="line" data-label="" points="269.00055034829035,310.2076104353738 277.0530950301392,310.2076104353738 277.0530950301392,302.1550657535249" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3,-12.45 -3,-12 -4.449999999999999,-12" data-type="line" data-label="" points="294.9476387675812,318.2601551172227 294.9476387675812,310.2076104353738 269.00055034829035,310.2076104353738" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-12 -6.675000000000001,-12 -6.675000000000001,-9.2 -8.4,-9.2" data-type="line" data-label="" points="249.31655223710416,310.2076104353738 229.18519053248195,310.2076104353738 229.18519053248195,260.1028879705363 198.31710258539454,260.1028879705363" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4,-14.45 -4,-14 -3,-14 -3,-13.55" data-type="line" data-label="" points="277.0530950301392,354.0492425921067 277.0530950301392,345.9966979102578 294.9476387675812,345.9966979102578 294.9476387675812,337.94415322840894" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4.449999999999999,-14 -4,-14 -4,-14.45" data-type="line" data-label="" points="269.00055034829035,345.9966979102578 277.0530950301392,345.9966979102578 277.0530950301392,354.0492425921067" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3,-13.55 -3,-14 -4.449999999999999,-14" data-type="line" data-label="" points="294.9476387675812,337.94415322840894 294.9476387675812,345.9966979102578 269.00055034829035,345.9966979102578" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-14 -6.775000000000001,-14 -6.775000000000001,-9.6 -8.4,-9.6" data-type="line" data-label="" points="249.31655223710416,345.9966979102578 227.39573615873775,345.9966979102578 227.39573615873775,267.26070546551307 198.31710258539454,267.26070546551307" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4.449999999999999,-16 -4,-16 -4,-15.55" data-type="line" data-label="" points="269.00055034829035,381.7857853851417 277.0530950301392,381.7857853851417 277.0530950301392,373.73324070329284" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-3,-16.45 -3,-16 -4,-16 -4,-15.55" data-type="line" data-label="" points="294.9476387675812,389.8383300669906 294.9476387675812,381.7857853851417 277.0530950301392,381.7857853851417 277.0530950301392,373.73324070329284" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-4.449999999999999,-16 -3,-16 -3,-16.45" data-type="line" data-label="" points="269.00055034829035,381.7857853851417 294.9476387675812,381.7857853851417 294.9476387675812,389.8383300669906" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-16 -6.875000000000001,-16 -6.875000000000001,-10 -8.4,-10" data-type="line" data-label="" points="249.31655223710416,381.7857853851417 225.60628178499354,381.7857853851417 225.60628178499354,274.4185229604899 198.31710258539454,274.4185229604899" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4,-18.45 -4,-18 -3,-18 -3,-17.55" data-type="line" data-label="" points="277.0530950301392,425.6274175418746 277.0530950301392,417.5748728600257 294.9476387675812,417.5748728600257 294.9476387675812,409.52232817817685" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3,-17.55 -3,-18 -4.449999999999999,-18" data-type="line" data-label="" points="294.9476387675812,409.52232817817685 294.9476387675812,417.5748728600257 269.00055034829035,417.5748728600257" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4.449999999999999,-18 -4,-18 -4,-18.45" data-type="line" data-label="" points="269.00055034829035,417.5748728600257 277.0530950301392,417.5748728600257 277.0530950301392,425.6274175418746" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-4.449999999999999,-20 -3,-20 -3,-20.45" data-type="line" data-label="" points="269.00055034829035,453.3639603349096 294.9476387675812,453.3639603349096 294.9476387675812,461.4165050167585" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4.449999999999999,-20 -4,-20 -4,-19.55" data-type="line" data-label="" points="269.00055034829035,453.3639603349096 277.0530950301392,453.3639603349096 277.0530950301392,445.31141565306075" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-3,-20.45 -3,-20 -4,-20 -4,-19.55" data-type="line" data-label="" points="294.9476387675812,461.4165050167585 294.9476387675812,453.3639603349096 277.0530950301392,453.3639603349096 277.0530950301392,445.31141565306075" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4,-22.45 -4,-22 -3,-22 -3,-21.55" data-type="line" data-label="" points="277.0530950301392,497.2055924916425 277.0530950301392,489.15304780979363 294.9476387675812,489.15304780979363 294.9476387675812,481.10050312794476" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4.449999999999999,-22 -4,-22 -4,-22.45" data-type="line" data-label="" points="269.00055034829035,489.15304780979363 277.0530950301392,489.15304780979363 277.0530950301392,497.2055924916425" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3,-21.55 -3,-22 -4.449999999999999,-22" data-type="line" data-label="" points="294.9476387675812,481.10050312794476 294.9476387675812,489.15304780979363 269.00055034829035,489.15304780979363" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-5.550000000000001,-22 -6.9750000000000005,-22 -6.9750000000000005,-15 -8.4,-15" data-type="line" data-label="" points="249.31655223710416,489.15304780979363 223.81682741124934,489.15304780979363 223.81682741124934,363.89124164769976 198.31710258539454,363.89124164769976" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-4.449999999999999,-24 -4,-24 -4,-23.55" data-type="line" data-label="" points="269.00055034829035,524.9421352846775 277.0530950301392,524.9421352846775 277.0530950301392,516.8895906028287" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-4.449999999999999,-24 -3,-24 -3,-24.45" data-type="line" data-label="" points="269.00055034829035,524.9421352846775 294.9476387675812,524.9421352846775 294.9476387675812,532.9946799665264" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-3,-24.45 -3,-24 -4,-24 -4,-23.55" data-type="line" data-label="" points="294.9476387675812,532.9946799665264 294.9476387675812,524.9421352846775 277.0530950301392,524.9421352846775 277.0530950301392,516.8895906028287" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4,-26.45 -4,-26 -3,-26 -3,-25.55" data-type="line" data-label="" points="277.0530950301392,568.7837674414103 277.0530950301392,560.7312227595614 294.9476387675812,560.7312227595614 294.9476387675812,552.6786780777126" fill="none" stroke="purple" stroke-width="1" />
-  </g>
-  <g>
-    <polyline data-points="-4.449999999999999,-26 -4,-26 -4,-26.45" data-type="line" data-label="" points="269.00055034829035,560.7312227595614 277.0530950301392,560.7312227595614 277.0530950301392,568.7837674414103" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-3,-25.55 -3,-26 -4.449999999999999,-26" data-type="line" data-label="" points="294.9476387675812,552.6786780777126 294.9476387675812,560.7312227595614 269.00055034829035,560.7312227595614" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <rect data-type="rect" data-label="schematic_component_0" data-x="-5" data-y="0" x="249.31655223710416" y="91.99339582051556" width="19.683998111186185" height="6.959379531109164" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.05588295598214286" />
@@ -1062,11 +1077,23 @@ globalConnNetId: connectivity_net0" data-x="-6.262500000000001" data-y="0.225" x
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R2 &gt; .pin2 to C4.pin1
-globalConnNetId: connectivity_net1" data-x="0.2999999999999998" data-y="2.1250000000000013" x="352.21017872739554" y="53.42090780308148" width="3.578908747488356" height="8.052544681848893" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net1" data-x="-3.7249999999999996" data-y="0.225" x="280.1846401841916" y="87.42054090422126" width="3.578908747488356" height="8.052544681848886" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .C4 &gt; .pin1 to U1.VC16
+globalConnNetId: connectivity_net1" data-x="3.3739999999999997" data-y="1.9000000000000012" x="404.9811882091119" y="59.68399811118617" width="8.052544681848872" height="3.5789087474883985" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R3 &gt; .pin2 to C5.pin1
-globalConnNetId: connectivity_net2" data-x="1.9500000000000006" data-y="1.4750000000000016" x="381.7361758941748" y="65.05236123241875" width="3.5789087474884127" height="8.0525446818489" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net2" data-x="-3.775" data-y="-2.225" x="277.0530950301392" y="133.49899102813433" width="8.052544681848929" height="3.5789087474884127" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .C5 &gt; .pin1 to U1.VC15
+globalConnNetId: connectivity_net2" data-x="-4" data-y="-1.775" x="275.26364065639507" y="123.2096283791052" width="3.578908747488356" height="8.0525446818489" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .C5 &gt; .pin1 to U1.VC15
+globalConnNetId: connectivity_net2" data-x="3.3739999999999997" data-y="1.7000000000000013" x="404.9811882091119" y="63.26290685867456" width="8.052544681848872" height="3.5789087474883914" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R3 &gt; .pin1 to J1.pin2
@@ -1074,7 +1101,11 @@ globalConnNetId: connectivity_net3" data-x="-5.750000000000001" data-y="-1.77499
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R4 &gt; .pin2 to C6.pin1
-globalConnNetId: connectivity_net4" data-x="-2.775" data-y="-4.225" x="294.9476387675812" y="169.28807850301828" width="8.052544681848872" height="3.5789087474883843" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net4" data-x="-3.775" data-y="-3.775" x="277.0530950301392" y="161.23553382116938" width="8.052544681848929" height="3.5789087474884127" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .C6 &gt; .pin1 to U1.VC14
+globalConnNetId: connectivity_net4" data-x="-3" data-y="-4.223999999999999" x="293.158184393837" y="167.03336599210058" width="3.5789087474884127" height="8.052544681848872" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C6 &gt; .pin1 to U1.VC14
@@ -1086,7 +1117,11 @@ globalConnNetId: connectivity_net5" data-x="-6.262500000000001" data-y="-3.775" 
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C7 &gt; .pin1 to U1.VC13
-globalConnNetId: connectivity_net6" data-x="-3.775" data-y="-6.225" x="277.0530950301392" y="205.07716597790224" width="8.052544681848929" height="3.5789087474883843" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net6" data-x="-2.775" data-y="-5.775" x="294.9476387675812" y="197.02462129605334" width="8.052544681848872" height="3.5789087474884127" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .R7 &gt; .pin2 to C7.pin1
+globalConnNetId: connectivity_net6" data-x="-4.223999999999999" data-y="-6" x="269.0184448920278" y="201.0508936369778" width="8.052544681848872" height="3.5789087474883843" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C7 &gt; .pin1 to U1.VC13
@@ -1098,7 +1133,11 @@ globalConnNetId: connectivity_net7" data-x="-5.750000000000001" data-y="-6.225" 
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R8 &gt; .pin2 to C8.pin1
-globalConnNetId: connectivity_net8" data-x="-4.225" data-y="-8.225" x="271.2373683154706" y="238.62943548560594" width="3.5789087474884127" height="8.052544681848872" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net8" data-x="-3.7249999999999996" data-y="-8.225" x="280.1846401841916" y="238.62943548560594" width="3.578908747488356" height="8.052544681848872" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .C8 &gt; .pin1 to U1.VC12
+globalConnNetId: connectivity_net8" data-x="-3" data-y="-8.224" x="293.158184393837" y="238.6115409418685" width="3.5789087474884127" height="8.052544681848872" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C8 &gt; .pin1 to U1.VC12
@@ -1110,7 +1149,11 @@ globalConnNetId: connectivity_net9" data-x="-6.262500000000001" data-y="-7.775" 
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C9 &gt; .pin1 to U1.VC10
-globalConnNetId: connectivity_net10" data-x="-3.775" data-y="-10.225" x="277.0530950301392" y="276.6553409276701" width="8.052544681848929" height="3.578908747488356" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net10" data-x="-2.775" data-y="-9.775" x="294.9476387675812" y="268.60279624582125" width="8.052544681848872" height="3.578908747488356" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .R11 &gt; .pin2 to C9.pin1
+globalConnNetId: connectivity_net10" data-x="-4.223999999999999" data-y="-10" x="269.0184448920278" y="272.6290685867457" width="8.052544681848872" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C9 &gt; .pin1 to U1.VC10
@@ -1122,7 +1165,11 @@ globalConnNetId: connectivity_net11" data-x="-5.750000000000001" data-y="-10.225
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C9 &gt; .pin2 to C10.pin1
-globalConnNetId: connectivity_net12" data-x="-3.775" data-y="-11.775" x="277.0530950301392" y="304.3918837207052" width="8.052544681848929" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net12" data-x="-2.775" data-y="-12.225" x="294.9476387675812" y="312.4444284025541" width="8.052544681848872" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .R12 &gt; .pin2 to C10.pin1
+globalConnNetId: connectivity_net12" data-x="-4.223999999999999" data-y="-12" x="269.0184448920278" y="308.41815606162965" width="8.052544681848872" height="3.578908747488356" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C10 &gt; .pin1 to U1.VC9
@@ -1134,7 +1181,11 @@ globalConnNetId: connectivity_net13" data-x="-6.112500000000001" data-y="-11.775
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C11 &gt; .pin1 to U1.VC8
-globalConnNetId: connectivity_net14" data-x="-3.775" data-y="-14.225" x="277.0530950301392" y="348.23351587743804" width="8.052544681848929" height="3.578908747488356" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net14" data-x="-2.775" data-y="-13.775" x="294.9476387675812" y="340.18097119558917" width="8.052544681848872" height="3.578908747488356" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .R13 &gt; .pin2 to C11.pin1
+globalConnNetId: connectivity_net14" data-x="-4.223999999999999" data-y="-14" x="269.0184448920278" y="344.2072435365136" width="8.052544681848872" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C11 &gt; .pin1 to U1.VC8
@@ -1146,7 +1197,11 @@ globalConnNetId: connectivity_net15" data-x="-6.162500000000001" data-y="-13.775
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R14 &gt; .pin2 to C14.pin1
-globalConnNetId: connectivity_net16" data-x="-4.225" data-y="-16.225" x="271.2373683154706" y="381.7857853851417" width="3.5789087474884127" height="8.052544681848985" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net16" data-x="-3.7249999999999996" data-y="-16.225" x="280.1846401841916" y="381.7857853851417" width="3.578908747488356" height="8.052544681848985" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .C14 &gt; .pin1 to U1.VC6
+globalConnNetId: connectivity_net16" data-x="-3" data-y="-16.223999999999997" x="293.158184393837" y="381.7678908414042" width="3.5789087474884127" height="8.052544681848985" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C14 &gt; .pin1 to U1.VC6
@@ -1158,7 +1213,11 @@ globalConnNetId: connectivity_net17" data-x="-6.2125" data-y="-15.775" x="235.67
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C16 &gt; .pin1 to U1.VC5
-globalConnNetId: connectivity_net18" data-x="-3.775" data-y="-18.225" x="277.0530950301392" y="419.8116908272059" width="8.052544681848929" height="3.5789087474885264" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net18" data-x="-2.775" data-y="-17.775" x="294.9476387675812" y="411.759146145357" width="8.052544681848872" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .R16 &gt; .pin2 to C16.pin1
+globalConnNetId: connectivity_net18" data-x="-4.223999999999999" data-y="-18" x="269.0184448920278" y="415.7854184862815" width="8.052544681848872" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C16 &gt; .pin1 to U1.VC5
@@ -1174,7 +1233,11 @@ globalConnNetId: connectivity_net19" data-x="-8.174000000000001" data-y="-10.4" 
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R17 &gt; .pin2 to C17.pin1
-globalConnNetId: connectivity_net20" data-x="-4.225" data-y="-20.225" x="271.2373683154706" y="453.3639603349096" width="3.5789087474884127" height="8.052544681848985" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net20" data-x="-3.7249999999999996" data-y="-20.225" x="280.1846401841916" y="453.3639603349096" width="3.578908747488356" height="8.052544681848985" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .C17 &gt; .pin1 to U1.VC4
+globalConnNetId: connectivity_net20" data-x="-3" data-y="-20.223999999999997" x="293.158184393837" y="453.3460657911721" width="3.5789087474884127" height="8.052544681848872" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C17 &gt; .pin1 to U1.VC4
@@ -1190,7 +1253,11 @@ globalConnNetId: connectivity_net21" data-x="-8.174000000000001" data-y="-10.8" 
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C18 &gt; .pin1 to U1.VC3
-globalConnNetId: connectivity_net22" data-x="-3.775" data-y="-22.225" x="277.0530950301392" y="491.3898657769738" width="8.052544681848929" height="3.5789087474885264" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net22" data-x="-2.775" data-y="-21.775" x="294.9476387675812" y="483.33732109512493" width="8.052544681848872" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .R18 &gt; .pin2 to C18.pin1
+globalConnNetId: connectivity_net22" data-x="-4.223999999999999" data-y="-22" x="269.0184448920278" y="487.3635934360493" width="8.052544681848872" height="3.5789087474885264" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C18 &gt; .pin1 to U1.VC3
@@ -1202,7 +1269,11 @@ globalConnNetId: connectivity_net23" data-x="-6.262500000000001" data-y="-21.775
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .R19 &gt; .pin2 to C19.pin1
-globalConnNetId: connectivity_net24" data-x="-4.225" data-y="-24.225" x="271.2373683154706" y="524.9421352846775" width="3.5789087474884127" height="8.052544681848985" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net24" data-x="-3.7249999999999996" data-y="-24.225" x="280.1846401841916" y="524.9421352846775" width="3.578908747488356" height="8.052544681848985" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .C19 &gt; .pin1 to U1.VC2
+globalConnNetId: connectivity_net24" data-x="-3" data-y="-24.223999999999997" x="293.158184393837" y="524.92424074094" width="3.5789087474884127" height="8.052544681848872" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C19 &gt; .pin1 to U1.VC2
@@ -1218,7 +1289,11 @@ globalConnNetId: connectivity_net25" data-x="-8.174000000000001" data-y="-15.4" 
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C21 &gt; .pin1 to U1.VC1
-globalConnNetId: connectivity_net26" data-x="-3.775" data-y="-26.225" x="277.0530950301392" y="562.9680407267417" width="8.052544681848929" height="3.5789087474884127" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+globalConnNetId: connectivity_net26" data-x="-2.775" data-y="-25.775" x="294.9476387675812" y="554.9154960448927" width="8.052544681848872" height="3.5789087474885264" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: .R21 &gt; .pin2 to C21.pin1
+globalConnNetId: connectivity_net26" data-x="-4.223999999999999" data-y="-26" x="269.0184448920278" y="558.9417683858172" width="8.052544681848872" height="3.5789087474885264" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.05588295598214286" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: .C21 &gt; .pin1 to U1.VC1

--- a/tests/functional/merge-same-net-trace-segments.test.ts
+++ b/tests/functional/merge-same-net-trace-segments.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { mergeSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/mergeSameNetTraceSegments"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: SolvedTracePath["tracePath"],
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}-a`, `${mspPairId}-b`],
+    pins: [] as any,
+  }) as SolvedTracePath
+
+test("merges close same-net horizontal trace segments", () => {
+  const traces = mergeSameNetTraceSegments([
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+    ]),
+    makeTrace("b", "net1", [
+      { x: 2.05, y: 0 },
+      { x: 4, y: 0 },
+    ]),
+  ])
+
+  expect(traces).toHaveLength(1)
+  expect(traces[0]!.mspConnectionPairIds).toEqual(["a", "b"])
+  expect(traces[0]!.tracePath).toEqual([
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+  ])
+})
+
+test("does not merge traces from different nets", () => {
+  const traces = mergeSameNetTraceSegments([
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+    ]),
+    makeTrace("b", "net2", [
+      { x: 2.05, y: 0 },
+      { x: 4, y: 0 },
+    ]),
+  ])
+
+  expect(traces).toHaveLength(2)
+})
+
+test("does not merge distant same-net segments on the same axis", () => {
+  const traces = mergeSameNetTraceSegments([
+    makeTrace("a", "net1", [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+    ]),
+    makeTrace("b", "net1", [
+      { x: 4, y: 0 },
+      { x: 6, y: 0 },
+    ]),
+  ])
+
+  expect(traces).toHaveLength(2)
+})


### PR DESCRIPTION
# Fix: merge close same-net schematic trace segments

## Summary

Adds a final trace-cleanup phase that merges close colinear trace segments belonging to the same `globalConnNetId`.

This addresses tscircuit/schematic-trace-solver#34 and strengthens the existing tscircuit/schematic-trace-solver#29 reproduction by reducing fragmented same-net trace output when two solved trace paths end close together on the same X or Y axis.

## What Changed

- Added `mergeSameNetTraceSegments`, a pure cleanup helper.
- Connected the helper as the final `TraceCleanupSolver` phase after L-shape balancing.
- Preserved safety checks so traces only merge when:
  - both traces share the same `globalConnNetId`;
  - endpoints are on the same X or Y axis within tolerance;
  - endpoint distance is within tolerance, avoiding distant same-axis merges.
- Added focused tests for merge and non-merge behavior.
- Updated the `example29` snapshot after validating the reproduction against the new cleanup phase.

## Verification

Ran the focused functional test and the existing example repro tests:

```text
bun test tests/examples/example29.test.ts tests/examples/example34.test.ts tests/functional/merge-same-net-trace-segments.test.ts

5 pass
0 fail
9 expect() calls
```

The local workspace needed the `sharp` native binary installed before running the SVG snapshot tests.

## Bounty

Targets issues:
- https://github.com/tscircuit/schematic-trace-solver/issues/34
- https://github.com/tscircuit/schematic-trace-solver/issues/29

Algora listing: https://algora.io/tscircuit/bounties/community

/claim #34
/claim #29
