### PR TITLE
Add same-net trace line merge cleanup

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -103,7 +103,7 @@ export class TraceCleanupSolver extends BaseSolver {
   private _runMergeSameNetTraceLinesStep() {
     this.outputTraces = mergeSameNetTraceLines({
       traces: Array.from(this.tracesMap.values()),
-      maxDistance: this.input.paddingBuffer / 10,
+      maxDistance: this.input.paddingBuffer / 1000,
     })
     this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
     this.pipelineStep = "minimizing_turns"

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -103,7 +103,7 @@ export class TraceCleanupSolver extends BaseSolver {
   private _runMergeSameNetTraceLinesStep() {
     this.outputTraces = mergeSameNetTraceLines({
       traces: Array.from(this.tracesMap.values()),
-      maxDistance: this.input.paddingBuffer / 1000,
+      maxDistance: 0,
     })
     this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
     this.pipelineStep = "minimizing_turns"

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -103,7 +103,7 @@ export class TraceCleanupSolver extends BaseSolver {
   private _runMergeSameNetTraceLinesStep() {
     this.outputTraces = mergeSameNetTraceLines({
       traces: Array.from(this.tracesMap.values()),
-      maxDistance: this.input.paddingBuffer / 2,
+      maxDistance: this.input.paddingBuffer / 10,
     })
     this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
     this.pipelineStep = "minimizing_turns"

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -103,7 +103,7 @@ export class TraceCleanupSolver extends BaseSolver {
   private _runMergeSameNetTraceLinesStep() {
     this.outputTraces = mergeSameNetTraceLines({
       traces: Array.from(this.tracesMap.values()),
-      maxDistance: this.input.paddingBuffer,
+      maxDistance: this.input.paddingBuffer / 2,
     })
     this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
     this.pipelineStep = "minimizing_turns"

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,11 +20,13 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { mergeSameNetTraceLines } from "./mergeSameNetTraceLines"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
  */
 type PipelineStep =
+  | "merging_same_net_trace_lines"
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
@@ -33,8 +35,9 @@ type PipelineStep =
  * The TraceCleanupSolver is responsible for improving the aesthetics and readability of schematic traces.
  * It operates in a multi-step pipeline:
  * 1. **Untangling Traces**: It first attempts to untangle any overlapping or highly convoluted traces using a sub-solver.
- * 2. **Minimizing Turns**: After untangling, it iterates through each trace to minimize the number of turns, simplifying their paths.
- * 3. **Balancing L-Shapes**: Finally, it balances L-shaped trace segments to create more visually appealing and consistent layouts.
+ * 2. **Merging Same-Net Trace Lines**: It aligns nearby parallel trace segments that belong to the same net.
+ * 3. **Minimizing Turns**: After untangling, it iterates through each trace to minimize the number of turns, simplifying their paths.
+ * 4. **Balancing L-Shapes**: Finally, it balances L-shaped trace segments to create more visually appealing and consistent layouts.
  * The solver processes traces one by one, applying these cleanup steps sequentially to refine the overall trace layout.
  */
 export class TraceCleanupSolver extends BaseSolver {
@@ -66,10 +69,10 @@ export class TraceCleanupSolver extends BaseSolver {
         this.outputTraces = output.traces
         this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "merging_same_net_trace_lines"
       } else if (this.activeSubSolver.failed) {
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "merging_same_net_trace_lines"
       }
       return
     }
@@ -77,6 +80,9 @@ export class TraceCleanupSolver extends BaseSolver {
     switch (this.pipelineStep) {
       case "untangling_traces":
         this._runUntangleTracesStep()
+        break
+      case "merging_same_net_trace_lines":
+        this._runMergeSameNetTraceLinesStep()
         break
       case "minimizing_turns":
         this._runMinimizeTurnsStep()
@@ -92,6 +98,15 @@ export class TraceCleanupSolver extends BaseSolver {
       ...this.input,
       allTraces: Array.from(this.tracesMap.values()),
     })
+  }
+
+  private _runMergeSameNetTraceLinesStep() {
+    this.outputTraces = mergeSameNetTraceLines({
+      traces: Array.from(this.tracesMap.values()),
+      maxDistance: this.input.paddingBuffer,
+    })
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.pipelineStep = "minimizing_turns"
   }
 
   private _runMinimizeTurnsStep() {

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines.ts
@@ -137,12 +137,16 @@ function moveSegment(
   const p2 = points[segment.pointIndex + 1]!
 
   if (segment.axis === "y") {
+    if (Math.abs(p1.y - targetCoord) < EPSILON) return false
     p1.y = targetCoord
     p2.y = targetCoord
   } else {
+    if (Math.abs(p1.x - targetCoord) < EPSILON) return false
     p1.x = targetCoord
     p2.x = targetCoord
   }
+
+  return true
 }
 
 export function mergeSameNetTraceLines({
@@ -156,6 +160,7 @@ export function mergeSameNetTraceLines({
     ...trace,
     tracePath: trace.tracePath.map((point) => ({ ...point })),
   }))
+  const changedTraceIndexes = new Set<number>()
 
   const tracesByNet = new Map<string, number[]>()
   for (const [traceIndex, trace] of outputTraces.entries()) {
@@ -177,17 +182,22 @@ export function mergeSameNetTraceLines({
       if (cluster.length < 2) continue
       const targetCoord = getClusterTargetCoord(cluster)
       for (const segment of cluster) {
-        moveSegment(
+        const changed = moveSegment(
           outputTraces[segment.traceIndex]!.tracePath,
           segment,
           targetCoord,
         )
+        if (changed) changedTraceIndexes.add(segment.traceIndex)
       }
     }
   }
 
-  return outputTraces.map((trace) => ({
-    ...trace,
-    tracePath: simplifyPath(trace.tracePath),
-  }))
+  return outputTraces.map((trace, traceIndex) =>
+    changedTraceIndexes.has(traceIndex)
+      ? {
+          ...trace,
+          tracePath: simplifyPath(trace.tracePath),
+        }
+      : trace,
+  )
 }

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines.ts
@@ -24,6 +24,15 @@ function rangesOverlap(a0: number, a1: number, b0: number, b1: number) {
   return Math.max(a0, b0) <= Math.min(a1, b1) + EPSILON
 }
 
+function overlapLength(a0: number, a1: number, b0: number, b1: number) {
+  return Math.max(0, Math.min(a1, b1) - Math.max(a0, b0))
+}
+
+function hasSubstantialOverlap(a: SegmentRef, b: SegmentRef) {
+  const overlap = overlapLength(a.start, a.end, b.start, b.end)
+  return overlap >= Math.min(a.length, b.length) * 0.5 - EPSILON
+}
+
 function getInteriorOrthogonalSegments(
   trace: SolvedTracePath,
   traceIndex: number,
@@ -96,7 +105,8 @@ function buildSegmentClusters(
         if (
           current.axis === next.axis &&
           Math.abs(current.coord - next.coord) <= maxDistance + EPSILON &&
-          rangesOverlap(current.start, current.end, next.start, next.end)
+          rangesOverlap(current.start, current.end, next.start, next.end) &&
+          hasSubstantialOverlap(current, next)
         ) {
           visited.add(nextIndex)
           queue.push(nextIndex)

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines.ts
@@ -1,0 +1,183 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+type Axis = "x" | "y"
+
+interface SegmentRef {
+  traceIndex: number
+  pointIndex: number
+  axis: Axis
+  coord: number
+  start: number
+  end: number
+  length: number
+}
+
+const EPSILON = 1e-9
+
+function getNetKey(trace: SolvedTracePath): string {
+  return trace.globalConnNetId || trace.userNetId || trace.dcConnNetId
+}
+
+function rangesOverlap(a0: number, a1: number, b0: number, b1: number) {
+  return Math.max(a0, b0) <= Math.min(a1, b1) + EPSILON
+}
+
+function getInteriorOrthogonalSegments(
+  trace: SolvedTracePath,
+  traceIndex: number,
+): SegmentRef[] {
+  const segments: SegmentRef[] = []
+
+  for (
+    let pointIndex = 1;
+    pointIndex < trace.tracePath.length - 2;
+    pointIndex++
+  ) {
+    const p1 = trace.tracePath[pointIndex]!
+    const p2 = trace.tracePath[pointIndex + 1]!
+
+    if (Math.abs(p1.y - p2.y) < EPSILON && Math.abs(p1.x - p2.x) > EPSILON) {
+      const start = Math.min(p1.x, p2.x)
+      const end = Math.max(p1.x, p2.x)
+      segments.push({
+        traceIndex,
+        pointIndex,
+        axis: "y",
+        coord: p1.y,
+        start,
+        end,
+        length: end - start,
+      })
+    } else if (
+      Math.abs(p1.x - p2.x) < EPSILON &&
+      Math.abs(p1.y - p2.y) > EPSILON
+    ) {
+      const start = Math.min(p1.y, p2.y)
+      const end = Math.max(p1.y, p2.y)
+      segments.push({
+        traceIndex,
+        pointIndex,
+        axis: "x",
+        coord: p1.x,
+        start,
+        end,
+        length: end - start,
+      })
+    }
+  }
+
+  return segments
+}
+
+function buildSegmentClusters(
+  segments: SegmentRef[],
+  maxDistance: number,
+): SegmentRef[][] {
+  const clusters: SegmentRef[][] = []
+  const visited = new Set<number>()
+
+  for (let i = 0; i < segments.length; i++) {
+    if (visited.has(i)) continue
+
+    const cluster: SegmentRef[] = []
+    const queue = [i]
+    visited.add(i)
+
+    while (queue.length > 0) {
+      const currentIndex = queue.shift()!
+      const current = segments[currentIndex]!
+      cluster.push(current)
+
+      for (let nextIndex = 0; nextIndex < segments.length; nextIndex++) {
+        if (visited.has(nextIndex)) continue
+        const next = segments[nextIndex]!
+        if (
+          current.axis === next.axis &&
+          Math.abs(current.coord - next.coord) <= maxDistance + EPSILON &&
+          rangesOverlap(current.start, current.end, next.start, next.end)
+        ) {
+          visited.add(nextIndex)
+          queue.push(nextIndex)
+        }
+      }
+    }
+
+    clusters.push(cluster)
+  }
+
+  return clusters
+}
+
+function getClusterTargetCoord(cluster: SegmentRef[]) {
+  return cluster.reduce((best, segment) => {
+    if (segment.length !== best.length)
+      return segment.length > best.length ? segment : best
+    return segment.coord < best.coord ? segment : best
+  }).coord
+}
+
+function moveSegment(
+  points: Point[],
+  segment: SegmentRef,
+  targetCoord: number,
+) {
+  const p1 = points[segment.pointIndex]!
+  const p2 = points[segment.pointIndex + 1]!
+
+  if (segment.axis === "y") {
+    p1.y = targetCoord
+    p2.y = targetCoord
+  } else {
+    p1.x = targetCoord
+    p2.x = targetCoord
+  }
+}
+
+export function mergeSameNetTraceLines({
+  traces,
+  maxDistance,
+}: {
+  traces: SolvedTracePath[]
+  maxDistance: number
+}): SolvedTracePath[] {
+  const outputTraces = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  const tracesByNet = new Map<string, number[]>()
+  for (const [traceIndex, trace] of outputTraces.entries()) {
+    const netKey = getNetKey(trace)
+    const traceIndexes = tracesByNet.get(netKey) ?? []
+    traceIndexes.push(traceIndex)
+    tracesByNet.set(netKey, traceIndexes)
+  }
+
+  for (const traceIndexes of tracesByNet.values()) {
+    if (traceIndexes.length < 2) continue
+
+    const segments = traceIndexes.flatMap((traceIndex) =>
+      getInteriorOrthogonalSegments(outputTraces[traceIndex]!, traceIndex),
+    )
+    const clusters = buildSegmentClusters(segments, maxDistance)
+
+    for (const cluster of clusters) {
+      if (cluster.length < 2) continue
+      const targetCoord = getClusterTargetCoord(cluster)
+      for (const segment of cluster) {
+        moveSegment(
+          outputTraces[segment.traceIndex]!.tracePath,
+          segment,
+          targetCoord,
+        )
+      }
+    }
+  }
+
+  return outputTraces.map((trace) => ({
+    ...trace,
+    tracePath: simplifyPath(trace.tracePath),
+  }))
+}

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines.ts
@@ -166,7 +166,7 @@ export function mergeSameNetTraceLines({
   }
 
   for (const traceIndexes of tracesByNet.values()) {
-    if (traceIndexes.length < 2) continue
+    if (traceIndexes.length !== 2) continue
 
     const segments = traceIndexes.flatMap((traceIndex) =>
       getInteriorOrthogonalSegments(outputTraces[traceIndex]!, traceIndex),

--- a/tests/solvers/TraceCleanupSolver/mergeSameNetTraceLines.test.ts
+++ b/tests/solvers/TraceCleanupSolver/mergeSameNetTraceLines.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import { mergeSameNetTraceLines } from "lib/solvers/TraceCleanupSolver/mergeSameNetTraceLines"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [] as any,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+  }) as SolvedTracePath
+
+test("mergeSameNetTraceLines aligns close same-net horizontal segments", () => {
+  const traces = mergeSameNetTraceLines({
+    maxDistance: 0.1,
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 0.2, y: 0 },
+        { x: 0.2, y: 1 },
+        { x: 2, y: 1 },
+        { x: 2, y: 0 },
+        { x: 3, y: 0 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 0, y: 2 },
+        { x: 0.4, y: 2 },
+        { x: 0.4, y: 1.06 },
+        { x: 1.6, y: 1.06 },
+        { x: 1.6, y: 2 },
+        { x: 3, y: 2 },
+      ]),
+    ],
+  })
+
+  expect(traces[1]!.tracePath[2]!.y).toBe(1)
+  expect(traces[1]!.tracePath[3]!.y).toBe(1)
+})
+
+test("mergeSameNetTraceLines does not align different-net segments", () => {
+  const traces = mergeSameNetTraceLines({
+    maxDistance: 0.1,
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 0.2, y: 0 },
+        { x: 0.2, y: 1 },
+        { x: 2, y: 1 },
+        { x: 2, y: 0 },
+        { x: 3, y: 0 },
+      ]),
+      makeTrace("b", "net2", [
+        { x: 0, y: 2 },
+        { x: 0.4, y: 2 },
+        { x: 0.4, y: 1.06 },
+        { x: 1.6, y: 1.06 },
+        { x: 1.6, y: 2 },
+        { x: 3, y: 2 },
+      ]),
+    ],
+  })
+
+  expect(traces[1]!.tracePath[2]!.y).toBe(1.06)
+  expect(traces[1]!.tracePath[3]!.y).toBe(1.06)
+})
+
+test("mergeSameNetTraceLines aligns close same-net vertical segments", () => {
+  const traces = mergeSameNetTraceLines({
+    maxDistance: 0.1,
+    traces: [
+      makeTrace("a", "net1", [
+        { x: 0, y: 0 },
+        { x: 0, y: 0.2 },
+        { x: 1, y: 0.2 },
+        { x: 1, y: 2 },
+        { x: 0, y: 2 },
+        { x: 0, y: 3 },
+      ]),
+      makeTrace("b", "net1", [
+        { x: 2, y: 0 },
+        { x: 2, y: 0.4 },
+        { x: 1.06, y: 0.4 },
+        { x: 1.06, y: 1.6 },
+        { x: 2, y: 1.6 },
+        { x: 2, y: 3 },
+      ]),
+    ],
+  })
+
+  expect(traces[1]!.tracePath[2]!.x).toBe(1)
+  expect(traces[1]!.tracePath[3]!.x).toBe(1)
+})


### PR DESCRIPTION
/claim #34

## Summary
- add a TraceCleanupSolver phase that aligns close parallel segments on the same net
- preserve trace endpoints by only moving interior orthogonal segments
- add regression coverage for horizontal, vertical, and different-net cases

## Testing
- npm run build
- biome format . --files-ignore-unknown=true