### PR TITLE
fix(#78): remove duplicate consecutive points from trace paths

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,7 +4,21 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+export const removeDuplicateConsecutivePoints = (path: Point[]): Point[] => {
+  if (path.length === 0) return path
+  const result: Point[] = [path[0]!]
+  for (let i = 1; i < path.length; i++) {
+    const prev = result[result.length - 1]!
+    const curr = path[i]!
+    if (curr.x !== prev.x || curr.y !== prev.y) {
+      result.push(curr)
+    }
+  }
+  return result
+}
+
 export const simplifyPath = (path: Point[]): Point[] => {
+  path = removeDuplicateConsecutivePoints(path)
   if (path.length < 3) return path
   const newPath: Point[] = [path[0]]
   for (let i = 1; i < path.length - 1; i++) {

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -3,6 +3,7 @@ import type { InputProblem } from "../../../types/InputProblem"
 import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import type { NetLabelPlacement } from "../../NetLabelPlacementSolver/NetLabelPlacementSolver"
 
+import { removeDuplicateConsecutivePoints } from "../simplifyPath"
 import { findAllLShapedTurns, type LShape } from "./findAllLShapedTurns"
 import { getTraceObstacles } from "./getTraceObstacles"
 import { findIntersectionsWithObstacles } from "./findIntersectionsWithObstacles"
@@ -258,11 +259,11 @@ export class UntangleTraceSubsolver extends BaseSolver {
           p.x === this.currentLShape!.p2.x && p.y === this.currentLShape!.p2.y,
       )
       if (p2Index !== -1) {
-        const newTracePath = [
+        const newTracePath = removeDuplicateConsecutivePoints([
           ...originalTrace.tracePath.slice(0, p2Index),
           ...bestRoute,
           ...originalTrace.tracePath.slice(p2Index + 1),
-        ]
+        ])
         this.input.allTraces[traceIndex] = {
           ...originalTrace,
           tracePath: newTracePath,


### PR DESCRIPTION
## Summary

Spurious extra trace lines appear after the post-processing step because `UntangleTraceSubsolver._applyBestRoute()` splices a rerouted segment back into the original path, which can produce identical consecutive points at the splice boundaries. `simplifyPath()` collapses collinear points but does not remove zero-length (duplicate consecutive) segments, so these survive into the final output.

## Fix

- Added `removeDuplicateConsecutivePoints()` to `lib/solvers/TraceCleanupSolver/simplifyPath.ts` — filters out any consecutive points with identical coordinates.
- Called at the top of `simplifyPath()` so all paths are cleaned before collinear-collapse runs.
- Applied directly on the assembled `newTracePath` in `UntangleTraceSubsolver._applyBestRoute()` to strip duplicates at their source.

## Testing

- All 64 existing tests pass, 4 skip, 0 fail.
- Verified example32 (DISCH pin pattern, the canonical reproduction case) continues to pass.

/claim #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)