### PR TITLE
Fix npm install and build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@tscircuit/math-utils": "^0.0.19",
     "@types/bun": "^1.2.21",
-    "bun-match-svg": "^0.0.13",
+    "bun-match-svg": "^0.0.9",
     "calculate-elbow": "^0.0.12",
     "connectivity-map": "^1.0.0",
     "flatbush": "^4.5.0",
@@ -24,6 +24,7 @@
     "react-cosmos-plugin-vite": "^7.0.0",
     "react-dom": "^19.1.1",
     "tsup": "^8.5.0",
+    "typescript": "^5.0.0",
     "vite": "^7.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

This fixes the default npm install/build path for the package.

- Downgrades `bun-match-svg` from `^0.0.13` to the published `^0.0.9` range so npm can resolve it.
- Adds the missing `typescript` dev dependency required by the `tsup-node --dts` build.

## Verification

- `npm install --ignore-scripts --no-audit --no-fund` passed.
- `npm run build` passed.

I did not include a generated `package-lock.json` because the repository does not currently track one.

Related microbounty lead: charles-openclaw/charles-microbounties#28