### PR TITLE
Fix npm install and build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "calculate-elbow": "^0.0.12",
     "connectivity-map": "^1.0.0",
     "flatbush": "^4.5.0",
-    "graphics-debug": "^0.0.62",
+    "graphics-debug": "^0.0.95",
     "react": "^19.1.1",
     "react-cosmos": "^7.0.0",
     "react-cosmos-plugin-vite": "^7.0.0",
     "react-dom": "^19.1.1",
     "tsup": "^8.5.0",
+    "typescript": "^5.0.0",
     "vite": "^7.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- update `graphics-debug` to a version whose `bun-match-svg` peer range accepts the current dependency
- add `typescript` as a dev dependency so the `tsup-node --dts` build can run from a clean npm install

## Verification
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm run build`

Notes:
- `npm run format:check` still fails on existing repository-wide CRLF formatting diagnostics unrelated to this dependency fix.

Fixes/related bounty lead:
- charles-openclaw/charles-microbounties#28