### PR TITLE
fix: remove duplicate consecutive points from trace paths (#78)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,7 +4,23 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+export const removeDuplicateConsecutivePoints = (
+  points: { x: number; y: number }[],
+): { x: number; y: number }[] => {
+  if (points.length === 0) return points
+  const result: { x: number; y: number }[] = [points[0]]
+  for (let i = 1; i < points.length; i++) {
+    const prev = result[result.length - 1]
+    const curr = points[i]
+    if (curr.x !== prev.x || curr.y !== prev.y) {
+      result.push(curr)
+    }
+  }
+  return result
+}
+
 export const simplifyPath = (path: Point[]): Point[] => {
+  path = removeDuplicateConsecutivePoints(path) as Point[]
   if (path.length < 3) return path
   const newPath: Point[] = [path[0]]
   for (let i = 1; i < path.length - 1; i++) {

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -4,6 +4,7 @@ import type { SolvedTracePath } from "../../SchematicTraceLinesSolver/SchematicT
 import type { NetLabelPlacement } from "../../NetLabelPlacementSolver/NetLabelPlacementSolver"
 
 import { findAllLShapedTurns, type LShape } from "./findAllLShapedTurns"
+import { removeDuplicateConsecutivePoints } from "../simplifyPath"
 import { getTraceObstacles } from "./getTraceObstacles"
 import { findIntersectionsWithObstacles } from "./findIntersectionsWithObstacles"
 import { generateLShapeRerouteCandidates } from "./generateLShapeRerouteCandidates"
@@ -258,11 +259,11 @@ export class UntangleTraceSubsolver extends BaseSolver {
           p.x === this.currentLShape!.p2.x && p.y === this.currentLShape!.p2.y,
       )
       if (p2Index !== -1) {
-        const newTracePath = [
+        const newTracePath = removeDuplicateConsecutivePoints([
           ...originalTrace.tracePath.slice(0, p2Index),
           ...bestRoute,
           ...originalTrace.tracePath.slice(p2Index + 1),
-        ]
+        ])
         this.input.allTraces[traceIndex] = {
           ...originalTrace,
           tracePath: newTracePath,

--- a/tests/solvers/TraceCleanupSolver/removeDuplicateConsecutivePoints.test.ts
+++ b/tests/solvers/TraceCleanupSolver/removeDuplicateConsecutivePoints.test.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "bun:test"
+import { removeDuplicateConsecutivePoints } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+test("removeDuplicateConsecutivePoints - empty array returns empty array", () => {
+  expect(removeDuplicateConsecutivePoints([])).toEqual([])
+})
+
+test("removeDuplicateConsecutivePoints - single point returns unchanged", () => {
+  const input = [{ x: 1, y: 2 }]
+  expect(removeDuplicateConsecutivePoints(input)).toEqual([{ x: 1, y: 2 }])
+})
+
+test("removeDuplicateConsecutivePoints - no duplicates returns unchanged", () => {
+  const input = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ]
+  expect(removeDuplicateConsecutivePoints(input)).toEqual(input)
+})
+
+test("removeDuplicateConsecutivePoints - one consecutive duplicate is removed", () => {
+  const input = [
+    { x: 0, y: 0 },
+    { x: 1, y: 1 },
+    { x: 1, y: 1 },
+    { x: 2, y: 2 },
+  ]
+  expect(removeDuplicateConsecutivePoints(input)).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 1 },
+    { x: 2, y: 2 },
+  ])
+})
+
+test("removeDuplicateConsecutivePoints - multiple consecutive duplicates are all removed", () => {
+  const input = [
+    { x: 0, y: 0 },
+    { x: 1, y: 1 },
+    { x: 1, y: 1 },
+    { x: 1, y: 1 },
+    { x: 2, y: 2 },
+    { x: 2, y: 2 },
+    { x: 3, y: 3 },
+  ]
+  expect(removeDuplicateConsecutivePoints(input)).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 1 },
+    { x: 2, y: 2 },
+    { x: 3, y: 3 },
+  ])
+})
+
+test("removeDuplicateConsecutivePoints - non-consecutive duplicates are kept", () => {
+  // Same x,y appears twice but not consecutively — both should be kept
+  const input = [
+    { x: 0, y: 0 },
+    { x: 1, y: 1 },
+    { x: 2, y: 2 },
+    { x: 1, y: 1 },
+    { x: 0, y: 0 },
+  ]
+  expect(removeDuplicateConsecutivePoints(input)).toEqual(input)
+})
+
+test("removeDuplicateConsecutivePoints - duplicate at splice boundary (UntangleTraceSubsolver scenario)", () => {
+  // Simulates: slice(0, p2Index) ends with P, bestRoute starts with P, and slice(p2Index+1) starts with P
+  const beforeSplice = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ]
+  const bestRoute = [
+    { x: 1, y: 0 }, // duplicates last point of beforeSplice
+    { x: 1, y: 1 },
+    { x: 2, y: 1 },
+  ]
+  const afterSplice = [
+    { x: 2, y: 1 }, // duplicates last point of bestRoute
+    { x: 3, y: 1 },
+  ]
+  const combined = [...beforeSplice, ...bestRoute, ...afterSplice]
+  expect(removeDuplicateConsecutivePoints(combined)).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 2, y: 1 },
+    { x: 3, y: 1 },
+  ])
+})


### PR DESCRIPTION
## Problem

After trace routing, the post-processing step produces extra zero-length trace lines. These appear as visual artifacts in schematics.

## Root Cause

In `UntangleTraceSubsolver._applyBestRoute()`, a new trace path is assembled by splicing together three arrays:

```ts
[...tracePath.slice(0, p2Index), ...bestRoute, ...tracePath.slice(p2Index + 1)]
```

The splice boundaries can produce consecutive points with identical x,y coordinates — e.g. the last point of `slice(0, p2Index)` equals the first point of `bestRoute`. These zero-length segments pass through to the renderer as extra trace lines.

## Fix

Added `removeDuplicateConsecutivePoints()` to `simplifyPath.ts` — a pure function that removes any consecutive point where both `x` and `y` exactly match the previous point.

Two application points:
1. **`UntangleTraceSubsolver._applyBestRoute()`** — wraps the spliced `newTracePath` directly at the source of the problem.
2. **`simplifyPath()`** — called as the first step so any duplicate consecutive points entering the cleanup pass are stripped.

## Tests

Added 7 focused unit tests in `tests/solvers/TraceCleanupSolver/removeDuplicateConsecutivePoints.test.ts` covering: empty array, single point, no duplicates, one consecutive duplicate, multiple consecutive duplicates, non-consecutive duplicates (retained), and the exact splice-boundary scenario from `_applyBestRoute()`.

All 71 tests pass (64 pre-existing + 7 new), 4 skipped, 0 failing.

Fixes #78

/claim #78