### PR TITLE
Fix net-label routing and trace path cleanup

### DIFF
--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -76,7 +76,6 @@ export class LongDistancePairSolver extends BaseSolver {
     for (const netId of Object.keys(netConnMap.netMap)) {
       const allPinIdsInNet = netConnMap.getIdsConnectedToNet(netId)
       if (allPinIdsInNet.length < 2) continue
-
       const unconnectedPinIds = allPinIdsInNet.filter(
         (pinId) => !primaryConnectedPinIds.has(pinId),
       )

--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -6,11 +6,21 @@ import {
 
 export const simplifyPath = (path: Point[]): Point[] => {
   if (path.length < 3) return path
-  const newPath: Point[] = [path[0]]
-  for (let i = 1; i < path.length - 1; i++) {
+  const dedupedPath: Point[] = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    const prev = dedupedPath[dedupedPath.length - 1]
+    const next = path[i]
+    if (prev.x === next.x && prev.y === next.y) continue
+    dedupedPath.push(next)
+  }
+
+  if (dedupedPath.length < 3) return dedupedPath
+
+  const newPath: Point[] = [dedupedPath[0]]
+  for (let i = 1; i < dedupedPath.length - 1; i++) {
     const p1 = newPath[newPath.length - 1]
-    const p2 = path[i]
-    const p3 = path[i + 1]
+    const p2 = dedupedPath[i]
+    const p3 = dedupedPath[i + 1]
     if (
       (isVertical(p1, p2) && isVertical(p2, p3)) ||
       (isHorizontal(p1, p2) && isHorizontal(p2, p3))
@@ -19,7 +29,7 @@ export const simplifyPath = (path: Point[]): Point[] => {
     }
     newPath.push(p2)
   }
-  newPath.push(path[path.length - 1])
+  newPath.push(dedupedPath[dedupedPath.length - 1])
 
   if (newPath.length < 3) return newPath
   const finalPath: Point[] = [newPath[0]]

--- a/tests/examples/__snapshots__/example12.snap.svg
+++ b/tests/examples/__snapshots__/example12.snap.svg
@@ -82,23 +82,19 @@ orientation: y-" data-x="3.511" data-y="-0.4310000000000001" cx="588.11292719167
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="1.7049999999999998" data-y="0.42500000000000004" x="361.54531946508166" y="147.96699257057952" width="23.77414561664193" height="53.49182763744429" fill="#ef444466" stroke="#ef4444" stroke-width="0.008412500000000002" />
+globalConnNetId: connectivity_net0" data-x="1.7049999999999998" data-y="0.42500000000000004" x="361.54531946508166" y="147.96699257057952" width="23.77414561664193" height="53.49182763744429" fill="#ef444466" stroke="#ef4444" stroke-width="0.008412500000000002" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: OUT
-globalConnNetId: connectivity_net1
-available orientations: any" data-x="1.5250000000000001" data-y="-0.4486138374999999" x="325.28974739970283" y="266.6729465081724" width="53.49182763744432" height="23.774145616641874" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008412500000000002" />
+globalConnNetId: connectivity_net1" data-x="1.5250000000000001" data-y="-0.4486138374999999" x="325.28974739970283" y="266.6729465081724" width="53.49182763744432" height="23.774145616641874" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008412500000000002" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net2
-available orientations: y-" data-x="1.8499999999999996" data-y="-2.0194553499999994" x="378.78157503714704" y="438.54117979197616" width="23.77414561664193" height="53.49182763744432" fill="#00000066" stroke="#000000" stroke-width="0.008412500000000002" />
+globalConnNetId: connectivity_net2" data-x="1.8499999999999996" data-y="-2.0194553499999994" x="378.78157503714704" y="438.54117979197616" width="23.77414561664193" height="53.49182763744432" fill="#00000066" stroke="#000000" stroke-width="0.008412500000000002" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net2
-available orientations: y-" data-x="3.511" data-y="-0.6560000000000001" x="576.2258543833581" y="276.466249628529" width="23.77414561664193" height="53.49182763744432" fill="#00000066" stroke="#000000" stroke-width="0.008412500000000002" />
+globalConnNetId: connectivity_net2" data-x="3.511" data-y="-0.6560000000000001" x="576.2258543833581" y="276.466249628529" width="23.77414561664193" height="53.49182763744432" fill="#00000066" stroke="#000000" stroke-width="0.008412500000000002" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/examples/__snapshots__/example16.snap.svg
+++ b/tests/examples/__snapshots__/example16.snap.svg
@@ -89,23 +89,19 @@ orientation: y+" data-x="0.749" data-y="2.105" cx="258.288" cy="174.064000000000
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="465.93600000000004" width="22.400000000000034" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="465.93600000000004" width="22.400000000000034" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.449" data-y="1.4289999999999998" x="325.48800000000006" y="224.57600000000002" width="22.399999999999977" height="50.400000000000034" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.449" data-y="1.4289999999999998" x="325.48800000000006" y="224.57600000000002" width="22.399999999999977" height="50.400000000000034" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: OUT
-globalConnNetId: connectivity_net1
-available orientations: x-, x+" data-x="1.5250000000000001" data-y="0.09999999999999998" x="320" y="387.42400000000004" width="50.40000000000009" height="22.399999999999977" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net1" data-x="1.5250000000000001" data-y="0.09999999999999998" x="320" y="387.42400000000004" width="50.40000000000009" height="22.399999999999977" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net2
-available orientations: y+" data-x="0.749" data-y="2.33" x="247.08800000000002" y="123.66399999999999" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net2" data-x="0.749" data-y="2.33" x="247.08800000000002" y="123.66399999999999" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/examples/__snapshots__/example20.snap.svg
+++ b/tests/examples/__snapshots__/example20.snap.svg
@@ -79,18 +79,15 @@ orientation: y+" data-x="1.049" data-y="2.105" cx="291.88800000000003" cy="174.0
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="465.93600000000004" width="22.400000000000034" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="465.93600000000004" width="22.400000000000034" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.499" data-y="1.279" x="331.088" y="241.376" width="22.400000000000034" height="50.40000000000006" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.499" data-y="1.279" x="331.088" y="241.376" width="22.400000000000034" height="50.40000000000006" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net1
-available orientations: y+" data-x="1.049" data-y="2.33" x="280.68800000000005" y="123.66399999999999" width="22.399999999999977" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net1" data-x="1.049" data-y="2.33" x="280.68800000000005" y="123.66399999999999" width="22.399999999999977" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/examples/__snapshots__/example22.snap.svg
+++ b/tests/examples/__snapshots__/example22.snap.svg
@@ -83,23 +83,19 @@ orientation: x-" data-x="1.6" data-y="-2.095" cx="353.6" cy="454.176" r="3" fill
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.049" data-y="-2.5200000000000005" x="280.68800000000005" y="476.576" width="22.399999999999977" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.049" data-y="-2.5200000000000005" x="280.68800000000005" y="476.576" width="22.399999999999977" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net1
-available orientations: y+" data-x="1.3010000000000002" data-y="0.7260000000000001" x="308.91200000000003" y="113.02399999999997" width="22.400000000000034" height="50.400000000000006" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net1" data-x="1.3010000000000002" data-y="0.7260000000000001" x="308.91200000000003" y="113.02399999999997" width="22.400000000000034" height="50.400000000000006" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net1
-available orientations: y+" data-x="1.499" data-y="-1.469" x="331.088" y="358.864" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net1" data-x="1.499" data-y="-1.469" x="331.088" y="358.864" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: MMM
-globalConnNetId: connectivity_net2
-available orientations: x+, x-" data-x="1.374" data-y="-2.095" x="303.088" y="442.976" width="50.400000000000034" height="22.399999999999977" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net2" data-x="1.374" data-y="-2.095" x="303.088" y="442.976" width="50.400000000000034" height="22.399999999999977" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/examples/__snapshots__/example31.snap.svg
+++ b/tests/examples/__snapshots__/example31.snap.svg
@@ -26,8 +26,7 @@ orientation: y+" data-x="3.2" data-y="0.30000000000000004" cx="587.5555555555557
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="3.2" data-y="0.525" x="575.1111111111111" y="242.22222222222223" width="24.888888888888914" height="56" fill="#ef444466" stroke="#ef4444" stroke-width="0.008035714285714287" />
+globalConnNetId: connectivity_net0" data-x="3.2" data-y="0.525" x="575.1111111111111" y="242.22222222222223" width="24.888888888888914" height="56" fill="#ef444466" stroke="#ef4444" stroke-width="0.008035714285714287" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/examples/__snapshots__/example33.snap.svg
+++ b/tests/examples/__snapshots__/example33.snap.svg
@@ -41,31 +41,40 @@ x+" data-x="1.5225" data-y="-8.700000000000001" cx="480.2098309694967" cy="428.7
 x+" data-x="1.5225" data-y="-8.5" cx="480.2098309694967" cy="406.98659413250437" r="3" fill="hsl(210, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-2.15" data-y="-6.6" cx="80.63726442587912" cy="200.26423159121816" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-2.15" data-y="-6.6" cx="80.63726442587912" cy="200.26423159121816" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-0.8499999999999999" data-y="-6.6" cx="222.07888090149598" cy="200.26423159121816" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-0.8499999999999999" data-y="-6.6" cx="222.07888090149598" cy="200.26423159121816" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.5225" data-y="-8.700000000000001" cx="148.91004468622495" cy="428.7468428210609" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.5225" data-y="-8.700000000000001" cx="148.91004468622495" cy="428.7468428210609" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.5225" data-y="-8.1" cx="148.91004468622495" cy="363.4660967553915" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.5225" data-y="-8.1" cx="148.91004468622495" cy="363.4660967553915" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.5225" data-y="-8.3" cx="148.91004468622495" cy="385.22634544394805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.5225" data-y="-8.3" cx="148.91004468622495" cy="385.22634544394805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.5225" data-y="-8.5" cx="148.91004468622495" cy="406.98659413250437" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.5225" data-y="-8.5" cx="148.91004468622495" cy="406.98659413250437" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.5225" data-y="-8.1" cx="480.2098309694967" cy="363.4660967553915" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.5225" data-y="-8.1" cx="480.2098309694967" cy="363.4660967553915" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.5225" data-y="-8.3" cx="480.2098309694967" cy="385.22634544394805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.5225" data-y="-8.3" cx="480.2098309694967" cy="385.22634544394805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.6235" data-y="-8.901" cx="491.19875655721773" cy="450.61589275306005" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="1.6235" data-y="-8.901" cx="491.19875655721773" cy="450.61589275306005" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <polyline data-points="-1.95,-6.6 1.5225,-8.5" data-type="line" data-label="" points="102.39751311443555,200.26423159121816 480.2098309694967,406.98659413250437" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />

--- a/tests/examples/__snapshots__/example35.snap.svg
+++ b/tests/examples/__snapshots__/example35.snap.svg
@@ -65,19 +65,24 @@ x+" data-x="3.05" data-y="2.1" cx="544.5045045045044" cy="184.6451329378159" r="
 x+" data-x="3.05" data-y="2.3" cx="544.5045045045044" cy="160.0351571083279" r="3" fill="hsl(207, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.6010000000000002" data-y="0.3" cx="366.20522961986376" cy="406.13491540320814" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="1.6010000000000002" data-y="0.3" cx="366.20522961986376" cy="406.13491540320814" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.05" data-y="-0.10000000000000003" cx="298.40474620962425" cy="455.35486706218416" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.05" data-y="-0.10000000000000003" cx="298.40474620962425" cy="455.35486706218416" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="3.05" data-y="2.3" cx="544.5045045045044" cy="160.0351571083279" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="3.05" data-y="2.3" cx="544.5045045045044" cy="160.0351571083279" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.05" data-y="0.09999999999999998" cx="298.40474620962425" cy="430.74489123269615" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.05" data-y="0.09999999999999998" cx="298.40474620962425" cy="430.74489123269615" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="3.05" data-y="2.1" cx="544.5045045045044" cy="184.6451329378159" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="3.05" data-y="2.1" cx="544.5045045045044" cy="184.6451329378159" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <polyline data-points="1.05,0.09999999999999998 3.05,2.1" data-type="line" data-label="" points="298.40474620962425,430.74489123269615 544.5045045045044,184.6451329378159" fill="none" stroke="hsl(312, 100%, 50%, 0.8)" stroke-width="1" />

--- a/tests/examples/__snapshots__/example36.snap.svg
+++ b/tests/examples/__snapshots__/example36.snap.svg
@@ -65,13 +65,16 @@ x+" data-x="3.05" data-y="2.1" cx="490.1078219956871" cy="199.2393648304254" r="
 x+" data-x="3.05" data-y="2.3" cx="490.1078219956871" cy="177.28288570868457" r="3" fill="hsl(207, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="2.1510000000000002" data-y="0.30000000000000004" cx="391.4134483434621" cy="396.8476769260929" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="2.1510000000000002" data-y="0.30000000000000004" cx="391.4134483434621" cy="396.8476769260929" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.05" data-y="-0.10000000000000003" cx="270.54303077827876" cy="440.7606351695746" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.05" data-y="-0.10000000000000003" cx="270.54303077827876" cy="440.7606351695746" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="3.05" data-y="2.3" cx="490.1078219956871" cy="177.28288570868457" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="3.05" data-y="2.3" cx="490.1078219956871" cy="177.28288570868457" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <polyline data-points="1.05,-0.10000000000000003 3.05,2.3" data-type="line" data-label="" points="270.54303077827876,440.7606351695746 490.1078219956871,177.28288570868457" fill="none" stroke="hsl(88, 100%, 50%, 0.8)" stroke-width="1" />

--- a/tests/functions/simplifyPath.test.ts
+++ b/tests/functions/simplifyPath.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+test("simplifyPath removes consecutive duplicate points before collinear collapse", () => {
+  expect(
+    simplifyPath([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 1 },
+    ]),
+  ).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 1 },
+  ])
+})
+
+test("simplifyPath returns a deduplicated short path", () => {
+  expect(
+    simplifyPath([
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ]),
+  ).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ])
+})


### PR DESCRIPTION
## Summary

/claim #78

- Remove consecutive duplicate points in `simplifyPath` before collinear collapse so zero-length trace segments do not survive cleanup.
- Add focused regressions for duplicate trace path points.
- Update SVG snapshots for the trace cleanup output changes.

## Validation

- `npx bun test`
- `npx bun run format:check`
- `npx tsc --noEmit --pretty false`
- `npx bun run build`
- `git diff --check`