### PR TITLE
Keep net-label-only nets out of physical routing

### DIFF
--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -57,7 +57,8 @@ export class LongDistancePairSolver extends BaseSolver {
       primaryConnectedPinIds.add(pair.pins[1].pinId)
     }
 
-    const { netConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
+    const { directConnMap, netConnMap } =
+      getConnectivityMapsFromInputProblem(inputProblem)
     this.netConnMap = netConnMap
     const pinMap = new Map<PinId, InputPin & { chipId: string }>()
     for (const chip of inputProblem.chips) {
@@ -76,6 +77,20 @@ export class LongDistancePairSolver extends BaseSolver {
     for (const netId of Object.keys(netConnMap.netMap)) {
       const allPinIdsInNet = netConnMap.getIdsConnectedToNet(netId)
       if (allPinIdsInNet.length < 2) continue
+      const userNetIds = allPinIdsInNet.filter((id) => !pinMap.has(id))
+      const hasDirectPin = allPinIdsInNet.some(
+        (pinId) => directConnMap.getNetConnectedToId(pinId) !== undefined,
+      )
+      const hasAvailableNetLabel = userNetIds.some(
+        (userNetId) =>
+          (inputProblem.availableNetLabelOrientations[userNetId]?.length ?? 0) >
+          0,
+      )
+      const pinCount = allPinIdsInNet.filter((pinId) =>
+        pinMap.has(pinId),
+      ).length
+
+      if (!hasDirectPin && hasAvailableNetLabel && pinCount === 2) continue
 
       const unconnectedPinIds = allPinIdsInNet.filter(
         (pinId) => !primaryConnectedPinIds.has(pinId),

--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -75,7 +75,21 @@ export class MspConnectionPairSolver extends BaseSolver {
       }
     }
 
-    this.queuedDcNetIds = Object.keys(netConnMap.netMap)
+    this.queuedDcNetIds = Object.keys(netConnMap.netMap).filter((netId) => {
+      const connectedIds = netConnMap.getIdsConnectedToNet(netId)
+      const pinIds = connectedIds.filter((id) => this.pinMap[id])
+      const userNetIds = connectedIds.filter((id) => !this.pinMap[id])
+      const hasDirectPin = pinIds.some(
+        (pinId) => directConnMap.getNetConnectedToId(pinId) !== undefined,
+      )
+      const hasAvailableNetLabel = userNetIds.some(
+        (userNetId) =>
+          (this.inputProblem.availableNetLabelOrientations[userNetId]?.length ??
+            0) > 0,
+      )
+
+      return hasDirectPin || !hasAvailableNetLabel || pinIds.length !== 2
+    })
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
+++ b/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
@@ -14,7 +14,14 @@ export const getConnectivityMapsFromInputProblem = (
     ])
   }
 
-  const netConnMap = new ConnectivityMap(directConnMap.netMap)
+  const netConnMap = new ConnectivityMap(
+    Object.fromEntries(
+      Object.entries(directConnMap.netMap).map(([netId, connectedIds]) => [
+        netId,
+        [...connectedIds],
+      ]),
+    ),
+  )
 
   for (const netConn of inputProblem.netConnections) {
     netConnMap.addConnections([[netConn.netId, ...netConn.pinIds]])

--- a/tests/examples/__snapshots__/example12.snap.svg
+++ b/tests/examples/__snapshots__/example12.snap.svg
@@ -2,103 +2,110 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="J1.1
-x+" data-x="1.1" data-y="0.2" cx="301.5156017830609" cy="201.4588202080238" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+x+" data-x="1.1" data-y="0.2" cx="301.5156017830609" cy="217.56580386329867" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.2
-x+" data-x="1.1" data-y="0" cx="301.5156017830609" cy="225.2329658246657" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+x+" data-x="1.1" data-y="0" cx="301.5156017830609" cy="241.33994947994057" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.3
-x+" data-x="1.1" data-y="-0.2" cx="301.5156017830609" cy="249.00711144130761" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
+x+" data-x="1.1" data-y="-0.2" cx="301.5156017830609" cy="265.11409509658245" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R1.1
-x-" data-x="0.5499999999999996" data-y="-1.7944553499999996" cx="236.13670133729568" cy="438.5411797919762" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+x-" data-x="0.5499999999999996" data-y="-1.7944553499999996" cx="236.13670133729568" cy="454.648163447251" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R1.2
-x+" data-x="1.6499999999999997" data-y="-1.7944553499999996" cx="366.8945022288261" cy="438.5411797919762" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+x+" data-x="1.6499999999999997" data-y="-1.7944553499999996" cx="366.8945022288261" cy="454.648163447251" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C1.1
-x-" data-x="2.3099999999999996" data-y="0.01999999999999985" cx="445.34918276374435" cy="222.85555126300153" r="3" fill="hsl(121, 100%, 50%, 0.8)" />
+x-" data-x="2.3099999999999996" data-y="0.01999999999999985" cx="445.34918276374435" cy="238.9625349182764" r="3" fill="hsl(121, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="C1.2
-x+" data-x="3.41" data-y="0.01999999999999985" cx="576.1069836552749" cy="222.85555126300153" r="3" fill="hsl(122, 100%, 50%, 0.8)" />
+x+" data-x="3.41" data-y="0.01999999999999985" cx="576.1069836552749" cy="238.9625349182764" r="3" fill="hsl(122, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="1.7049999999999998" data-y="0.2" cx="373.4323922734027" cy="201.4588202080238" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="1.201" data-y="0.451" cx="313.5215453194651" cy="187.7292511144131" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="1.3" data-y="-0.4486138374999999" cx="325.28974739970283" cy="278.5600193164933" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="2.2089999999999996" data-y="0.4709999999999998" cx="433.3432392273402" cy="185.35183655274892" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.8499999999999996" data-y="-1.7944553499999996" cx="390.668647845468" cy="438.5411797919762" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="1.3" data-y="0" cx="325.28974739970283" cy="241.33994947994057" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="3.511" data-y="-0.4310000000000001" cx="588.1129271916791" cy="276.466249628529" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y-" data-x="1.8499999999999996" data-y="-1.7944553499999996" cx="390.668647845468" cy="454.648163447251" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.1,0.2 2.3099999999999996,0.01999999999999985" data-type="line" data-label="" points="301.5156017830609,201.4588202080238 445.34918276374435,222.85555126300153" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="3.511" data-y="-0.4310000000000001" cx="588.1129271916791" cy="292.57323328380386" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.1,0 0.5499999999999996,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,225.2329658246657 236.13670133729568,438.5411797919762" fill="none" stroke="hsl(158, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.1,0.2 2.3099999999999996,0.01999999999999985" data-type="line" data-label="" points="301.5156017830609,217.56580386329867 445.34918276374435,238.9625349182764" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.1,-0.2 1.6499999999999997,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,249.00711144130761 366.8945022288261,438.5411797919762" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.1,0 0.5499999999999996,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,241.33994947994057 236.13670133729568,454.648163447251" fill="none" stroke="hsl(158, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.1,-0.2 3.41,0.01999999999999985" data-type="line" data-label="" points="301.5156017830609,249.00711144130761 576.1069836552749,222.85555126300153" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.1,-0.2 1.6499999999999997,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,265.11409509658245 366.8945022288261,454.648163447251" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.6499999999999997,-1.7944553499999996 3.41,0.01999999999999985" data-type="line" data-label="" points="366.8945022288261,438.5411797919762 576.1069836552749,222.85555126300153" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.1,-0.2 3.41,0.01999999999999985" data-type="line" data-label="" points="301.5156017830609,265.11409509658245 576.1069836552749,238.9625349182764" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.1,0.2 1.7049999999999998,0.2 1.7049999999999998,0.01999999999999985 2.3099999999999996,0.01999999999999985" data-type="line" data-label="" points="301.5156017830609,201.4588202080238 373.4323922734027,201.4588202080238 373.4323922734027,222.85555126300153 445.34918276374435,222.85555126300153" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.6499999999999997,-1.7944553499999996 3.41,0.01999999999999985" data-type="line" data-label="" points="366.8945022288261,454.648163447251 576.1069836552749,238.9625349182764" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.1,0 1.3,0 1.3,-0.8972276749999998 0.34999999999999964,-0.8972276749999998 0.34999999999999964,-1.7944553499999996 0.5499999999999996,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,225.2329658246657 325.28974739970283,225.2329658246657 325.28974739970283,331.88707280832097 212.36255572065375,331.88707280832097 212.36255572065375,438.5411797919762 236.13670133729568,438.5411797919762" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.1,0 1.3,0 1.3,-0.8972276749999998 0.34999999999999964,-0.8972276749999998 0.34999999999999964,-1.7944553499999996 0.5499999999999996,-1.7944553499999996" data-type="line" data-label="" points="301.5156017830609,241.33994947994057 325.28974739970283,241.33994947994057 325.28974739970283,347.9940564635958 212.36255572065375,347.9940564635958 212.36255572065375,454.648163447251 236.13670133729568,454.648163447251" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.6499999999999997,-1.7944553499999996 1.8499999999999996,-1.7944553499999996 1.8499999999999996,-0.2 1.1,-0.2" data-type="line" data-label="" points="366.8945022288261,438.5411797919762 390.668647845468,438.5411797919762 390.668647845468,249.00711144130761 301.5156017830609,249.00711144130761" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.6499999999999997,-1.7944553499999996 1.8499999999999996,-1.7944553499999996 1.8499999999999996,-0.2 1.1,-0.2" data-type="line" data-label="" points="366.8945022288261,454.648163447251 390.668647845468,454.648163447251 390.668647845468,265.11409509658245 301.5156017830609,265.11409509658245" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="3.41,0.01999999999999985 3.511,0.01999999999999985 3.511,-0.4310000000000001" data-type="line" data-label="" points="576.1069836552749,222.85555126300153 588.1129271916791,222.85555126300153 588.1129271916791,276.466249628529" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.1,0.2 1.201,0.2 1.201,0.451" data-type="line" data-label="" points="301.5156017830609,217.56580386329867 313.5215453194651,217.56580386329867 313.5215453194651,187.7292511144131" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40.00000000000003" y="177.6846745913819" width="261.5156017830609" height="95.09658246656761" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
+    <polyline data-points="2.3099999999999996,0.01999999999999985 2.2089999999999996,0.01999999999999985 2.2089999999999996,0.4709999999999998" data-type="line" data-label="" points="445.34918276374435,238.9625349182764 433.3432392273402,238.9625349182764 433.3432392273402,185.35183655274892" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="1.0999999999999996" data-y="-1.7944553499999996" x="236.13670133729568" y="415.42613075780093" width="130.75780089153045" height="46.230098068350514" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
+    <polyline data-points="3.41,0.01999999999999985 3.511,0.01999999999999985 3.511,-0.4310000000000001" data-type="line" data-label="" points="576.1069836552749,238.9625349182764 588.1129271916791,238.9625349182764 588.1129271916791,292.57323328380386" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_2" data-x="2.86" data-y="0.01999999999999985" x="445.34918276374435" y="172.92984546805354" width="130.75780089153056" height="99.85141158989597" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40.00000000000003" y="193.79165824665677" width="261.5156017830609" height="95.09658246656761" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="1.0999999999999996" data-y="-1.7944553499999996" x="236.13670133729568" y="431.5331144130758" width="130.75780089153045" height="46.230098068350514" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_2" data-x="2.86" data-y="0.01999999999999985" x="445.34918276374435" y="189.0368291233284" width="130.75780089153056" height="99.85141158989597" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008412500000000002" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="1.7049999999999998" data-y="0.42500000000000004" x="361.54531946508166" y="147.96699257057952" width="23.77414561664193" height="53.49182763744429" fill="#ef444466" stroke="#ef4444" stroke-width="0.008412500000000002" />
+globalConnNetId: connectivity_net0" data-x="1.201" data-y="0.676" x="301.63447251114417" y="134.23742347696881" width="23.77414561664193" height="53.49182763744426" fill="#ef444466" stroke="#ef4444" stroke-width="0.008412500000000002" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net0" data-x="2.2089999999999996" data-y="0.6959999999999998" x="421.45616641901927" y="131.86000891530466" width="23.77414561664193" height="53.49182763744426" fill="#ef444466" stroke="#ef4444" stroke-width="0.008412500000000002" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: OUT
-globalConnNetId: connectivity_net1
-available orientations: any" data-x="1.5250000000000001" data-y="-0.4486138374999999" x="325.28974739970283" y="266.6729465081724" width="53.49182763744432" height="23.774145616641874" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008412500000000002" />
+globalConnNetId: connectivity_net1" data-x="1.3" data-y="0.225" x="313.40267459138187" y="187.8481218424963" width="23.77414561664193" height="53.49182763744426" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008412500000000002" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net2
-available orientations: y-" data-x="1.8499999999999996" data-y="-2.0194553499999994" x="378.78157503714704" y="438.54117979197616" width="23.77414561664193" height="53.49182763744432" fill="#00000066" stroke="#000000" stroke-width="0.008412500000000002" />
+globalConnNetId: connectivity_net2" data-x="1.8499999999999996" data-y="-2.0194553499999994" x="378.78157503714704" y="454.648163447251" width="23.77414561664193" height="53.49182763744432" fill="#00000066" stroke="#000000" stroke-width="0.008412500000000002" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net2
-available orientations: y-" data-x="3.511" data-y="-0.6560000000000001" x="576.2258543833581" y="276.466249628529" width="23.77414561664193" height="53.49182763744432" fill="#00000066" stroke="#000000" stroke-width="0.008412500000000002" />
+globalConnNetId: connectivity_net2" data-x="3.511" data-y="-0.6560000000000001" x="576.2258543833581" y="292.5732332838039" width="23.77414561664193" height="53.49182763744426" fill="#00000066" stroke="#000000" stroke-width="0.008412500000000002" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -133,7 +140,7 @@ available orientations: y-" data-x="3.511" data-y="-0.6560000000000001" x="576.2
         "e": 170.75780089153048,
         "b": 0,
         "d": -118.8707280832095,
-        "f": 225.2329658246657
+        "f": 241.33994947994057
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example16.snap.svg
+++ b/tests/examples/__snapshots__/example16.snap.svg
@@ -2,110 +2,122 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="U1.1
-x+" data-x="1.2000000000000002" data-y="-0.30000000000000004" cx="308.80000000000007" cy="443.42400000000004" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="-0.30000000000000004" cx="308.80000000000007" cy="454.68000000000006" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.2
-x-" data-x="-1.2000000000000002" data-y="-0.30000000000000004" cx="40" cy="443.42400000000004" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="-0.30000000000000004" cx="40" cy="454.68000000000006" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.3
-x+" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="308.80000000000007" cy="398.624" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="308.80000000000007" cy="409.88000000000005" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.4
-x-" data-x="-1.2000000000000002" data-y="0.30000000000000004" cx="40" cy="376.224" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="0.30000000000000004" cx="40" cy="387.48" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.5
-x-" data-x="-1.2000000000000002" data-y="0.10000000000000003" cx="40" cy="398.624" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="0.10000000000000003" cx="40" cy="409.88000000000005" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.6
-x-" data-x="-1.2000000000000002" data-y="-0.09999999999999998" cx="40" cy="421.024" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="-0.09999999999999998" cx="40" cy="432.28000000000003" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.7
-x+" data-x="1.2000000000000002" data-y="-0.10000000000000003" cx="308.80000000000007" cy="421.024" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="-0.10000000000000003" cx="308.80000000000007" cy="432.28000000000003" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.8
-x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="308.80000000000007" cy="376.224" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="308.80000000000007" cy="387.48" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.1
-x-" data-x="1.6" data-y="2.105" cx="353.6" cy="174.06400000000002" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="2.105" cx="353.6" cy="185.32000000000005" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.2
-x-" data-x="1.6" data-y="1.9049999999999998" cx="353.6" cy="196.46400000000003" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="1.9049999999999998" cx="353.6" cy="207.72000000000006" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.3
-x-" data-x="1.6" data-y="1.7049999999999998" cx="353.6" cy="218.86400000000003" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="1.7049999999999998" cx="353.6" cy="230.12000000000006" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.3010000000000002" data-y="-0.5010000000000001" cx="320.1120000000001" cy="465.93600000000004" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y-" data-x="1.3010000000000002" data-y="-0.5010000000000001" cx="320.1120000000001" cy="477.19200000000006" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.449" data-y="1.654" cx="336.68800000000005" cy="224.57600000000002" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y-" data-x="1.499" data-y="1.504" cx="342.288" cy="252.63200000000003" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x+" data-x="1.3" data-y="0.09999999999999998" cx="320" cy="398.624" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: x+" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="308.80000000000007" cy="409.88000000000005" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="0.749" data-y="2.105" cx="258.288" cy="174.06400000000002" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: x-" data-x="1.6" data-y="1.9049999999999998" cx="353.6" cy="207.72000000000006" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.6,1.7049999999999998" data-type="line" data-label="" points="308.80000000000007,443.42400000000004 353.6,218.86400000000003" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="1.3010000000000002" data-y="0.5010000000000001" cx="320.1120000000001" cy="364.968" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.09999999999999998 1.6,1.9049999999999998" data-type="line" data-label="" points="308.80000000000007,398.624 353.6,196.46400000000003" fill="none" stroke="hsl(158, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="1.499" data-y="2.306" cx="342.288" cy="162.80800000000005" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.30000000000000004 1.6,2.105" data-type="line" data-label="" points="308.80000000000007,376.224 353.6,174.06400000000002" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.6,1.7049999999999998" data-type="line" data-label="" points="308.80000000000007,454.68000000000006 353.6,230.12000000000006" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.09999999999999998 1.3,0.09999999999999998 1.3,1.5049999999999997 1.049,1.5049999999999997 1.049,1.905 1.6,1.9049999999999998" data-type="line" data-label="" points="308.80000000000007,398.624 320,398.624 320,241.26400000000004 291.88800000000003,241.26400000000004 291.88800000000003,196.464 353.6,196.46400000000003" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.2000000000000002,0.09999999999999998 1.6,1.9049999999999998" data-type="line" data-label="" points="308.80000000000007,409.88000000000005 353.6,207.72000000000006" fill="none" stroke="hsl(158, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.30000000000000004 1.5000000000000002,0.30000000000000004 1.5000000000000002,1.2049999999999996 0.749,1.2049999999999996 0.749,2.105 1.6,2.105" data-type="line" data-label="" points="308.80000000000007,376.224 342.4000000000001,376.224 342.4000000000001,274.86400000000003 258.288,274.86400000000003 258.288,174.06400000000002 353.6,174.06400000000002" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.2000000000000002,0.30000000000000004 1.6,2.105" data-type="line" data-label="" points="308.80000000000007,387.48 353.6,185.32000000000005" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.3010000000000002,-0.30000000000000004 1.3010000000000002,-0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,443.42400000000004 320.1120000000001,443.42400000000004 320.1120000000001,465.93600000000004" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.3010000000000002,-0.30000000000000004 1.3010000000000002,-0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,454.68000000000006 320.1120000000001,454.68000000000006 320.1120000000001,477.19200000000006" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.6,1.7049999999999998 1.449,1.7049999999999998 1.449,1.654" data-type="line" data-label="" points="353.6,218.86400000000003 336.68800000000005,218.86400000000003 336.68800000000005,224.57600000000002" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.6,1.7049999999999998 1.499,1.7049999999999998 1.499,1.504" data-type="line" data-label="" points="353.6,230.12000000000006 342.288,230.12000000000006 342.288,252.63200000000003" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="353.824" width="268.80000000000007" height="112" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+    <polyline data-points="1.2000000000000002,0.30000000000000004 1.3010000000000002,0.30000000000000004 1.3010000000000002,0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,387.48 320.1120000000001,387.48 320.1120000000001,364.968" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="2.7" data-y="1.9049999999999998" x="353.6" y="151.66400000000004" width="246.39999999999998" height="89.59999999999997" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+    <polyline data-points="1.6,2.105 1.499,2.105 1.499,2.306" data-type="line" data-label="" points="353.6,185.32000000000005 342.288,185.32000000000005 342.288,162.80800000000005" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="365.08000000000004" width="268.80000000000007" height="112" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="2.7" data-y="1.9049999999999998" x="353.6" y="162.92000000000007" width="246.39999999999998" height="89.59999999999997" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="465.93600000000004" width="22.400000000000034" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="477.19200000000006" width="22.400000000000034" height="50.400000000000034" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.449" data-y="1.4289999999999998" x="325.48800000000006" y="224.57600000000002" width="22.399999999999977" height="50.400000000000034" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.499" data-y="1.279" x="331.088" y="252.63200000000003" width="22.400000000000034" height="50.400000000000006" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: OUT
-globalConnNetId: connectivity_net1
-available orientations: x-, x+" data-x="1.5250000000000001" data-y="0.09999999999999998" x="320" y="387.42400000000004" width="50.40000000000009" height="22.399999999999977" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net1" data-x="1.4260000000000002" data-y="0.09999999999999998" x="308.91200000000003" y="398.68000000000006" width="50.400000000000034" height="22.399999999999977" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: OUT
+globalConnNetId: connectivity_net1" data-x="1.374" data-y="1.9049999999999998" x="303.088" y="196.52000000000004" width="50.400000000000034" height="22.400000000000034" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net2
-available orientations: y+" data-x="0.749" data-y="2.33" x="247.08800000000002" y="123.66399999999999" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net2" data-x="1.3010000000000002" data-y="0.7260000000000001" x="308.91200000000003" y="314.56800000000004" width="22.400000000000034" height="50.39999999999998" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net2" data-x="1.499" data-y="2.531" x="331.088" y="112.40800000000002" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -140,7 +152,7 @@ available orientations: y+" data-x="0.749" data-y="2.33" x="247.08800000000002" 
         "e": 174.40000000000003,
         "b": 0,
         "d": -112,
-        "f": 409.824
+        "f": 421.08000000000004
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example20.snap.svg
+++ b/tests/examples/__snapshots__/example20.snap.svg
@@ -2,95 +2,103 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="U1.1
-x+" data-x="1.2000000000000002" data-y="-0.30000000000000004" cx="308.80000000000007" cy="443.42400000000004" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="-0.30000000000000004" cx="308.80000000000007" cy="454.68000000000006" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.2
-x-" data-x="-1.2000000000000002" data-y="-0.30000000000000004" cx="40" cy="443.42400000000004" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="-0.30000000000000004" cx="40" cy="454.68000000000006" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.3
-x+" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="308.80000000000007" cy="398.624" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="308.80000000000007" cy="409.88000000000005" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.4
-x-" data-x="-1.2000000000000002" data-y="0.30000000000000004" cx="40" cy="376.224" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="0.30000000000000004" cx="40" cy="387.48" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.5
-x-" data-x="-1.2000000000000002" data-y="0.10000000000000003" cx="40" cy="398.624" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="0.10000000000000003" cx="40" cy="409.88000000000005" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.6
-x-" data-x="-1.2000000000000002" data-y="-0.09999999999999998" cx="40" cy="421.024" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="-0.09999999999999998" cx="40" cy="432.28000000000003" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.7
-x+" data-x="1.2000000000000002" data-y="-0.10000000000000003" cx="308.80000000000007" cy="421.024" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="-0.10000000000000003" cx="308.80000000000007" cy="432.28000000000003" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.8
-x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="308.80000000000007" cy="376.224" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="308.80000000000007" cy="387.48" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.1
-x-" data-x="1.6" data-y="2.105" cx="353.6" cy="174.06400000000002" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="2.105" cx="353.6" cy="185.32000000000005" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.2
-x-" data-x="1.6" data-y="1.9049999999999998" cx="353.6" cy="196.46400000000003" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="1.9049999999999998" cx="353.6" cy="207.72000000000006" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.3
-x-" data-x="1.6" data-y="1.7049999999999998" cx="353.6" cy="218.86400000000003" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="1.7049999999999998" cx="353.6" cy="230.12000000000006" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.3010000000000002" data-y="-0.5010000000000001" cx="320.1120000000001" cy="465.93600000000004" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y-" data-x="1.3010000000000002" data-y="-0.5010000000000001" cx="320.1120000000001" cy="477.19200000000006" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.499" data-y="1.504" cx="342.288" cy="241.376" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y-" data-x="1.499" data-y="1.504" cx="342.288" cy="252.63200000000003" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="1.049" data-y="2.105" cx="291.88800000000003" cy="174.06400000000002" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="1.3010000000000002" data-y="0.5010000000000001" cx="320.1120000000001" cy="364.968" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.6,1.7049999999999998" data-type="line" data-label="" points="308.80000000000007,443.42400000000004 353.6,218.86400000000003" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="1.499" data-y="2.306" cx="342.288" cy="162.80800000000005" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.30000000000000004 1.6,2.105" data-type="line" data-label="" points="308.80000000000007,376.224 353.6,174.06400000000002" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.6,1.7049999999999998" data-type="line" data-label="" points="308.80000000000007,454.68000000000006 353.6,230.12000000000006" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.30000000000000004 1.4000000000000001,0.30000000000000004 1.4000000000000001,1.2025000000000001 1.049,1.2025000000000001 1.049,2.105 1.6,2.105" data-type="line" data-label="" points="308.80000000000007,376.224 331.20000000000005,376.224 331.20000000000005,275.144 291.88800000000003,275.144 291.88800000000003,174.06400000000002 353.6,174.06400000000002" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.2000000000000002,0.30000000000000004 1.6,2.105" data-type="line" data-label="" points="308.80000000000007,387.48 353.6,185.32000000000005" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.3010000000000002,-0.30000000000000004 1.3010000000000002,-0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,443.42400000000004 320.1120000000001,443.42400000000004 320.1120000000001,465.93600000000004" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.3010000000000002,-0.30000000000000004 1.3010000000000002,-0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,454.68000000000006 320.1120000000001,454.68000000000006 320.1120000000001,477.19200000000006" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.6,1.7049999999999998 1.499,1.7049999999999998 1.499,1.504" data-type="line" data-label="" points="353.6,218.86400000000003 342.288,218.86400000000003 342.288,241.376" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.6,1.7049999999999998 1.499,1.7049999999999998 1.499,1.504" data-type="line" data-label="" points="353.6,230.12000000000006 342.288,230.12000000000006 342.288,252.63200000000003" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="353.824" width="268.80000000000007" height="112" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+    <polyline data-points="1.2000000000000002,0.30000000000000004 1.3010000000000002,0.30000000000000004 1.3010000000000002,0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,387.48 320.1120000000001,387.48 320.1120000000001,364.968" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="2.7" data-y="1.9049999999999998" x="353.6" y="151.66400000000004" width="246.39999999999998" height="89.59999999999997" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+    <polyline data-points="1.6,2.105 1.499,2.105 1.499,2.306" data-type="line" data-label="" points="353.6,185.32000000000005 342.288,185.32000000000005 342.288,162.80800000000005" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="365.08000000000004" width="268.80000000000007" height="112" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="2.7" data-y="1.9049999999999998" x="353.6" y="162.92000000000007" width="246.39999999999998" height="89.59999999999997" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="465.93600000000004" width="22.400000000000034" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="477.19200000000006" width="22.400000000000034" height="50.400000000000034" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.499" data-y="1.279" x="331.088" y="241.376" width="22.400000000000034" height="50.40000000000006" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.499" data-y="1.279" x="331.088" y="252.63200000000003" width="22.400000000000034" height="50.400000000000006" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net1
-available orientations: y+" data-x="1.049" data-y="2.33" x="280.68800000000005" y="123.66399999999999" width="22.399999999999977" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net1" data-x="1.3010000000000002" data-y="0.7260000000000001" x="308.91200000000003" y="314.56800000000004" width="22.400000000000034" height="50.39999999999998" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net1" data-x="1.499" data-y="2.531" x="331.088" y="112.40800000000002" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -125,7 +133,7 @@ available orientations: y+" data-x="1.049" data-y="2.33" x="280.68800000000005" 
         "e": 174.40000000000003,
         "b": 0,
         "d": -112,
-        "f": 409.824
+        "f": 421.08000000000004
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example22.snap.svg
+++ b/tests/examples/__snapshots__/example22.snap.svg
@@ -2,104 +2,111 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="U1.1
-x+" data-x="1.2000000000000002" data-y="-0.30000000000000004" cx="308.80000000000007" cy="253.13599999999997" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="-0.30000000000000004" cx="308.80000000000007" cy="241.88" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.2
-x-" data-x="-1.2000000000000002" data-y="-0.30000000000000004" cx="40" cy="253.13599999999997" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="-0.30000000000000004" cx="40" cy="241.88" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.3
-x+" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="308.80000000000007" cy="208.33599999999998" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="308.80000000000007" cy="197.08" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.4
-x-" data-x="-1.2000000000000002" data-y="0.30000000000000004" cx="40" cy="185.93599999999998" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="0.30000000000000004" cx="40" cy="174.68" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.5
-x-" data-x="-1.2000000000000002" data-y="0.10000000000000003" cx="40" cy="208.33599999999996" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="0.10000000000000003" cx="40" cy="197.07999999999998" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.6
-x-" data-x="-1.2000000000000002" data-y="-0.09999999999999998" cx="40" cy="230.73599999999996" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
+x-" data-x="-1.2000000000000002" data-y="-0.09999999999999998" cx="40" cy="219.48" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.7
-x+" data-x="1.2000000000000002" data-y="-0.10000000000000003" cx="308.80000000000007" cy="230.736" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="-0.10000000000000003" cx="308.80000000000007" cy="219.48000000000002" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.8
-x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="308.80000000000007" cy="185.93599999999998" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="308.80000000000007" cy="174.68" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.1
-x-" data-x="1.6" data-y="-1.895" cx="353.6" cy="431.77599999999995" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="-1.895" cx="353.6" cy="420.52" r="3" fill="hsl(218, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.2
-x-" data-x="1.6" data-y="-2.095" cx="353.6" cy="454.176" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="-2.095" cx="353.6" cy="442.92" r="3" fill="hsl(219, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="J1.3
-x-" data-x="1.6" data-y="-2.295" cx="353.6" cy="476.5759999999999" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
+x-" data-x="1.6" data-y="-2.295" cx="353.6" cy="465.31999999999994" r="3" fill="hsl(220, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y-" data-x="1.049" data-y="-2.2950000000000004" cx="291.88800000000003" cy="476.576" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y-" data-x="1.3010000000000002" data-y="-0.5010000000000001" cx="320.1120000000001" cy="264.392" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="1.3010000000000002" data-y="0.5010000000000001" cx="320.1120000000001" cy="163.42399999999998" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y-" data-x="1.499" data-y="-2.496" cx="342.288" cy="487.832" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="1.499" data-y="-1.6940000000000002" cx="342.288" cy="409.264" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="1.3010000000000002" data-y="0.5010000000000001" cx="320.1120000000001" cy="152.168" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: x-" data-x="1.6" data-y="-2.095" cx="353.6" cy="454.176" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="1.499" data-y="-1.6940000000000002" cx="342.288" cy="398.00800000000004" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.6,-2.295" data-type="line" data-label="" points="308.80000000000007,253.13599999999997 353.6,476.5759999999999" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="1.6" data-y="-2.095" cx="353.6" cy="442.92" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.30000000000000004 1.6,-1.895" data-type="line" data-label="" points="308.80000000000007,185.93599999999998 353.6,431.77599999999995" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.6,-2.295" data-type="line" data-label="" points="308.80000000000007,241.88 353.6,465.31999999999994" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.4000000000000001,-0.30000000000000004 1.4000000000000001,-1.2975000000000003 1.049,-1.2975000000000003 1.049,-2.2950000000000004 1.6,-2.295" data-type="line" data-label="" points="308.80000000000007,253.13599999999997 331.20000000000005,253.13599999999997 331.20000000000005,364.856 291.88800000000003,364.856 291.88800000000003,476.576 353.6,476.5759999999999" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.2000000000000002,0.30000000000000004 1.6,-1.895" data-type="line" data-label="" points="308.80000000000007,174.68 353.6,420.52" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.30000000000000004 1.3010000000000002,0.30000000000000004 1.3010000000000002,0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,185.93599999999998 320.1120000000001,185.93599999999998 320.1120000000001,163.42399999999998" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.2000000000000002,-0.30000000000000004 1.3010000000000002,-0.30000000000000004 1.3010000000000002,-0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,241.88 320.1120000000001,241.88 320.1120000000001,264.392" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.6,-1.895 1.499,-1.895 1.499,-1.6940000000000002" data-type="line" data-label="" points="353.6,431.77599999999995 342.288,431.77599999999995 342.288,409.264" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.6,-2.295 1.499,-2.295 1.499,-2.496" data-type="line" data-label="" points="353.6,465.31999999999994 342.288,465.31999999999994 342.288,487.832" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="163.53599999999997" width="268.80000000000007" height="111.99999999999997" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+    <polyline data-points="1.2000000000000002,0.30000000000000004 1.3010000000000002,0.30000000000000004 1.3010000000000002,0.5010000000000001" data-type="line" data-label="" points="308.80000000000007,174.68 320.1120000000001,174.68 320.1120000000001,152.168" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="2.7" data-y="-2.095" x="353.6" y="409.376" width="246.39999999999998" height="89.60000000000002" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+    <polyline data-points="1.6,-1.895 1.499,-1.895 1.499,-1.6940000000000002" data-type="line" data-label="" points="353.6,420.52 342.288,420.52 342.288,398.00800000000004" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="152.28" width="268.80000000000007" height="111.99999999999997" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="2.7" data-y="-2.095" x="353.6" y="398.12" width="246.39999999999998" height="89.60000000000002" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net0
-available orientations: y-" data-x="1.049" data-y="-2.5200000000000005" x="280.68800000000005" y="476.576" width="22.399999999999977" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net0" data-x="1.3010000000000002" data-y="-0.7260000000000001" x="308.91200000000003" y="264.392" width="22.400000000000034" height="50.400000000000034" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net0" data-x="1.499" data-y="-2.721" x="331.088" y="487.832" width="22.400000000000034" height="50.39999999999998" fill="#00000066" stroke="#000000" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net1
-available orientations: y+" data-x="1.3010000000000002" data-y="0.7260000000000001" x="308.91200000000003" y="113.02399999999997" width="22.400000000000034" height="50.400000000000006" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net1" data-x="1.3010000000000002" data-y="0.7260000000000001" x="308.91200000000003" y="101.768" width="22.400000000000034" height="50.400000000000006" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net1
-available orientations: y+" data-x="1.499" data-y="-1.469" x="331.088" y="358.864" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net1" data-x="1.499" data-y="-1.469" x="331.088" y="347.608" width="22.400000000000034" height="50.400000000000034" fill="#ef444466" stroke="#ef4444" stroke-width="0.008928571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: MMM
-globalConnNetId: connectivity_net2
-available orientations: x+, x-" data-x="1.374" data-y="-2.095" x="303.088" y="442.976" width="50.400000000000034" height="22.399999999999977" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
+globalConnNetId: connectivity_net2" data-x="1.374" data-y="-2.095" x="303.088" y="431.72" width="50.400000000000034" height="22.399999999999977" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -134,7 +141,7 @@ available orientations: x+, x-" data-x="1.374" data-y="-2.095" x="303.088" y="44
         "e": 174.40000000000003,
         "b": 0,
         "d": -112,
-        "f": 219.53599999999997
+        "f": 208.28
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example31.snap.svg
+++ b/tests/examples/__snapshots__/example31.snap.svg
@@ -2,32 +2,42 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="U1.1
-x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="338.66666666666674" cy="298.22222222222223" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+x+" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="345.38513974096804" cy="310.52033628720744" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R1.1
-x+" data-x="3" data-y="-0.10000000000000016" cx="562.6666666666667" cy="348" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+x+" data-x="3" data-y="-0.10000000000000016" cx="574.4239945466941" cy="361.4178595773688" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="3.2" data-y="0.30000000000000004" cx="587.5555555555557" cy="298.22222222222223" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+orientation: y+" data-x="1.3010000000000002" data-y="0.5010000000000001" cx="358.2367643717338" cy="284.94433083390135" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.30000000000000004 3,-0.10000000000000016" data-type="line" data-label="" points="338.66666666666674,298.22222222222223 562.6666666666667,348" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="3.101" data-y="0.10099999999999985" cx="587.2756191774597" cy="335.8418541240627" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.2000000000000002,0.30000000000000004 3.2,0.30000000000000004 3.2,-0.10000000000000016 3,-0.10000000000000016" data-type="line" data-label="" points="338.66666666666674,298.22222222222223 587.5555555555557,298.22222222222223 587.5555555555557,348 562.6666666666667,348" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.2000000000000002,0.30000000000000004 3,-0.10000000000000016" data-type="line" data-label="" points="345.38513974096804,310.52033628720744 574.4239945466941,361.4178595773688" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40.00000000000003" y="273.3333333333333" width="298.66666666666674" height="124.44444444444446" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
+    <polyline data-points="1.2000000000000002,0.30000000000000004 1.3010000000000002,0.30000000000000004 1.3010000000000002,0.5010000000000001" data-type="line" data-label="" points="345.38513974096804,310.52033628720744 358.2367643717338,310.52033628720744 358.2367643717338,284.94433083390135" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="2.45" data-y="-0.10000000000000009" x="425.7777777777778" y="323.80111200000005" width="136.8888888888889" height="48.39777599999991" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008035714285714287" />
+    <polyline data-points="3,-0.10000000000000016 3.101,-0.10000000000000016 3.101,0.10099999999999985" data-type="line" data-label="" points="574.4239945466941,361.4178595773688 587.2756191774597,361.4178595773688 587.2756191774597,335.8418541240627" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="285.0715746421268" width="305.38513974096804" height="127.24380822540331" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.00785892857142857" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="2.45" data-y="-0.10000000000000009" x="434.45580549875035" y="336.6746203135652" width="139.96818904794372" height="49.48647852760723" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.00785892857142857" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net0
-available orientations: y+" data-x="3.2" data-y="0.525" x="575.1111111111111" y="242.22222222222223" width="24.888888888888914" height="56" fill="#ef444466" stroke="#ef4444" stroke-width="0.008035714285714287" />
+globalConnNetId: connectivity_net0" data-x="1.3010000000000002" data-y="0.7260000000000001" x="345.51238354919343" y="227.6846171324699" width="25.44876164508065" height="57.25971370143145" fill="#ef444466" stroke="#ef4444" stroke-width="0.00785892857142857" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net0" data-x="3.101" data-y="0.32599999999999985" x="574.5512383549194" y="278.58214042263126" width="25.448761645080594" height="57.25971370143145" fill="#ef444466" stroke="#ef4444" stroke-width="0.00785892857142857" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -57,12 +67,12 @@ available orientations: y+" data-x="3.2" data-y="0.525" x="575.1111111111111" y=
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 124.44444444444444,
+        "a": 127.24380822540333,
         "c": 0,
-        "e": 189.33333333333337,
+        "e": 192.69256987048402,
         "b": 0,
-        "d": -124.44444444444444,
-        "f": 335.55555555555554
+        "d": -127.24380822540333,
+        "f": 348.69347875482845
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example33.snap.svg
+++ b/tests/examples/__snapshots__/example33.snap.svg
@@ -2,124 +2,144 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="R7.1
-x-" data-x="-1.95" data-y="-6.6" cx="102.39751311443555" cy="200.26423159121816" r="3" fill="hsl(232, 100%, 50%, 0.8)" />
+x-" data-x="-1.95" data-y="-6.6" cx="102.39751311443555" cy="211.19875655721773" r="3" fill="hsl(232, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="R7.2
-x+" data-x="-0.8499999999999999" data-y="-6.6" cx="222.07888090149598" cy="200.26423159121816" r="3" fill="hsl(233, 100%, 50%, 0.8)" />
+x+" data-x="-0.8499999999999999" data-y="-6.6" cx="222.07888090149598" cy="211.19875655721773" r="3" fill="hsl(233, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U5.1
-x-" data-x="-1.5225" data-y="-8.1" cx="148.91004468622495" cy="363.4660967553915" r="3" fill="hsl(203, 100%, 50%, 0.8)" />
+x-" data-x="-1.5225" data-y="-8.1" cx="148.91004468622495" cy="374.4006217213911" r="3" fill="hsl(203, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U5.2
-x-" data-x="-1.5225" data-y="-8.3" cx="148.91004468622495" cy="385.22634544394805" r="3" fill="hsl(204, 100%, 50%, 0.8)" />
+x-" data-x="-1.5225" data-y="-8.3" cx="148.91004468622495" cy="396.1608704099476" r="3" fill="hsl(204, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U5.3
-x-" data-x="-1.5225" data-y="-8.5" cx="148.91004468622495" cy="406.98659413250437" r="3" fill="hsl(205, 100%, 50%, 0.8)" />
+x-" data-x="-1.5225" data-y="-8.5" cx="148.91004468622495" cy="417.92111909850394" r="3" fill="hsl(205, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U5.4
-x-" data-x="-1.5225" data-y="-8.700000000000001" cx="148.91004468622495" cy="428.7468428210609" r="3" fill="hsl(206, 100%, 50%, 0.8)" />
+x-" data-x="-1.5225" data-y="-8.700000000000001" cx="148.91004468622495" cy="439.6813677870605" r="3" fill="hsl(206, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U5.5
-x+" data-x="1.5225" data-y="-8.1" cx="480.2098309694967" cy="363.4660967553915" r="3" fill="hsl(207, 100%, 50%, 0.8)" />
+x+" data-x="1.5225" data-y="-8.1" cx="480.2098309694967" cy="374.4006217213911" r="3" fill="hsl(207, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U5.6
-x+" data-x="1.5225" data-y="-8.3" cx="480.2098309694967" cy="385.22634544394805" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
+x+" data-x="1.5225" data-y="-8.3" cx="480.2098309694967" cy="396.1608704099476" r="3" fill="hsl(208, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U5.7
-x+" data-x="1.5225" data-y="-8.700000000000001" cx="480.2098309694967" cy="428.7468428210609" r="3" fill="hsl(209, 100%, 50%, 0.8)" />
+x+" data-x="1.5225" data-y="-8.700000000000001" cx="480.2098309694967" cy="439.6813677870605" r="3" fill="hsl(209, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U5.8
-x+" data-x="1.5225" data-y="-8.5" cx="480.2098309694967" cy="406.98659413250437" r="3" fill="hsl(210, 100%, 50%, 0.8)" />
+x+" data-x="1.5225" data-y="-8.5" cx="480.2098309694967" cy="417.92111909850394" r="3" fill="hsl(210, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-2.15" data-y="-6.6" cx="80.63726442587912" cy="200.26423159121816" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-2.0509999999999997" data-y="-6.398999999999999" cx="91.4085875267146" cy="189.32970662521848" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-0.8499999999999999" data-y="-6.6" cx="222.07888090149598" cy="200.26423159121816" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="2.5235000000000003" data-y="-7.9990000000000006" cx="589.1198756557217" cy="363.41169613367015" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.5225" data-y="-8.700000000000001" cx="148.91004468622495" cy="428.7468428210609" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-0.8499999999999999" data-y="-6.6" cx="222.07888090149598" cy="211.19875655721773" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.5225" data-y="-8.1" cx="148.91004468622495" cy="363.4660967553915" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.5225" data-y="-8.700000000000001" cx="148.91004468622495" cy="439.6813677870605" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.5225" data-y="-8.3" cx="148.91004468622495" cy="385.22634544394805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.5225" data-y="-8.1" cx="148.91004468622495" cy="374.4006217213911" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="-1.5225" data-y="-8.5" cx="148.91004468622495" cy="406.98659413250437" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.5225" data-y="-8.3" cx="148.91004468622495" cy="396.1608704099476" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.5225" data-y="-8.1" cx="480.2098309694967" cy="363.4660967553915" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.5225" data-y="-8.5" cx="148.91004468622495" cy="417.92111909850394" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.5225" data-y="-8.3" cx="480.2098309694967" cy="385.22634544394805" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.5225" data-y="-8.1" cx="480.2098309694967" cy="374.4006217213911" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.6235" data-y="-8.901" cx="491.19875655721773" cy="450.61589275306005" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.5225" data-y="-8.3" cx="480.2098309694967" cy="396.1608704099476" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="-1.95,-6.6 1.5225,-8.5" data-type="line" data-label="" points="102.39751311443555,200.26423159121816 480.2098309694967,406.98659413250437" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="1.6235" data-y="-8.901" cx="491.19875655721773" cy="461.5504177190596" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="-0.8499999999999999,-6.6 -1.5225,-8.700000000000001" data-type="line" data-label="" points="222.07888090149598,200.26423159121816 148.91004468622495,428.7468428210609" fill="none" stroke="hsl(172, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="-1.95,-6.6 1.5225,-8.5" data-type="line" data-label="" points="102.39751311443555,211.19875655721773 480.2098309694967,417.92111909850394" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="-1.95,-6.6 -2.15,-6.6 -2.15,-7.55 1.7225000000000004,-7.55 1.7225000000000004,-7.8999999999999995 2.6235,-7.8999999999999995 2.6235,-8.499999999999998 1.5225000000000002,-8.5" data-type="line" data-label="" points="102.39751311443555,200.26423159121816 80.63726442587912,200.26423159121816 80.63726442587912,303.62541286186126 501.97007965805324,303.62541286186126 501.97007965805324,341.70584806683496 600,341.70584806683496 600,406.98659413250414 480.20983096949675,406.98659413250437" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-0.8499999999999999,-6.6 -1.5225,-8.700000000000001" data-type="line" data-label="" points="222.07888090149598,211.19875655721773 148.91004468622495,439.6813677870605" fill="none" stroke="hsl(172, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.5225,-8.700000000000001 1.6235,-8.700000000000001 1.6235,-8.901" data-type="line" data-label="" points="480.2098309694967,428.7468428210609 491.19875655721773,428.7468428210609 491.19875655721773,450.61589275306005" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="-1.95,-6.6 -2.0509999999999997,-6.6 -2.0509999999999997,-6.398999999999999" data-type="line" data-label="" points="102.39751311443555,211.19875655721773 91.4085875267146,211.19875655721773 91.4085875267146,189.32970662521848" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="-1.4" data-y="-6.6" x="102.39751311443555" y="179.10724771711682" width="119.68136778706042" height="42.313967748202685" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.009191071428571429" />
+    <polyline data-points="1.5225,-8.5 2.5235000000000003,-8.5 2.5235000000000003,-7.9990000000000006" data-type="line" data-label="" points="480.2098309694967,417.92111909850394 589.1198756557217,417.92111909850394 589.1198756557217,363.41169613367015" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="0" data-y="-8.4" x="148.91004468622495" y="341.7058480668351" width="331.2997862832717" height="108.80124344278227" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.009191071428571429" />
+    <polyline data-points="1.5225,-8.700000000000001 1.6235,-8.700000000000001 1.6235,-8.901" data-type="line" data-label="" points="480.2098309694967,439.6813677870605 491.19875655721773,439.6813677870605 491.19875655721773,461.5504177190596" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="-1.4" data-y="-6.6" x="102.39751311443555" y="190.0417726831164" width="119.68136778706042" height="42.313967748202685" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.009191071428571429" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="0" data-y="-8.4" x="148.91004468622495" y="352.64037303283465" width="331.2997862832717" height="108.80124344278227" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: V3V3
-globalConnNetId: connectivity_net0" data-x="-2.15" data-y="-6.3999999999999995" x="69.75714008160091" y="156.7437342141053" width="21.76024868855646" height="43.52049737711286" fill="#ef444466" stroke="#ef4444" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net0" data-x="-2.0509999999999997" data-y="-6.198999999999999" x="80.52846318243635" y="145.8092092481055" width="21.76024868855646" height="43.520497377112974" fill="#ef444466" stroke="#ef4444" stroke-width="0.009191071428571429" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: V3V3
+globalConnNetId: connectivity_net0" data-x="2.5235000000000003" data-y="-7.799" x="578.2397513114436" y="319.8911987565572" width="21.76024868855643" height="43.520497377112974" fill="#ef444466" stroke="#ef4444" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: QSPI_CS
-globalConnNetId: connectivity_net1" data-x="-0.4989999999999999" data-y="-6.6" x="222.18768214493878" y="189.38410724693995" width="76.1608704099475" height="21.76024868855643" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net1" data-x="-0.4989999999999999" data-y="-6.6" x="222.18768214493878" y="200.31863221293952" width="76.1608704099475" height="21.76024868855643" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: QSPI_CS
-globalConnNetId: connectivity_net1" data-x="-1.8735" data-y="-8.700000000000001" x="72.64037303283462" y="417.8667184767828" width="76.16087040994756" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net1" data-x="-1.8735" data-y="-8.700000000000001" x="72.64037303283462" y="428.8012434427824" width="76.16087040994756" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: QSPI_SCK
-globalConnNetId: connectivity_net2" data-x="-1.9234999999999998" data-y="-8.1" x="61.76024868855643" y="352.5859724111133" width="87.04099475422575" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net2" data-x="-1.9234999999999998" data-y="-8.1" x="61.76024868855643" y="363.52049737711286" width="87.04099475422575" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: QSPI_DATA0
-globalConnNetId: connectivity_net3" data-x="-2.0235" data-y="-8.3" x="40" y="374.34622109966983" width="108.80124344278218" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net3" data-x="-2.0235" data-y="-8.3" x="40" y="385.2807460656694" width="108.80124344278218" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: QSPI_DATA1
-globalConnNetId: connectivity_net4" data-x="-2.0235" data-y="-8.5" x="40" y="396.10646978822615" width="108.80124344278218" height="21.76024868855643" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net4" data-x="-2.0235" data-y="-8.5" x="40" y="407.0409947542257" width="108.80124344278218" height="21.76024868855643" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: QSPI_DATA2
-globalConnNetId: connectivity_net5" data-x="2.0235" data-y="-8.1" x="480.3186322129395" y="352.5859724111133" width="108.80124344278215" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net5" data-x="2.0235" data-y="-8.1" x="480.3186322129395" y="363.52049737711286" width="108.80124344278215" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: QSPI_DATA3
-globalConnNetId: connectivity_net6" data-x="2.0235" data-y="-8.3" x="480.3186322129395" y="374.34622109966983" width="108.80124344278215" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net6" data-x="2.0235" data-y="-8.3" x="480.3186322129395" y="385.2807460656694" width="108.80124344278215" height="21.760248688556317" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009191071428571429" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: GND
-globalConnNetId: connectivity_net7" data-x="1.6235" data-y="-9.051" x="480.3186322129395" y="450.61589275306005" width="21.76024868855643" height="32.64037303283476" fill="#00000066" stroke="#000000" stroke-width="0.009191071428571429" />
+globalConnNetId: connectivity_net7" data-x="1.6235" data-y="-9.051" x="480.3186322129395" y="461.5504177190596" width="21.76024868855643" height="32.64037303283476" fill="#00000066" stroke="#000000" stroke-width="0.009191071428571429" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -154,7 +174,7 @@ globalConnNetId: connectivity_net7" data-x="1.6235" data-y="-9.051" x="480.31863
         "e": 314.55993782786084,
         "b": 0,
         "d": -108.8012434427822,
-        "f": -517.8239751311443
+        "f": -506.8894501651447
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/examples/__snapshots__/example35.snap.svg
+++ b/tests/examples/__snapshots__/example35.snap.svg
@@ -65,19 +65,24 @@ x+" data-x="3.05" data-y="2.1" cx="544.5045045045044" cy="184.6451329378159" r="
 x+" data-x="3.05" data-y="2.3" cx="544.5045045045044" cy="160.0351571083279" r="3" fill="hsl(207, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.6010000000000002" data-y="0.3" cx="366.20522961986376" cy="406.13491540320814" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="3.351" data-y="-0.24900000000000005" cx="581.542518127884" cy="473.68929905515273" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.05" data-y="-0.10000000000000003" cx="298.40474620962425" cy="455.35486706218416" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="1.151" data-y="0.5010000000000001" cx="310.8327840035157" cy="381.4018896945726" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="3.05" data-y="2.3" cx="544.5045045045044" cy="160.0351571083279" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="1.05" data-y="-0.10000000000000003" cx="298.40474620962425" cy="455.35486706218416" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.05" data-y="0.09999999999999998" cx="298.40474620962425" cy="430.74489123269615" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="3.05" data-y="2.3" cx="544.5045045045044" cy="160.0351571083279" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="3.05" data-y="2.1" cx="544.5045045045044" cy="184.6451329378159" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="2.15" data-y="0.09999999999999998" cx="433.7596132718084" cy="430.74489123269615" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
     <polyline data-points="1.05,0.09999999999999998 3.05,2.1" data-type="line" data-label="" points="298.40474620962425,430.74489123269615 544.5045045045044,184.6451329378159" fill="none" stroke="hsl(312, 100%, 50%, 0.8)" stroke-width="1" />
@@ -89,7 +94,13 @@ x+" data-x="3.05" data-y="2.3" cx="544.5045045045044" cy="160.0351571083279" r="
     <polyline data-points="1.05,-0.30000000000000004 1.05,0.30000000000000004" data-type="line" data-label="" points="298.40474620962425,479.9648428916722 298.40474620962425,406.1349154032081" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.05,-0.30000000000000004 1.6010000000000002,-0.30000000000000004 1.6010000000000002,0.3 1.05,0.30000000000000004" data-type="line" data-label="" points="298.40474620962425,479.9648428916722 366.20522961986376,479.9648428916722 366.20522961986376,406.13491540320814 298.40474620962425,406.1349154032081" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.05,0.09999999999999998 3.25,0.09999999999999998 3.25,2.1 3.05,2.1" data-type="line" data-label="" points="298.40474620962425,430.74489123269615 569.1144803339926,430.74489123269615 569.1144803339926,184.6451329378159 544.5045045045044,184.6451329378159" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.05,-0.30000000000000004 3.351,-0.30000000000000004 3.351,-0.24900000000000005" data-type="line" data-label="" points="298.40474620962425,479.9648428916722 581.542518127884,479.9648428916722 581.542518127884,473.68929905515273" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.05,0.30000000000000004 1.151,0.30000000000000004 1.151,0.5010000000000001" data-type="line" data-label="" points="298.40474620962425,406.1349154032081 310.8327840035157,406.1349154032081 310.8327840035157,381.4018896945726" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
     <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="381.5249395737201" width="258.40474620962425" height="123.04987914744015" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008126785714285715" />
@@ -99,7 +110,11 @@ x+" data-x="3.05" data-y="2.3" cx="544.5045045045044" cy="160.0351571083279" r="
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net2" data-x="1.6010000000000002" data-y="0.54" x="353.90024170511975" y="347.07097341243684" width="24.609975829488064" height="59.06394199077124" fill="#ef444466" stroke="#ef4444" stroke-width="0.008126785714285715" />
+globalConnNetId: connectivity_net2" data-x="3.351" data-y="-0.009000000000000064" x="569.23753021314" y="414.6253570643815" width="24.609975829488008" height="59.06394199077124" fill="#ef444466" stroke="#ef4444" stroke-width="0.008126785714285715" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net2" data-x="1.151" data-y="0.7410000000000001" x="298.52779608877165" y="322.3379477038014" width="24.60997582948812" height="59.06394199077124" fill="#ef444466" stroke="#ef4444" stroke-width="0.008126785714285715" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: U1.CLK to U2.VCC
@@ -111,11 +126,7 @@ globalConnNetId: connectivity_net1" data-x="3.276" data-y="2.3" x="544.627554383
   </g>
   <g>
     <rect data-type="rect" data-label="netId: U1.IO3 to U2.IO3
-globalConnNetId: connectivity_net0" data-x="1.276" data-y="0.09999999999999998" x="298.52779608877165" y="418.43990331795214" width="55.3724456163481" height="24.609975829488008" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008126785714285715" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="netId: U1.IO3 to U2.IO3
-globalConnNetId: connectivity_net0" data-x="3.276" data-y="2.1" x="544.6275543836518" y="172.34014502307184" width="55.37244561634816" height="24.609975829488064" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008126785714285715" />
+globalConnNetId: connectivity_net0" data-x="2.15" data-y="0.32499999999999996" x="421.45462535706434" y="375.3724456163481" width="24.609975829488064" height="55.372445616348045" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008126785714285715" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/examples/__snapshots__/example36.snap.svg
+++ b/tests/examples/__snapshots__/example36.snap.svg
@@ -2,103 +2,112 @@
   <rect width="100%" height="100%" fill="white" />
   <g>
     <circle data-type="point" data-label="U1.1
-x-" data-x="-1.05" data-y="0.30000000000000004" cx="39.999999999999986" cy="396.8476769260929" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
+x-" data-x="-1.05" data-y="0.30000000000000004" cx="40" cy="407.0917573872473" r="3" fill="hsl(319, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.2
-x-" data-x="-1.05" data-y="0.10000000000000003" cx="39.999999999999986" cy="418.80415604783377" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
+x-" data-x="-1.05" data-y="0.10000000000000003" cx="40" cy="431.97511664074653" r="3" fill="hsl(320, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.3
-x-" data-x="-1.05" data-y="-0.09999999999999998" cx="39.999999999999986" cy="440.7606351695746" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
+x-" data-x="-1.05" data-y="-0.09999999999999998" cx="40" cy="456.8584758942457" r="3" fill="hsl(321, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.4
-x-" data-x="-1.05" data-y="-0.30000000000000004" cx="39.999999999999986" cy="462.71711429131545" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
+x-" data-x="-1.05" data-y="-0.30000000000000004" cx="40" cy="481.74183514774495" r="3" fill="hsl(322, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.5
-x+" data-x="1.05" data-y="-0.30000000000000004" cx="270.54303077827876" cy="462.71711429131545" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
+x+" data-x="1.05" data-y="-0.30000000000000004" cx="301.27527216174184" cy="481.74183514774495" r="3" fill="hsl(323, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.6
-x+" data-x="1.05" data-y="-0.10000000000000003" cx="270.54303077827876" cy="440.7606351695746" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
+x+" data-x="1.05" data-y="-0.10000000000000003" cx="301.27527216174184" cy="456.8584758942457" r="3" fill="hsl(324, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.7
-x+" data-x="1.05" data-y="0.09999999999999998" cx="270.54303077827876" cy="418.80415604783377" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
+x+" data-x="1.05" data-y="0.09999999999999998" cx="301.27527216174184" cy="431.97511664074653" r="3" fill="hsl(325, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1.8
-x+" data-x="1.05" data-y="0.30000000000000004" cx="270.54303077827876" cy="396.8476769260929" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
+x+" data-x="1.05" data-y="0.30000000000000004" cx="301.27527216174184" cy="407.0917573872473" r="3" fill="hsl(326, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U2.1
-x-" data-x="0.95" data-y="2.3" cx="259.56479121740836" cy="177.28288570868457" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
+x-" data-x="0.95" data-y="2.3" cx="288.8335925349922" cy="158.2581648522551" r="3" fill="hsl(200, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U2.2
-x-" data-x="0.95" data-y="2.1" cx="259.56479121740836" cy="199.2393648304254" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
+x-" data-x="0.95" data-y="2.1" cx="288.8335925349922" cy="183.14152410575429" r="3" fill="hsl(201, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U2.3
-x-" data-x="0.95" data-y="1.9" cx="259.56479121740836" cy="221.19584395216626" r="3" fill="hsl(202, 100%, 50%, 0.8)" />
+x-" data-x="0.95" data-y="1.9" cx="288.8335925349922" cy="208.02488335925355" r="3" fill="hsl(202, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U2.4
-x-" data-x="0.95" data-y="1.7" cx="259.56479121740836" cy="243.15232307390707" r="3" fill="hsl(203, 100%, 50%, 0.8)" />
+x-" data-x="0.95" data-y="1.7" cx="288.8335925349922" cy="232.90824261275276" r="3" fill="hsl(203, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U2.5
-x+" data-x="3.05" data-y="1.7" cx="490.1078219956871" cy="243.15232307390707" r="3" fill="hsl(204, 100%, 50%, 0.8)" />
+x+" data-x="3.05" data-y="1.7" cx="550.108864696734" cy="232.90824261275276" r="3" fill="hsl(204, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U2.6
-x+" data-x="3.05" data-y="1.9" cx="490.1078219956871" cy="221.19584395216626" r="3" fill="hsl(205, 100%, 50%, 0.8)" />
+x+" data-x="3.05" data-y="1.9" cx="550.108864696734" cy="208.02488335925355" r="3" fill="hsl(205, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U2.7
-x+" data-x="3.05" data-y="2.1" cx="490.1078219956871" cy="199.2393648304254" r="3" fill="hsl(206, 100%, 50%, 0.8)" />
+x+" data-x="3.05" data-y="2.1" cx="550.108864696734" cy="183.14152410575429" r="3" fill="hsl(206, 100%, 50%, 0.8)" />
   </g>
   <g>
     <circle data-type="point" data-label="U2.8
-x+" data-x="3.05" data-y="2.3" cx="490.1078219956871" cy="177.28288570868457" r="3" fill="hsl(207, 100%, 50%, 0.8)" />
+x+" data-x="3.05" data-y="2.3" cx="550.108864696734" cy="158.2581648522551" r="3" fill="hsl(207, 100%, 50%, 0.8)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="2.1510000000000002" data-y="0.30000000000000004" cx="391.4134483434621" cy="396.8476769260929" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="3.351" data-y="-0.24900000000000005" cx="587.5583203732504" cy="475.39657853810263" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="1.05" data-y="-0.10000000000000003" cx="270.54303077827876" cy="440.7606351695746" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="1.151" data-y="0.5010000000000001" cx="313.8413685847589" cy="382.08398133748057" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <circle data-type="point" data-label="" data-x="3.05" data-y="2.3" cx="490.1078219956871" cy="177.28288570868457" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="2.15" data-y="-0.10000000000000003" cx="438.13374805598755" cy="456.8584758942457" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
   </g>
   <g>
-    <polyline data-points="1.05,-0.10000000000000003 3.05,2.3" data-type="line" data-label="" points="270.54303077827876,440.7606351695746 490.1078219956871,177.28288570868457" fill="none" stroke="hsl(88, 100%, 50%, 0.8)" stroke-width="1" />
+    <polyline data-points="1.05,-0.10000000000000003 3.05,2.3" data-type="line" data-label="" points="301.27527216174184,456.8584758942457 550.108864696734,158.2581648522551" fill="none" stroke="hsl(88, 100%, 50%, 0.8)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.05,-0.30000000000000004 1.05,0.30000000000000004" data-type="line" data-label="" points="270.54303077827876,462.71711429131545 270.54303077827876,396.8476769260929" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+    <polyline data-points="1.05,-0.30000000000000004 1.05,0.30000000000000004" data-type="line" data-label="" points="301.27527216174184,481.74183514774495 301.27527216174184,407.0917573872473" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
   </g>
   <g>
-    <polyline data-points="1.05,-0.30000000000000004 2.1510000000000002,-0.30000000000000004 2.1510000000000002,0.30000000000000004 1.05,0.30000000000000004" data-type="line" data-label="" points="270.54303077827876,462.71711429131545 391.4134483434621,462.71711429131545 391.4134483434621,396.8476769260929 270.54303077827876,396.8476769260929" fill="none" stroke="purple" stroke-width="1" />
+    <polyline data-points="1.05,-0.10000000000000003 3.25,-0.10000000000000003 3.25,2.3 3.05,2.3" data-type="line" data-label="" points="301.27527216174184,456.8584758942457 574.9922239502332,456.8584758942457 574.9922239502332,158.2581648522551 550.108864696734,158.2581648522551" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="39.999999999999986" y="374.8911978043521" width="230.54303077827876" height="109.78239560870418" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.009108928571428572" />
+    <polyline data-points="1.05,-0.30000000000000004 3.351,-0.30000000000000004 3.351,-0.24900000000000005" data-type="line" data-label="" points="301.27527216174184,481.74183514774495 587.5583203732504,481.74183514774495 587.5583203732504,475.39657853810263" fill="none" stroke="purple" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="schematic_component_1" data-x="2" data-y="2" x="259.56479121740836" y="155.32640658694373" width="230.54303077827876" height="109.78239560870418" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.009108928571428572" />
+    <polyline data-points="1.05,0.30000000000000004 1.151,0.30000000000000004 1.151,0.5010000000000001" data-type="line" data-label="" points="301.27527216174184,407.0917573872473 313.8413685847589,407.0917573872473 313.8413685847589,382.08398133748057" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="382.20839813374806" width="261.27527216174184" height="124.41679626749612" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008037500000000001" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="2" data-y="2" x="288.8335925349922" y="133.37480559875587" width="261.27527216174184" height="124.41679626749612" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008037500000000001" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: VCC
-globalConnNetId: connectivity_net1" data-x="2.1510000000000002" data-y="0.54" x="380.43520878259164" y="344.1521270339149" width="21.95647912174087" height="52.69554989217801" fill="#ef444466" stroke="#ef4444" stroke-width="0.009108928571428572" />
+globalConnNetId: connectivity_net1" data-x="3.351" data-y="-0.009000000000000064" x="575.1166407465007" y="415.67651632970455" width="24.883359253499293" height="59.720062208398076" fill="#ef444466" stroke="#ef4444" stroke-width="0.008037500000000001" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net1" data-x="1.151" data-y="0.7410000000000001" x="301.3996889580093" y="322.36391912908243" width="24.883359253499293" height="59.72006220839813" fill="#ef444466" stroke="#ef4444" stroke-width="0.008037500000000001" />
   </g>
   <g>
     <rect data-type="rect" data-label="netId: U1.CLK to U2.VCC
-globalConnNetId: connectivity_net0" data-x="1.551" data-y="-0.10000000000000003" x="270.65281317388747" y="429.7823956087042" width="109.78239560870418" height="21.956479121740813" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009108928571428572" />
-  </g>
-  <g>
-    <rect data-type="rect" data-label="netId: U1.CLK to U2.VCC
-globalConnNetId: connectivity_net0" data-x="3.5509999999999997" data-y="2.3" x="490.2176043912958" y="166.30464614781414" width="109.78239560870418" height="21.95647912174087" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.009108928571428572" />
+globalConnNetId: connectivity_net0" data-x="2.15" data-y="0.39999999999999997" x="425.6920684292379" y="332.44167962674965" width="24.88335925349918" height="124.41679626749607" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008037500000000001" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
@@ -128,12 +137,12 @@ globalConnNetId: connectivity_net0" data-x="3.5509999999999997" data-y="2.3" x="
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 109.78239560870418,
+        "a": 124.4167962674961,
         "c": 0,
-        "e": 155.27151538913938,
+        "e": 170.63763608087092,
         "b": 0,
-        "d": -109.78239560870418,
-        "f": 429.7823956087042
+        "d": -124.4167962674961,
+        "f": 444.4167962674961
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/solvers/MspConnectionPairSolver/MspConnectionPairSolver_schematicSections.test.ts
+++ b/tests/solvers/MspConnectionPairSolver/MspConnectionPairSolver_schematicSections.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "bun:test"
+import { LongDistancePairSolver } from "lib/solvers/LongDistancePairSolver/LongDistancePairSolver"
 import { MspConnectionPairSolver } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import { getConnectivityMapsFromInputProblem } from "lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem"
 import { NetLabelPlacementSolver } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { InputProblem } from "lib/types/InputProblem"
@@ -67,4 +69,95 @@ test("cross-section input connections are not visualized as future traces", () =
   ]
 
   expect(visualizeInputProblem(netConnectionProblem).lines).toHaveLength(0)
+})
+
+const createNetLabelOnlyInputProblem = (): InputProblem => ({
+  chips: [
+    {
+      chipId: "schematic_component_0",
+      center: { x: 0, y: 0 },
+      width: 1,
+      height: 1,
+      pins: [{ pinId: "U1.1", x: 0.5, y: 0, _facingDirection: "x+" }],
+    },
+    {
+      chipId: "schematic_component_1",
+      center: { x: 2, y: 0 },
+      width: 1,
+      height: 1,
+      pins: [{ pinId: "U2.1", x: 1.5, y: 0, _facingDirection: "x-" }],
+    },
+  ],
+  directConnections: [],
+  netConnections: [{ netId: "SIG", pinIds: ["U1.1", "U2.1"] }],
+  availableNetLabelOrientations: {
+    SIG: ["x+", "x-"],
+  },
+  maxMspPairDistance: 10,
+})
+
+test("net-label-only connections do not mutate direct connectivity", () => {
+  const { directConnMap, netConnMap } = getConnectivityMapsFromInputProblem(
+    createNetLabelOnlyInputProblem(),
+  )
+
+  expect(Object.keys(directConnMap.netMap)).toHaveLength(0)
+  const netId = netConnMap.getNetConnectedToId("U1.1")
+  expect(netConnMap.getIdsConnectedToNet(netId!)).toEqual([
+    "SIG",
+    "U1.1",
+    "U2.1",
+  ])
+})
+
+test("net connections do not extend the direct connectivity map", () => {
+  const { directConnMap, netConnMap } = getConnectivityMapsFromInputProblem({
+    ...createInputProblem(),
+    chips: [
+      ...createInputProblem().chips,
+      {
+        chipId: "schematic_component_2",
+        center: { x: 4, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U3.1", x: 3.5, y: 0, _facingDirection: "x-" }],
+      },
+    ],
+    netConnections: [{ netId: "SIG", pinIds: ["U3.1"] }],
+  })
+
+  const directNetId = directConnMap.getNetConnectedToId("U1.1")
+  expect(directConnMap.getIdsConnectedToNet(directNetId!)).toEqual([
+    "SIG",
+    "U1.1",
+    "U2.1",
+  ])
+
+  const globalNetId = netConnMap.getNetConnectedToId("U1.1")
+  expect(netConnMap.getIdsConnectedToNet(globalNetId!)).toEqual([
+    "SIG",
+    "U1.1",
+    "U2.1",
+    "U3.1",
+  ])
+})
+
+test("MspConnectionPairSolver does not physically route two-pin net-label-only nets", () => {
+  const solver = new MspConnectionPairSolver({
+    inputProblem: createNetLabelOnlyInputProblem(),
+  })
+
+  solver.solve()
+
+  expect(solver.mspConnectionPairs).toHaveLength(0)
+})
+
+test("LongDistancePairSolver does not queue two-pin net-label-only pairs", () => {
+  const solver = new LongDistancePairSolver({
+    inputProblem: createNetLabelOnlyInputProblem(),
+    primaryMspConnectionPairs: [],
+    alreadySolvedTraces: [],
+  })
+
+  expect((solver as any).queuedCandidatePairs).toHaveLength(0)
 })


### PR DESCRIPTION
## Summary

/claim #79

- Clone connectivity-map buckets before adding `netConnections`, so global net-label connectivity cannot mutate the direct connectivity map.
- Avoid creating physical MSP/long-distance routes for two-pin pure net-label-only nets when a net label orientation is available.
- Add focused regressions for direct/global connectivity separation and net-label-only routing behavior.
- Update SVG snapshots for the corrected routing output.

## Validation

- `BUN_UPDATE_SNAPSHOTS=1 npx bun test`
- `npx bun test`
- `npx bun run format:check`
- `npx tsc --noEmit --pretty false`
- `npx bun run build`
- `git diff --check`