### PR TITLE
fix: remove duplicate points in simplifyPath to eliminate extra trace lines (#78)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/simplifyPath.ts
+++ b/lib/solvers/TraceCleanupSolver/simplifyPath.ts
@@ -4,38 +4,83 @@ import {
   isVertical,
 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 
+/**
+ * Removes consecutive duplicate points (zero-length segments) from a path.
+ *
+ * Post-processing steps such as `UntangleTraceSubsolver._applyBestRoute` splice a
+ * rerouted segment into an existing trace by concatenating
+ * `[...slice(0, p2Index), ...bestRoute, ...slice(p2Index + 1)]`. The endpoints of
+ * `bestRoute` coincide with the surrounding trace points, so the concatenation
+ * produces consecutive points with identical coordinates. These zero-length
+ * segments are rendered as spurious "extra trace lines".
+ */
+const removeDuplicateConsecutivePoints = (path: Point[]): Point[] => {
+  if (path.length < 2) return path
+  const out: Point[] = [path[0]]
+  for (let i = 1; i < path.length; i++) {
+    const prev = out[out.length - 1]
+    const cur = path[i]
+    if (isVertical(prev, cur) && isHorizontal(prev, cur)) {
+      // prev and cur are the same point (zero-length segment) -> skip
+      continue
+    }
+    out.push(cur)
+  }
+  return out
+}
+
+/**
+ * Removes redundant collinear points from an axis-aligned path so that each
+ * retained vertex represents an actual turn.
+ *
+ * The previous implementation ran a single forward pass twice and always pushed
+ * the final point unconditionally. That left two defects:
+ *   1. Consecutive duplicate points (zero-length segments) were not removed, and
+ *      a duplicate sitting next to a corner survived both passes.
+ *   2. The final point was never re-checked, so when its neighbour was dropped it
+ *      could end up collinear with (or identical to) the previous kept point,
+ *      producing a redundant trailing segment.
+ * Both defects render as extra trace lines in the schematic output.
+ *
+ * This implementation first strips duplicate points, then repeatedly removes any
+ * interior point that is collinear with its neighbours until the path is stable,
+ * which is robust regardless of point ordering.
+ */
 export const simplifyPath = (path: Point[]): Point[] => {
-  if (path.length < 3) return path
-  const newPath: Point[] = [path[0]]
-  for (let i = 1; i < path.length - 1; i++) {
-    const p1 = newPath[newPath.length - 1]
-    const p2 = path[i]
-    const p3 = path[i + 1]
-    if (
-      (isVertical(p1, p2) && isVertical(p2, p3)) ||
-      (isHorizontal(p1, p2) && isHorizontal(p2, p3))
-    ) {
-      continue
-    }
-    newPath.push(p2)
-  }
-  newPath.push(path[path.length - 1])
+  let pts = removeDuplicateConsecutivePoints(path)
+  if (pts.length < 3) return pts
 
-  if (newPath.length < 3) return newPath
-  const finalPath: Point[] = [newPath[0]]
-  for (let i = 1; i < newPath.length - 1; i++) {
-    const p1 = finalPath[finalPath.length - 1]
-    const p2 = newPath[i]
-    const p3 = newPath[i + 1]
-    if (
-      (isVertical(p1, p2) && isVertical(p2, p3)) ||
-      (isHorizontal(p1, p2) && isHorizontal(p2, p3))
-    ) {
-      continue
+  let changed = true
+  while (changed) {
+    changed = false
+    const newPath: Point[] = [pts[0]]
+    for (let i = 1; i < pts.length - 1; i++) {
+      const p1 = newPath[newPath.length - 1]
+      const p2 = pts[i]
+      const p3 = pts[i + 1]
+      if (
+        (isVertical(p1, p2) && isVertical(p2, p3)) ||
+        (isHorizontal(p1, p2) && isHorizontal(p2, p3))
+      ) {
+        changed = true
+        continue
+      }
+      newPath.push(p2)
     }
-    finalPath.push(p2)
+    newPath.push(pts[pts.length - 1])
+    pts = newPath
   }
-  finalPath.push(newPath[newPath.length - 1])
 
-  return finalPath
+  // A fully degenerate path (e.g. a trace that returns to its start) can reduce
+  // to two identical endpoints. Collapse it to a single point so the result
+  // never contains a zero-length segment.
+  if (
+    pts.length === 2 &&
+    isVertical(pts[0], pts[1]) &&
+    isHorizontal(pts[0], pts[1])
+  ) {
+    return [pts[0]]
+  }
+
+  return pts
 }

--- a/tests/solvers/TraceCleanupSolver/simplifyPath.test.ts
+++ b/tests/solvers/TraceCleanupSolver/simplifyPath.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "bun:test"
+import type { Point } from "graphics-debug"
+import { simplifyPath } from "lib/solvers/TraceCleanupSolver/simplifyPath"
+
+const hasZeroLengthSegment = (path: Point[]) => {
+  for (let i = 1; i < path.length; i++) {
+    if (path[i].x === path[i - 1].x && path[i].y === path[i - 1].y) return true
+  }
+  return false
+}
+
+const hasCollinearLeftover = (path: Point[]) => {
+  for (let i = 1; i < path.length - 1; i++) {
+    const a = path[i - 1]
+    const b = path[i]
+    const c = path[i + 1]
+    const vertical = a.x === b.x && b.x === c.x
+    const horizontal = a.y === b.y && b.y === c.y
+    if (vertical || horizontal) return true
+  }
+  return false
+}
+
+test("simplifyPath removes consecutive duplicate points (zero-length segments)", () => {
+  // These duplicate points are exactly what UntangleTraceSubsolver._applyBestRoute
+  // introduces when it splices a rerouted segment into a trace path. They render
+  // as spurious extra trace lines (issue #78).
+  const path: Point[] = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 0 }, // duplicate
+    { x: 1, y: 1 },
+  ]
+  const result = simplifyPath(path)
+  expect(hasZeroLengthSegment(result)).toBe(false)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ])
+})
+
+test("simplifyPath removes a duplicate point sitting at a corner", () => {
+  // A duplicate adjacent to a turn is NOT collinear with the next distinct point,
+  // so the original collinear-only passes left it in place.
+  const path: Point[] = [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 0 }, // duplicate at the corner
+    { x: 2, y: 2 },
+  ]
+  const result = simplifyPath(path)
+  expect(hasZeroLengthSegment(result)).toBe(false)
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 2 },
+  ])
+})
+
+test("simplifyPath does not emit a redundant trailing segment when a path doubles back (issue #78 repro)", () => {
+  // Minimal reproduction of the "extra trace lines" artifact. The original
+  // two-pass implementation returned [(0,0),(-1,0),(-1,0)] for this input -- a
+  // zero-length trailing segment that renders as an extra trace line.
+  const path: Point[] = [
+    { x: 0, y: 0 },
+    { x: -1, y: 0 },
+    { x: -1, y: -1 },
+    { x: -2, y: -1 },
+    { x: -1, y: -1 },
+    { x: -1, y: 0 },
+  ]
+  const result = simplifyPath(path)
+  expect(hasZeroLengthSegment(result)).toBe(false)
+  expect(hasCollinearLeftover(result)).toBe(false)
+})
+
+test("simplifyPath does not leave a redundant trailing segment", () => {
+  // The original implementation pushed the final point unconditionally, so when
+  // the second-to-last point was dropped the last point could become collinear
+  // with (or identical to) the previous kept point -> an extra trace line.
+  const path: Point[] = [
+    { x: 0, y: 0 },
+    { x: 0, y: -1 },
+    { x: 0, y: -1 }, // duplicate
+    { x: 0, y: -2 },
+    { x: -1, y: -2 },
+    { x: 0, y: -2 }, // backtrack onto the previous horizontal line
+  ]
+  const result = simplifyPath(path)
+  expect(hasZeroLengthSegment(result)).toBe(false)
+  expect(hasCollinearLeftover(result)).toBe(false)
+})
+
+test("simplifyPath removes all collinear points", () => {
+  const path: Point[] = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: 1 },
+  ]
+  expect(simplifyPath(path)).toEqual([
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: 1 },
+  ])
+})
+
+test("simplifyPath preserves genuine turns (L and Z shapes)", () => {
+  const lShape: Point[] = [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 2 },
+  ]
+  expect(simplifyPath(lShape)).toEqual(lShape)
+
+  const zShape: Point[] = [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 2 },
+    { x: 4, y: 2 },
+  ]
+  expect(simplifyPath(zShape)).toEqual(zShape)
+})
+
+test("simplifyPath collapses a fully degenerate path to a single point", () => {
+  const path: Point[] = [
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+  ]
+  expect(simplifyPath(path)).toEqual([{ x: 0, y: 0 }])
+})


### PR DESCRIPTION
Fixes #78.

/claim #78

## Problem
Post-processing left zero-length segments and collinear leftovers in trace paths, which render as the extra/overlapping trace lines shown in the issue.

## Root cause
`lib/solvers/TraceCleanupSolver/simplifyPath.ts` only collapsed *collinear* points and pushed the final point unconditionally. It never removed *duplicate* consecutive points. `UntangleTraceSubsolver._applyBestRoute()` splices a rerouted segment into a trace (`[...slice(0, p2Index), ...bestRoute, ...slice(p2Index + 1)]`); because `bestRoute`'s endpoints coincide with the surrounding trace points, this creates consecutive points with identical coordinates. A duplicate sitting next to a corner is not collinear with the next distinct point, so the old collinear-only logic left it in place. Likewise, because the last point was pushed without re-checking, dropping its neighbour could leave a redundant trailing segment.

I confirmed (by instrumenting `simplifyPath` and running the full pipeline) that duplicate consecutive points are actually fed into it by example14 (a DISCH snapshot), example16, example22, example30, example33, example35 and example36.

## Fix
- Remove exact duplicate consecutive points before simplifying.
- Collapse collinear points with a loop-until-stable pass anchored on the last *kept* point (robust to ordering; never fabricates diagonals).
- Collapse a fully degenerate path (start == end) to a single point so no zero-length segment can ever be emitted.

Valid L/Z shapes are preserved, so existing snapshots are unchanged.

## Tests
Added `tests/solvers/TraceCleanupSolver/simplifyPath.test.ts` (7 tests, incl. a doubleback repro that fails on the previous implementation). Fuzzed on 100k random axis-aligned paths: 0 zero-length segments, 0 collinear leftovers, 0 fabricated diagonals.

- `bun test` -> 71 pass, 4 skip, 0 fail
- `bunx tsc --noEmit` -> clean
- `bun run format:check` -> clean
