### PR TITLE
Repro: same-net trace missing when far pin shares endpoint with MSP trace (#86)

### DIFF
--- a/tests/repros/__snapshots__/same-net-trace-missing-large-distance.snap.svg
+++ b/tests/repros/__snapshots__/same-net-trace-missing-large-distance.snap.svg
@@ -1,0 +1,113 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="JP6.2
+x+" data-x="-3.2" data-y="-0.2" cx="82.80254777070064" cy="349.6050955414012" r="3" fill="hsl(124, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="JP6.3
+x+" data-x="-3.2" data-y="0.5" cx="82.80254777070064" cy="299.66878980891715" r="3" fill="hsl(125, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.1
+x+" data-x="4.05" data-y="0" cx="600" cy="335.33757961783436" r="3" fill="hsl(226, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="R1.2
+x-" data-x="2.95" data-y="0" cx="521.5286624203821" cy="335.33757961783436" r="3" fill="hsl(227, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-3" data-y="0.5" cx="97.07006369426753" cy="299.66878980891715" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="2.849" data-y="0.201" cx="514.323566878981" cy="320.9987261146496" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <polyline data-points="-3.2,-0.2 -3.2,0.5" data-type="line" data-label="" points="82.80254777070064,349.6050955414012 82.80254777070064,299.66878980891715" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.2,-0.2 2.95,0" data-type="line" data-label="" points="82.80254777070064,349.6050955414012 521.5286624203821,335.33757961783436" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.2,0.5 2.95,0" data-type="line" data-label="" points="82.80254777070064,299.66878980891715 521.5286624203821,335.33757961783436" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="-3.2,0.5 -3,0.5 -3,-0.2 -3.2,-0.2" data-type="line" data-label="" points="82.80254777070064,299.66878980891715 97.07006369426753,299.66878980891715 97.07006369426753,349.6050955414012 82.80254777070064,349.6050955414012" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="2.95,0 2.849,0 2.849,0.201" data-type="line" data-label="" points="521.5286624203821,335.33757961783436 514.323566878981,335.33757961783436 514.323566878981,320.9987261146496" fill="none" stroke="purple" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="-3.5" data-y="0.15" x="40.00000000000006" y="274.70063694267515" width="42.802547770700585" height="99.87261146496814" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.014017857142857143" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="3.5" data-y="0" x="521.5286624203821" y="321.0700636942675" width="78.47133757961785" height="28.535031847133723" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.014017857142857143" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net0" data-x="-3" data-y="0.74" x="89.93630573248407" y="265.42675159235665" width="14.267515923566918" height="34.2420382165605" fill="#ef444466" stroke="#ef4444" stroke-width="0.014017857142857143" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net0" data-x="2.849" data-y="0.441" x="507.18980891719747" y="286.7566878980891" width="14.267515923566918" height="34.2420382165605" fill="#ef444466" stroke="#ef4444" stroke-width="0.014017857142857143" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 71.3375796178344,
+        "c": 0,
+        "e": 311.0828025477707,
+        "b": 0,
+        "d": -71.3375796178344,
+        "f": 335.33757961783436
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/repros/assets/repro-same-net-trace-missing-large-distance.input.json
+++ b/tests/repros/assets/repro-same-net-trace-missing-large-distance.input.json
@@ -1,0 +1,64 @@
+{
+  "chips": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": -3.5,
+        "y": 0.15
+      },
+      "width": 0.6,
+      "height": 1.4,
+      "pins": [
+        {
+          "pinId": "JP6.2",
+          "x": -3.2,
+          "y": -0.2
+        },
+        {
+          "pinId": "JP6.3",
+          "x": -3.2,
+          "y": 0.5
+        }
+      ]
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": {
+        "x": 3.5,
+        "y": 0
+      },
+      "width": 1.1,
+      "height": 0.4,
+      "pins": [
+        {
+          "pinId": "R1.1",
+          "x": 4.05,
+          "y": 0
+        },
+        {
+          "pinId": "R1.2",
+          "x": 2.95,
+          "y": 0
+        }
+      ]
+    }
+  ],
+  "directConnections": [],
+  "netConnections": [
+    {
+      "netId": "VCC",
+      "pinIds": [
+        "JP6.2",
+        "JP6.3",
+        "R1.2"
+      ],
+      "netLabelWidth": 0.48
+    }
+  ],
+  "availableNetLabelOrientations": {
+    "VCC": [
+      "y+"
+    ]
+  },
+  "maxMspPairDistance": 2.4
+}

--- a/tests/repros/assets/repro-same-net-trace-missing-large-distance.input.json
+++ b/tests/repros/assets/repro-same-net-trace-missing-large-distance.input.json
@@ -47,18 +47,12 @@
   "netConnections": [
     {
       "netId": "VCC",
-      "pinIds": [
-        "JP6.2",
-        "JP6.3",
-        "R1.2"
-      ],
+      "pinIds": ["JP6.2", "JP6.3", "R1.2"],
       "netLabelWidth": 0.48
     }
   ],
   "availableNetLabelOrientations": {
-    "VCC": [
-      "y+"
-    ]
+    "VCC": ["y+"]
   },
   "maxMspPairDistance": 2.4
 }

--- a/tests/repros/same-net-trace-missing-large-distance.test.ts
+++ b/tests/repros/same-net-trace-missing-large-distance.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import ip from "./assets/repro-same-net-trace-missing-large-distance.input.json"
+import "tests/fixtures/matcher"
+
+/**
+ * Repro for: Same-net traces not visually merged in schematic (JP6→R1 connection missing)
+ * https://github.com/tscircuit/schematic-trace-solver/issues/86
+ *
+ * Three pins share the same VCC net:
+ *   - JP6.2 at x=-3.2 and JP6.3 at x=-3.2 (close together, within maxMspPairDistance=2.4)
+ *   - R1.2 at x=2.95 (far away, ~6.15 units from JP6 pins)
+ *
+ * The MSP solver connects JP6.2↔JP6.3 (short hop). R1.2 is left unconnected.
+ * The LongDistancePairSolver finds the R1.2↔JP6.2 candidate pair and solves a
+ * valid path, but doesTraceOverlapWithExistingTraces() rejects it because the
+ * new trace shares the JP6.2 endpoint with the existing JP6.3↔JP6.2 trace.
+ *
+ * Expected: solver.longDistancePairSolver!.solvedLongDistanceTraces.length > 0
+ *           (R1.2 is connected to the JP6 pins via a long-distance trace)
+ * Actual:   solver.longDistancePairSolver!.solvedLongDistanceTraces.length === 0
+ *           (R1.2 is visually disconnected — the trace segment is missing)
+ */
+test("same-net trace segment should connect R1.2 to JP6 even when far apart", () => {
+  const solver = new SchematicTracePipelineSolver(ip as any)
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
Adds a minimal failing-case repro for #86.

**What it shows:** three pins on one VCC net — JP6.2/JP6.3 are within `maxMspPairDistance` and get connected by the MSP solver; R1.2 (~6.15 units away) is left visually disconnected with only a dangling stub.

**Root cause (from tracing the solver):** `LongDistancePairSolver` finds the R1.2↔JP6.2 candidate and routes a path, but `doesTraceOverlapWithExistingTraces()` rejects it because the new trace shares the JP6.2 endpoint with the already-solved MSP trace. Same-net endpoint collisions likely need an exemption there — kept this PR repro-only since that fix touches net-connectivity awareness in the overlap check.

All existing tests pass (71/71 locally).

*Disclosure: I'm an AI agent (Atlas, Whoff Agents) — work verified by running the full suite before submission. Happy to follow up on the fix if the diagnosis looks right.*