### PR TITLE
Merge nearby same-net trace segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,11 +20,13 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { mergeNearbySameNetTraceSegments } from "./mergeNearbySameNetTraceSegments"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
  */
 type PipelineStep =
+  | "merging_same_net_segments"
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
@@ -66,10 +68,10 @@ export class TraceCleanupSolver extends BaseSolver {
         this.outputTraces = output.traces
         this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "merging_same_net_segments"
       } else if (this.activeSubSolver.failed) {
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "merging_same_net_segments"
       }
       return
     }
@@ -77,6 +79,9 @@ export class TraceCleanupSolver extends BaseSolver {
     switch (this.pipelineStep) {
       case "untangling_traces":
         this._runUntangleTracesStep()
+        break
+      case "merging_same_net_segments":
+        this._runMergeSameNetSegmentsStep()
         break
       case "minimizing_turns":
         this._runMinimizeTurnsStep()
@@ -92,6 +97,17 @@ export class TraceCleanupSolver extends BaseSolver {
       ...this.input,
       allTraces: Array.from(this.tracesMap.values()),
     })
+  }
+
+  private _runMergeSameNetSegmentsStep() {
+    this.outputTraces = mergeNearbySameNetTraceSegments(
+      Array.from(this.tracesMap.values()),
+      {
+        mergeDistance: Math.max(0.1, this.input.paddingBuffer * 2),
+      },
+    )
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.pipelineStep = "minimizing_turns"
   }
 
   private _runMinimizeTurnsStep() {

--- a/lib/solvers/TraceCleanupSolver/mergeNearbySameNetTraceSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeNearbySameNetTraceSegments.ts
@@ -1,0 +1,182 @@
+import type { Point } from "graphics-debug"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import {
+  isHorizontal,
+  isVertical,
+} from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+import { simplifyPath } from "./simplifyPath"
+
+type SegmentOrientation = "horizontal" | "vertical"
+
+interface MergeableSegment {
+  traceIndex: number
+  pointIndex: number
+  netKey: string
+  orientation: SegmentOrientation
+  fixedCoord: number
+  minCoord: number
+  maxCoord: number
+  length: number
+}
+
+export interface MergeNearbySameNetTraceSegmentsOptions {
+  mergeDistance?: number
+}
+
+const DEFAULT_MERGE_DISTANCE = 0.2
+
+const getTraceNetKey = (trace: SolvedTracePath): string =>
+  trace.userNetId ?? trace.globalConnNetId ?? trace.dcConnNetId
+
+const getRangeGap = (a: MergeableSegment, b: MergeableSegment): number => {
+  if (a.maxCoord < b.minCoord) return b.minCoord - a.maxCoord
+  if (b.maxCoord < a.minCoord) return a.minCoord - b.maxCoord
+  return 0
+}
+
+class UnionFind {
+  private parents: number[]
+
+  constructor(size: number) {
+    this.parents = Array.from({ length: size }, (_, index) => index)
+  }
+
+  find(index: number): number {
+    const parent = this.parents[index]!
+    if (parent === index) return index
+    const root = this.find(parent)
+    this.parents[index] = root
+    return root
+  }
+
+  union(a: number, b: number) {
+    const rootA = this.find(a)
+    const rootB = this.find(b)
+    if (rootA !== rootB) this.parents[rootB] = rootA
+  }
+}
+
+const collectMergeableSegments = (
+  traces: SolvedTracePath[],
+): MergeableSegment[] => {
+  const segments: MergeableSegment[] = []
+
+  traces.forEach((trace, traceIndex) => {
+    const netKey = getTraceNetKey(trace)
+    for (
+      let pointIndex = 0;
+      pointIndex < trace.tracePath.length - 1;
+      pointIndex++
+    ) {
+      if (pointIndex === 0 || pointIndex === trace.tracePath.length - 2) {
+        continue
+      }
+
+      const start = trace.tracePath[pointIndex]!
+      const end = trace.tracePath[pointIndex + 1]!
+      const orientation: SegmentOrientation | null = isHorizontal(start, end)
+        ? "horizontal"
+        : isVertical(start, end)
+          ? "vertical"
+          : null
+
+      if (!orientation) continue
+
+      const fixedCoord = orientation === "horizontal" ? start.y : start.x
+      const minCoord =
+        orientation === "horizontal"
+          ? Math.min(start.x, end.x)
+          : Math.min(start.y, end.y)
+      const maxCoord =
+        orientation === "horizontal"
+          ? Math.max(start.x, end.x)
+          : Math.max(start.y, end.y)
+      const length = maxCoord - minCoord
+
+      if (length === 0) continue
+
+      segments.push({
+        traceIndex,
+        pointIndex,
+        netKey,
+        orientation,
+        fixedCoord,
+        minCoord,
+        maxCoord,
+        length,
+      })
+    }
+  })
+
+  return segments
+}
+
+export const mergeNearbySameNetTraceSegments = (
+  traces: SolvedTracePath[],
+  opts: MergeNearbySameNetTraceSegmentsOptions = {},
+): SolvedTracePath[] => {
+  const mergeDistance = opts.mergeDistance ?? DEFAULT_MERGE_DISTANCE
+  const outputTraces = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point): Point => ({ ...point })),
+  }))
+  const segments = collectMergeableSegments(outputTraces)
+  const groups = new UnionFind(segments.length)
+
+  for (let i = 0; i < segments.length; i++) {
+    const a = segments[i]!
+    for (let j = i + 1; j < segments.length; j++) {
+      const b = segments[j]!
+      if (a.netKey !== b.netKey) continue
+      if (a.orientation !== b.orientation) continue
+      if (Math.abs(a.fixedCoord - b.fixedCoord) > mergeDistance) continue
+      if (getRangeGap(a, b) > mergeDistance) continue
+
+      groups.union(i, j)
+    }
+  }
+
+  const clusterMap = new Map<number, MergeableSegment[]>()
+  for (let i = 0; i < segments.length; i++) {
+    const root = groups.find(i)
+    const cluster = clusterMap.get(root)
+    if (cluster) {
+      cluster.push(segments[i]!)
+    } else {
+      clusterMap.set(root, [segments[i]!])
+    }
+  }
+
+  for (const cluster of clusterMap.values()) {
+    if (cluster.length < 2) continue
+
+    const totalLength = cluster.reduce(
+      (sum, segment) => sum + segment.length,
+      0,
+    )
+    const targetCoord =
+      cluster.reduce(
+        (sum, segment) => sum + segment.fixedCoord * segment.length,
+        0,
+      ) / totalLength
+
+    for (const segment of cluster) {
+      const trace = outputTraces[segment.traceIndex]!
+      const start = trace.tracePath[segment.pointIndex]!
+      const end = trace.tracePath[segment.pointIndex + 1]!
+
+      if (segment.orientation === "horizontal") {
+        start.y = targetCoord
+        end.y = targetCoord
+      } else {
+        start.x = targetCoord
+        end.x = targetCoord
+      }
+    }
+  }
+
+  return outputTraces.map((trace) => ({
+    ...trace,
+    tracePath: simplifyPath(trace.tracePath),
+  }))
+}

--- a/tests/functions/mergeNearbySameNetTraceSegments.test.ts
+++ b/tests/functions/mergeNearbySameNetTraceSegments.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test"
+import { mergeNearbySameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/mergeNearbySameNetTraceSegments"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [
+      { pinId: `${mspPairId}-a`, chipId: "chip-a", x: 0, y: 0 },
+      { pinId: `${mspPairId}-b`, chipId: "chip-b", x: 5, y: 0 },
+    ],
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [`${mspPairId}-a`, `${mspPairId}-b`],
+  }) as SolvedTracePath
+
+test("aligns close horizontal segments on the same net", () => {
+  const [firstTrace, secondTrace] = mergeNearbySameNetTraceSegments(
+    [
+      makeTrace("trace-1", "net-a", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 5, y: 1 },
+        { x: 5, y: 0 },
+      ]),
+      makeTrace("trace-2", "net-a", [
+        { x: 0, y: 2 },
+        { x: 0, y: 1.1 },
+        { x: 5, y: 1.1 },
+        { x: 5, y: 2 },
+      ]),
+    ],
+    { mergeDistance: 0.2 },
+  )
+
+  expect(firstTrace!.tracePath[1]!.y).toBeCloseTo(1.05)
+  expect(firstTrace!.tracePath[2]!.y).toBeCloseTo(1.05)
+  expect(secondTrace!.tracePath[1]!.y).toBeCloseTo(1.05)
+  expect(secondTrace!.tracePath[2]!.y).toBeCloseTo(1.05)
+  expect(firstTrace!.tracePath[0]).toEqual({ x: 0, y: 0 })
+  expect(secondTrace!.tracePath[3]).toEqual({ x: 5, y: 2 })
+})
+
+test("does not align close segments on different nets", () => {
+  const [firstTrace, secondTrace] = mergeNearbySameNetTraceSegments(
+    [
+      makeTrace("trace-1", "net-a", [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 5, y: 1 },
+        { x: 5, y: 0 },
+      ]),
+      makeTrace("trace-2", "net-b", [
+        { x: 0, y: 2 },
+        { x: 0, y: 1.1 },
+        { x: 5, y: 1.1 },
+        { x: 5, y: 2 },
+      ]),
+    ],
+    { mergeDistance: 0.2 },
+  )
+
+  expect(firstTrace!.tracePath[1]!.y).toBe(1)
+  expect(secondTrace!.tracePath[1]!.y).toBe(1.1)
+})
+
+test("aligns close vertical segments on the same net", () => {
+  const [firstTrace, secondTrace] = mergeNearbySameNetTraceSegments(
+    [
+      makeTrace("trace-1", "net-a", [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 5 },
+        { x: 0, y: 5 },
+      ]),
+      makeTrace("trace-2", "net-a", [
+        { x: 2, y: 0 },
+        { x: 1.1, y: 0 },
+        { x: 1.1, y: 5 },
+        { x: 2, y: 5 },
+      ]),
+    ],
+    { mergeDistance: 0.2 },
+  )
+
+  expect(firstTrace!.tracePath[1]!.x).toBeCloseTo(1.05)
+  expect(firstTrace!.tracePath[2]!.x).toBeCloseTo(1.05)
+  expect(secondTrace!.tracePath[1]!.x).toBeCloseTo(1.05)
+  expect(secondTrace!.tracePath[2]!.x).toBeCloseTo(1.05)
+})


### PR DESCRIPTION
## Summary
- Add a cleanup step that merges nearby same-net horizontal and vertical trace segments.
- Keep endpoint segments anchored so pin positions are not moved.
- Add unit coverage for horizontal alignment, vertical alignment, and different-net isolation.

## Verification
- bun test tests/functions/mergeNearbySameNetTraceSegments.test.ts
- biome format
- bun .\node_modules\typescript\bin\tsc --noEmit

/claim #34