### PR TITLE
Merge same-net trace lines that are close together (make at the same Y or same X)

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -20,6 +20,7 @@ interface TraceCleanupSolverInput {
 
 import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { mergeSameNetCloseTraces } from "./mergeSameNetCloseTraces"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "merging_collinear_traces"
   | "untangling_traces"
 
 /**
@@ -34,7 +36,8 @@ type PipelineStep =
  * It operates in a multi-step pipeline:
  * 1. **Untangling Traces**: It first attempts to untangle any overlapping or highly convoluted traces using a sub-solver.
  * 2. **Minimizing Turns**: After untangling, it iterates through each trace to minimize the number of turns, simplifying their paths.
- * 3. **Balancing L-Shapes**: Finally, it balances L-shaped trace segments to create more visually appealing and consistent layouts.
+ * 3. **Balancing L-Shapes**: Then it balances L-shaped trace segments to create more visually appealing and consistent layouts.
+ * 4. **Merging Collinear Traces**: Finally, it merges same-net trace segments that are nearly parallel and close together by snapping them to a shared Y (for horizontal segments) or shared X (for vertical segments).
  * The solver processes traces one by one, applying these cleanup steps sequentially to refine the overall trace layout.
  */
 export class TraceCleanupSolver extends BaseSolver {
@@ -84,6 +87,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "merging_collinear_traces":
+        this._runMergeCollinearTracesStep()
+        break
     }
   }
 
@@ -108,11 +114,18 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "merging_collinear_traces"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runMergeCollinearTracesStep() {
+    const merged = mergeSameNetCloseTraces(Array.from(this.tracesMap.values()))
+    this.tracesMap = new Map(merged.map((t) => [t.mspPairId, t]))
+    this.outputTraces = merged
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.ts
+++ b/lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.ts
@@ -1,0 +1,220 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+interface Segment {
+  traceIndex: number
+  segIndex: number
+  p1: Point
+  p2: Point
+}
+
+/**
+ * Merges same-net trace lines that are close together by snapping them
+ * to the same Y (for horizontal segments) or the same X (for vertical
+ * segments). This produces cleaner schematics where traces belonging to
+ * the same net align rather than running as separate parallel lines with
+ * a tiny offset.
+ *
+ * @param threshold - Maximum distance between two parallel same-net
+ *   segments for them to be considered "close" and merged.
+ */
+export const mergeSameNetCloseTraces = (
+  allTraces: SolvedTracePath[],
+  threshold = 0.3,
+): SolvedTracePath[] => {
+  const EPS = 1e-9
+
+  // Group traces by globalConnNetId
+  const netGroups: Record<string, number[]> = {}
+  for (let i = 0; i < allTraces.length; i++) {
+    const netId = allTraces[i].globalConnNetId
+    if (!netGroups[netId]) netGroups[netId] = []
+    netGroups[netId].push(i)
+  }
+
+  // Clone all trace paths so we can mutate them
+  const result: SolvedTracePath[] = allTraces.map((t) => ({
+    ...t,
+    tracePath: t.tracePath.map((p) => ({ x: p.x, y: p.y })),
+  }))
+
+  for (const netId in netGroups) {
+    const traceIndices = netGroups[netId]
+    if (traceIndices.length < 2) continue
+
+    // Collect all horizontal and vertical segments for this net
+    const horizontalSegments: Segment[] = []
+    const verticalSegments: Segment[] = []
+
+    for (const traceIdx of traceIndices) {
+      const path = result[traceIdx].tracePath
+      for (let s = 0; s < path.length - 1; s++) {
+        const p1 = path[s]
+        const p2 = path[s + 1]
+        const isHorz = Math.abs(p1.y - p2.y) < EPS
+        const isVert = Math.abs(p1.x - p2.x) < EPS
+
+        // Skip endpoint segments (first and last) to preserve pin connectivity
+        const isEndpointSegment = s === 0 || s === path.length - 2
+        if (isEndpointSegment) continue
+
+        if (isHorz) {
+          horizontalSegments.push({ traceIndex: traceIdx, segIndex: s, p1, p2 })
+        } else if (isVert) {
+          verticalSegments.push({ traceIndex: traceIdx, segIndex: s, p1, p2 })
+        }
+      }
+    }
+
+    // Merge horizontal segments that are close in Y and overlap in X
+    mergeParallelSegments(horizontalSegments, "horizontal", threshold, result)
+
+    // Merge vertical segments that are close in X and overlap in Y
+    mergeParallelSegments(verticalSegments, "vertical", threshold, result)
+  }
+
+  return result
+}
+
+function mergeParallelSegments(
+  segments: Segment[],
+  direction: "horizontal" | "vertical",
+  threshold: number,
+  allTraces: SolvedTracePath[],
+) {
+  const EPS = 1e-9
+
+  // Group segments by their perpendicular coordinate (Y for horizontal, X for vertical)
+  // using a clustering approach based on threshold
+  if (segments.length < 2) return
+
+  // Sort by the perpendicular coordinate
+  const sorted = [...segments].sort((a, b) => {
+    if (direction === "horizontal") {
+      return a.p1.y - b.p1.y
+    }
+    return a.p1.x - b.p1.x
+  })
+
+  // Cluster segments that are within threshold of each other on the perpendicular axis
+  const clusters: Segment[][] = []
+  let currentCluster: Segment[] = [sorted[0]]
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = currentCluster[0]
+    const curr = sorted[i]
+
+    const prevCoord = direction === "horizontal" ? prev.p1.y : prev.p1.x
+    const currCoord = direction === "horizontal" ? curr.p1.y : curr.p1.x
+
+    if (Math.abs(currCoord - prevCoord) <= threshold) {
+      currentCluster.push(curr)
+    } else {
+      if (currentCluster.length > 1) {
+        clusters.push(currentCluster)
+      }
+      currentCluster = [curr]
+    }
+  }
+  if (currentCluster.length > 1) {
+    clusters.push(currentCluster)
+  }
+
+  // For each cluster, check which segments actually overlap on the parallel axis
+  // and snap them to the average perpendicular coordinate
+  for (const cluster of clusters) {
+    // Only merge segments from different traces
+    const uniqueTraces = new Set(cluster.map((s) => s.traceIndex))
+    if (uniqueTraces.size < 2) continue
+
+    // Find groups of segments that overlap on the parallel axis
+    const overlapGroups = findOverlappingGroups(cluster, direction, EPS)
+
+    for (const group of overlapGroups) {
+      // Only process groups with segments from multiple traces
+      const groupTraces = new Set(group.map((s) => s.traceIndex))
+      if (groupTraces.size < 2) continue
+
+      // Compute average perpendicular coordinate
+      let avgCoord = 0
+      for (const seg of group) {
+        avgCoord += direction === "horizontal" ? seg.p1.y : seg.p1.x
+      }
+      avgCoord /= group.length
+
+      // Snap all segments in this group to the average coordinate
+      for (const seg of group) {
+        const path = allTraces[seg.traceIndex].tracePath
+        if (direction === "horizontal") {
+          path[seg.segIndex].y = avgCoord
+          path[seg.segIndex + 1].y = avgCoord
+        } else {
+          path[seg.segIndex].x = avgCoord
+          path[seg.segIndex + 1].x = avgCoord
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Given a set of parallel segments in the same cluster (close perpendicular
+ * coord), find subsets that overlap on the parallel axis.
+ */
+function findOverlappingGroups(
+  segments: Segment[],
+  direction: "horizontal" | "vertical",
+  eps: number,
+): Segment[][] {
+  // For horizontal segments, parallel axis is X; for vertical, it's Y
+  const getRange = (seg: Segment): [number, number] => {
+    if (direction === "horizontal") {
+      return [Math.min(seg.p1.x, seg.p2.x), Math.max(seg.p1.x, seg.p2.x)]
+    }
+    return [Math.min(seg.p1.y, seg.p2.y), Math.max(seg.p1.y, seg.p2.y)]
+  }
+
+  const overlaps = (a: [number, number], b: [number, number]): boolean => {
+    const overlap = Math.min(a[1], b[1]) - Math.max(a[0], b[0])
+    return overlap > eps
+  }
+
+  // Use union-find to group overlapping segments
+  const parent: number[] = segments.map((_, i) => i)
+
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]]
+      i = parent[i]
+    }
+    return i
+  }
+
+  const union = (a: number, b: number) => {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent[ra] = rb
+  }
+
+  for (let i = 0; i < segments.length; i++) {
+    for (let j = i + 1; j < segments.length; j++) {
+      // Only merge segments from different traces
+      if (segments[i].traceIndex === segments[j].traceIndex) continue
+      const rangeI = getRange(segments[i])
+      const rangeJ = getRange(segments[j])
+      if (overlaps(rangeI, rangeJ)) {
+        union(i, j)
+      }
+    }
+  }
+
+  // Group by root
+  const groups: Record<number, Segment[]> = {}
+  for (let i = 0; i < segments.length; i++) {
+    const root = find(i)
+    if (!groups[root]) groups[root] = []
+    groups[root].push(segments[i])
+  }
+
+  return Object.values(groups).filter((g) => g.length > 1)
+}

--- a/tests/solvers/TraceCleanupSolver/merge-same-net-close-traces.test.ts
+++ b/tests/solvers/TraceCleanupSolver/merge-same-net-close-traces.test.ts
@@ -1,0 +1,252 @@
+import { test, expect } from "bun:test"
+import { mergeSameNetCloseTraces } from "lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+test("should merge horizontal same-net traces at nearly same Y", () => {
+  // Two traces in U-shapes; the middle horizontal segments are at slightly
+  // different Y values but should be snapped together.
+  const traces: SolvedTracePath[] = [
+    {
+      mspPairId: "pair1",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p1", x: 0, y: 0, chipId: "c1" },
+        { pinId: "p2", x: 5, y: 0, chipId: "c2" },
+      ],
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 5, y: 1 },
+        { x: 5, y: 0 },
+      ],
+      mspConnectionPairIds: ["pair1"],
+      pinIds: ["p1", "p2"],
+    },
+    {
+      mspPairId: "pair2",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p3", x: 2, y: 0, chipId: "c3" },
+        { pinId: "p4", x: 7, y: 0, chipId: "c4" },
+      ],
+      tracePath: [
+        { x: 2, y: 0 },
+        { x: 2, y: 1.2 },
+        { x: 7, y: 1.2 },
+        { x: 7, y: 0 },
+      ],
+      mspConnectionPairIds: ["pair2"],
+      pinIds: ["p3", "p4"],
+    },
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, 0.3)
+
+  // Both middle horizontal segments should now share the same Y (avg of 1 and 1.2 = 1.1)
+  expect(result[0].tracePath[1].y).toBeCloseTo(1.1)
+  expect(result[0].tracePath[2].y).toBeCloseTo(1.1)
+  expect(result[1].tracePath[1].y).toBeCloseTo(1.1)
+  expect(result[1].tracePath[2].y).toBeCloseTo(1.1)
+
+  // Endpoints (pin connections) must remain unchanged
+  expect(result[0].tracePath[0]).toEqual({ x: 0, y: 0 })
+  expect(result[0].tracePath[3]).toEqual({ x: 5, y: 0 })
+  expect(result[1].tracePath[0]).toEqual({ x: 2, y: 0 })
+  expect(result[1].tracePath[3]).toEqual({ x: 7, y: 0 })
+})
+
+test("should merge vertical same-net traces at nearly same X", () => {
+  const traces: SolvedTracePath[] = [
+    {
+      mspPairId: "pair1",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p1", x: 0, y: 0, chipId: "c1" },
+        { pinId: "p2", x: 0, y: 5, chipId: "c2" },
+      ],
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 5 },
+        { x: 0, y: 5 },
+      ],
+      mspConnectionPairIds: ["pair1"],
+      pinIds: ["p1", "p2"],
+    },
+    {
+      mspPairId: "pair2",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p3", x: 0, y: 1, chipId: "c3" },
+        { pinId: "p4", x: 0, y: 6, chipId: "c4" },
+      ],
+      tracePath: [
+        { x: 0, y: 1 },
+        { x: 1.2, y: 1 },
+        { x: 1.2, y: 6 },
+        { x: 0, y: 6 },
+      ],
+      mspConnectionPairIds: ["pair2"],
+      pinIds: ["p3", "p4"],
+    },
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, 0.3)
+
+  // The middle vertical segments should share the same X (avg of 1 and 1.2 = 1.1)
+  expect(result[0].tracePath[1].x).toBeCloseTo(1.1)
+  expect(result[0].tracePath[2].x).toBeCloseTo(1.1)
+  expect(result[1].tracePath[1].x).toBeCloseTo(1.1)
+  expect(result[1].tracePath[2].x).toBeCloseTo(1.1)
+})
+
+test("should not merge traces on different nets", () => {
+  const traces: SolvedTracePath[] = [
+    {
+      mspPairId: "pair1",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p1", x: 0, y: 0, chipId: "c1" },
+        { pinId: "p2", x: 5, y: 0, chipId: "c2" },
+      ],
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 5, y: 1 },
+        { x: 5, y: 0 },
+      ],
+      mspConnectionPairIds: ["pair1"],
+      pinIds: ["p1", "p2"],
+    },
+    {
+      mspPairId: "pair2",
+      dcConnNetId: "net2",
+      globalConnNetId: "net2",
+      pins: [
+        { pinId: "p3", x: 2, y: 0, chipId: "c3" },
+        { pinId: "p4", x: 7, y: 0, chipId: "c4" },
+      ],
+      tracePath: [
+        { x: 2, y: 0 },
+        { x: 2, y: 1.2 },
+        { x: 7, y: 1.2 },
+        { x: 7, y: 0 },
+      ],
+      mspConnectionPairIds: ["pair2"],
+      pinIds: ["p3", "p4"],
+    },
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, 0.3)
+
+  // Should NOT merge - different nets; horizontal Y stays as authored
+  expect(result[0].tracePath[1].y).toBe(1)
+  expect(result[0].tracePath[2].y).toBe(1)
+  expect(result[1].tracePath[1].y).toBe(1.2)
+  expect(result[1].tracePath[2].y).toBe(1.2)
+})
+
+test("should not merge traces that do not overlap on parallel axis", () => {
+  const traces: SolvedTracePath[] = [
+    {
+      mspPairId: "pair1",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p1", x: 0, y: 0, chipId: "c1" },
+        { pinId: "p2", x: 3, y: 0, chipId: "c2" },
+      ],
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 3, y: 1 },
+        { x: 3, y: 0 },
+      ],
+      mspConnectionPairIds: ["pair1"],
+      pinIds: ["p1", "p2"],
+    },
+    {
+      mspPairId: "pair2",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p3", x: 10, y: 0, chipId: "c3" },
+        { pinId: "p4", x: 15, y: 0, chipId: "c4" },
+      ],
+      tracePath: [
+        { x: 10, y: 0 },
+        { x: 10, y: 1.1 },
+        { x: 15, y: 1.1 },
+        { x: 15, y: 0 },
+      ],
+      mspConnectionPairIds: ["pair2"],
+      pinIds: ["p3", "p4"],
+    },
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, 0.3)
+
+  // Should NOT merge - the horizontal segments do not overlap on X axis
+  expect(result[0].tracePath[1].y).toBe(1)
+  expect(result[0].tracePath[2].y).toBe(1)
+  expect(result[1].tracePath[1].y).toBe(1.1)
+  expect(result[1].tracePath[2].y).toBe(1.1)
+})
+
+test("should preserve pin endpoints when merging", () => {
+  // The first/last segments of each trace touch a pin and must not move.
+  const traces: SolvedTracePath[] = [
+    {
+      mspPairId: "pair1",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p1", x: 0, y: 0.05, chipId: "c1" },
+        { pinId: "p2", x: 5, y: 0.05, chipId: "c2" },
+      ],
+      tracePath: [
+        // First segment is horizontal but at the pin — must not move.
+        { x: 0, y: 0.05 },
+        { x: 1, y: 0.05 },
+        { x: 1, y: 2 },
+        { x: 4, y: 2 },
+        { x: 4, y: 0.05 },
+        { x: 5, y: 0.05 },
+      ],
+      mspConnectionPairIds: ["pair1"],
+      pinIds: ["p1", "p2"],
+    },
+    {
+      mspPairId: "pair2",
+      dcConnNetId: "net1",
+      globalConnNetId: "net1",
+      pins: [
+        { pinId: "p3", x: 0, y: -0.05, chipId: "c3" },
+        { pinId: "p4", x: 5, y: -0.05, chipId: "c4" },
+      ],
+      tracePath: [
+        { x: 0, y: -0.05 },
+        { x: 1.2, y: -0.05 },
+        { x: 1.2, y: 2.1 },
+        { x: 3.8, y: 2.1 },
+        { x: 3.8, y: -0.05 },
+        { x: 5, y: -0.05 },
+      ],
+      mspConnectionPairIds: ["pair2"],
+      pinIds: ["p3", "p4"],
+    },
+  ]
+
+  const result = mergeSameNetCloseTraces(traces, 0.3)
+
+  // Endpoints stay where they were
+  expect(result[0].tracePath[0]).toEqual({ x: 0, y: 0.05 })
+  expect(result[0].tracePath[5]).toEqual({ x: 5, y: 0.05 })
+  expect(result[1].tracePath[0]).toEqual({ x: 0, y: -0.05 })
+  expect(result[1].tracePath[5]).toEqual({ x: 5, y: -0.05 })
+})


### PR DESCRIPTION
## Summary

Add a final cleanup pass to `TraceCleanupSolver` that merges same-net trace
segments that run almost-but-not-quite collinear. When two horizontal
segments on the same net sit at nearly-the-same Y (or two vertical
segments at nearly-the-same X) and overlap on the parallel axis, they are
snapped to a shared coordinate so the schematic shows a single clean line
instead of two close, separate lines.

## Changes

- `lib/solvers/TraceCleanupSolver/mergeSameNetCloseTraces.ts` — New utility
  that groups traces by `globalConnNetId`, finds parallel segments within
  a configurable distance threshold (default `0.3`), and snaps each
  overlapping group to its average perpendicular coordinate. Endpoint
  segments touching pins are skipped to preserve connectivity.
- `lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts` — Add a new
  `merging_collinear_traces` pipeline step that runs once after the
  per-trace untangle / minimize-turns / balance-L-shapes phases.
- `tests/solvers/TraceCleanupSolver/merge-same-net-close-traces.test.ts` —
  Unit tests covering horizontal merging, vertical merging, different-net
  isolation, non-overlapping segments, and pin-endpoint preservation.

## Test Plan

- `bun test tests/solvers/TraceCleanupSolver/merge-same-net-close-traces.test.ts`
  → 5 new tests pass.
- `bun test` → 71 pass, 0 fail (4 pre-existing skips unchanged).
- `bunx tsc --noEmit` → no type errors.
- `bun run format:check` → clean.

## Notes

The merge is intentionally conservative: only same-net segments that
actually overlap on the parallel axis are aligned, and pin-anchored
endpoint segments are left untouched. Segments on different nets are
never combined, so circuit topology is preserved.

Closes #34
