### PR TITLE
Add same-net trace merge solver

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+export { SameNetTraceMergeSolver } from "./solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"

--- a/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
+++ b/lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.ts
@@ -1,0 +1,315 @@
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+type TracePin = SolvedTracePath["pins"][number]
+
+export interface TraceSegment {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  netId: string
+}
+
+type NormalizedTraceSegment = TraceSegment & {
+  orientation: "horizontal" | "vertical" | "other"
+}
+
+const DEFAULT_MERGE_TOLERANCE = 0.02
+
+const normalizeSegment = (
+  segment: TraceSegment,
+  tolerance = DEFAULT_MERGE_TOLERANCE,
+): NormalizedTraceSegment => {
+  if (Math.abs(segment.y1 - segment.y2) <= tolerance) {
+    const x1 = Math.min(segment.x1, segment.x2)
+    const x2 = Math.max(segment.x1, segment.x2)
+    const y = (segment.y1 + segment.y2) / 2
+    return { ...segment, x1, y1: y, x2, y2: y, orientation: "horizontal" }
+  }
+
+  if (Math.abs(segment.x1 - segment.x2) <= tolerance) {
+    const x = (segment.x1 + segment.x2) / 2
+    const y1 = Math.min(segment.y1, segment.y2)
+    const y2 = Math.max(segment.y1, segment.y2)
+    return { ...segment, x1: x, y1, x2: x, y2, orientation: "vertical" }
+  }
+
+  return { ...segment, orientation: "other" }
+}
+
+const rangesTouchOrOverlap = (
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number,
+  tolerance: number,
+) => Math.max(aStart, bStart) <= Math.min(aEnd, bEnd) + tolerance
+
+const tryMergeSegments = (
+  a: NormalizedTraceSegment,
+  b: NormalizedTraceSegment,
+  tolerance: number,
+): NormalizedTraceSegment | null => {
+  if (a.netId !== b.netId) return null
+  if (a.orientation !== b.orientation) return null
+  if (a.orientation === "other") return null
+
+  if (a.orientation === "horizontal") {
+    if (Math.abs(a.y1 - b.y1) > tolerance) return null
+    if (!rangesTouchOrOverlap(a.x1, a.x2, b.x1, b.x2, tolerance)) return null
+
+    const y = (a.y1 + b.y1) / 2
+    return {
+      netId: a.netId,
+      x1: Math.min(a.x1, b.x1),
+      y1: y,
+      x2: Math.max(a.x2, b.x2),
+      y2: y,
+      orientation: "horizontal",
+    }
+  }
+
+  if (Math.abs(a.x1 - b.x1) > tolerance) return null
+  if (!rangesTouchOrOverlap(a.y1, a.y2, b.y1, b.y2, tolerance)) return null
+
+  const x = (a.x1 + b.x1) / 2
+  return {
+    netId: a.netId,
+    x1: x,
+    y1: Math.min(a.y1, b.y1),
+    x2: x,
+    y2: Math.max(a.y2, b.y2),
+    orientation: "vertical",
+  }
+}
+
+export const mergeCloseSameNetTraceSegments = (
+  segments: TraceSegment[],
+  tolerance = DEFAULT_MERGE_TOLERANCE,
+): TraceSegment[] => {
+  const merged = segments.map((segment) => normalizeSegment(segment, tolerance))
+
+  let didMerge = true
+  while (didMerge) {
+    didMerge = false
+
+    for (let i = 0; i < merged.length && !didMerge; i++) {
+      for (let j = i + 1; j < merged.length; j++) {
+        const candidate = tryMergeSegments(merged[i]!, merged[j]!, tolerance)
+        if (!candidate) continue
+
+        merged.splice(j, 1)
+        merged[i] = candidate
+        didMerge = true
+        break
+      }
+    }
+  }
+
+  return merged.map(({ orientation: _orientation, ...segment }) => segment)
+}
+
+const getTraceNetId = (trace: SolvedTracePath) =>
+  trace.globalConnNetId ?? trace.dcConnNetId ?? trace.userNetId
+
+const isStraightTrace = (
+  trace: SolvedTracePath,
+  tolerance = DEFAULT_MERGE_TOLERANCE,
+) => {
+  if (trace.tracePath.length !== 2) return false
+  const [start, end] = trace.tracePath
+  return (
+    Math.abs(start!.x - end!.x) <= tolerance ||
+    Math.abs(start!.y - end!.y) <= tolerance
+  )
+}
+
+const segmentFromStraightTrace = (trace: SolvedTracePath): TraceSegment => {
+  const [start, end] = trace.tracePath
+  return {
+    x1: start!.x,
+    y1: start!.y,
+    x2: end!.x,
+    y2: end!.y,
+    netId: getTraceNetId(trace),
+  }
+}
+
+const segmentOrientation = (
+  segment: TraceSegment,
+  tolerance = DEFAULT_MERGE_TOLERANCE,
+) => {
+  if (Math.abs(segment.y1 - segment.y2) <= tolerance) return "horizontal"
+  if (Math.abs(segment.x1 - segment.x2) <= tolerance) return "vertical"
+  return "other"
+}
+
+const segmentCoversTrace = (
+  merged: TraceSegment,
+  source: TraceSegment,
+  tolerance = DEFAULT_MERGE_TOLERANCE,
+) => {
+  if (merged.netId !== source.netId) return false
+
+  const mergedOrientation = segmentOrientation(merged, tolerance)
+  if (mergedOrientation !== segmentOrientation(source, tolerance)) return false
+
+  if (mergedOrientation === "horizontal") {
+    const fixedAxisMatches = Math.abs(merged.y1 - source.y1) <= tolerance
+    const sourceMin = Math.min(source.x1, source.x2)
+    const sourceMax = Math.max(source.x1, source.x2)
+    const mergedMin = Math.min(merged.x1, merged.x2)
+    const mergedMax = Math.max(merged.x1, merged.x2)
+    return (
+      fixedAxisMatches &&
+      sourceMin >= mergedMin - tolerance &&
+      sourceMax <= mergedMax + tolerance
+    )
+  }
+
+  if (mergedOrientation === "vertical") {
+    const fixedAxisMatches = Math.abs(merged.x1 - source.x1) <= tolerance
+    const sourceMin = Math.min(source.y1, source.y2)
+    const sourceMax = Math.max(source.y1, source.y2)
+    const mergedMin = Math.min(merged.y1, merged.y2)
+    const mergedMax = Math.max(merged.y1, merged.y2)
+    return (
+      fixedAxisMatches &&
+      sourceMin >= mergedMin - tolerance &&
+      sourceMax <= mergedMax + tolerance
+    )
+  }
+
+  return false
+}
+
+const uniqueByPinId = (pins: TracePin[]) => {
+  const seen = new Set<string>()
+  return pins.filter((pin) => {
+    if (seen.has(pin.pinId)) return false
+    seen.add(pin.pinId)
+    return true
+  })
+}
+
+const distanceSquared = (
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+) => (a.x - b.x) ** 2 + (a.y - b.y) ** 2
+
+const pickEndpointPins = (
+  pins: TracePin[],
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+) => {
+  const uniquePins = uniqueByPinId(pins)
+  if (uniquePins.length < 2) return null
+
+  const startPin = uniquePins
+    .slice()
+    .sort((a, b) => distanceSquared(a, start) - distanceSquared(b, start))[0]!
+
+  const endPin =
+    uniquePins
+      .filter((pin) => pin.pinId !== startPin.pinId)
+      .sort((a, b) => distanceSquared(a, end) - distanceSquared(b, end))[0] ??
+    uniquePins
+      .slice()
+      .sort((a, b) => distanceSquared(a, end) - distanceSquared(b, end))[0]!
+
+  return [startPin, endPin] as [TracePin, TracePin]
+}
+
+export class SameNetTraceMergeSolver extends BaseSolver {
+  private inputTraces: SolvedTracePath[]
+  private outputTraces: SolvedTracePath[]
+
+  constructor(params: { traces: SolvedTracePath[] }) {
+    super()
+    this.inputTraces = params.traces
+    this.outputTraces = params.traces
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceMergeSolver
+  >[0] {
+    return {
+      traces: this.inputTraces,
+    }
+  }
+
+  override _step() {
+    const straightTraceEntries = this.inputTraces
+      .map((trace, index) => ({ trace, index }))
+      .filter(({ trace }) => isStraightTrace(trace))
+
+    const mergedSegments = mergeCloseSameNetTraceSegments(
+      straightTraceEntries.map(({ trace }) => segmentFromStraightTrace(trace)),
+    )
+
+    const consumedTraceIndexes = new Set<number>()
+    const mergedTraces: SolvedTracePath[] = []
+
+    for (const mergedSegment of mergedSegments) {
+      const sourceEntries = straightTraceEntries.filter(({ trace, index }) => {
+        if (consumedTraceIndexes.has(index)) return false
+        return segmentCoversTrace(
+          mergedSegment,
+          segmentFromStraightTrace(trace),
+        )
+      })
+
+      if (sourceEntries.length <= 1) continue
+
+      for (const { index } of sourceEntries) {
+        consumedTraceIndexes.add(index)
+      }
+
+      const sourceTraces = sourceEntries.map(({ trace }) => trace)
+      const representative = sourceTraces[0]!
+      const mspConnectionPairIds = Array.from(
+        new Set(
+          sourceTraces.flatMap((trace) => [
+            ...(trace.mspConnectionPairIds ?? []),
+            trace.mspPairId,
+          ]),
+        ),
+      )
+      const tracePath = [
+        { x: mergedSegment.x1, y: mergedSegment.y1 },
+        { x: mergedSegment.x2, y: mergedSegment.y2 },
+      ]
+      const endpointPins = pickEndpointPins(
+        sourceTraces.flatMap((trace) => trace.pins),
+        tracePath[0]!,
+        tracePath[1]!,
+      )
+
+      mergedTraces.push({
+        ...representative,
+        mspPairId: `same-net-merge-${mspConnectionPairIds.join("-")}`,
+        tracePath,
+        mspConnectionPairIds,
+        pinIds: Array.from(
+          new Set(sourceTraces.flatMap((trace) => trace.pinIds)),
+        ),
+        pins: endpointPins ?? representative.pins,
+      })
+    }
+
+    this.outputTraces = [
+      ...this.inputTraces.filter(
+        (_, index) => !consumedTraceIndexes.has(index),
+      ),
+      ...mergedTraces,
+    ]
+    this.solved = true
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -21,6 +21,7 @@ import { expandChipsToFitPins } from "./expandChipsToFitPins"
 import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import { SameNetTraceMergeSolver } from "../SameNetTraceMergeSolver/SameNetTraceMergeSolver"
 import { Example28Solver } from "../Example28Solver/Example28Solver"
 import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
 import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
@@ -76,6 +77,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetTraceMergeSolver?: SameNetTraceMergeSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -220,10 +222,20 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceMergeSolver",
+      SameNetTraceMergeSolver,
+      (instance) => [
+        {
+          traces: instance.traceCleanupSolver!.getOutput().traces,
+        },
+      ],
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceMergeSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -239,6 +251,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     ),
     definePipelineStep("example28Solver", Example28Solver, (instance) => {
       const traces =
+        instance.sameNetTraceMergeSolver?.getOutput().traces ??
         instance.traceCleanupSolver?.getOutput().traces ??
         instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 

--- a/tests/functions/mergeCloseSameNetTraceSegments.test.ts
+++ b/tests/functions/mergeCloseSameNetTraceSegments.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { mergeCloseSameNetTraceSegments } from "lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"
+
+describe("mergeCloseSameNetTraceSegments", () => {
+  test("merges overlapping horizontal same-net segments", () => {
+    const result = mergeCloseSameNetTraceSegments([
+      { x1: 0, y1: 1, x2: 3, y2: 1, netId: "VCC" },
+      { x1: 2, y1: 1, x2: 5, y2: 1, netId: "VCC" },
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ x1: 0, y1: 1, x2: 5, y2: 1 })
+  })
+
+  test("merges vertical same-net segments whose fixed axis is within tolerance", () => {
+    const result = mergeCloseSameNetTraceSegments([
+      { x1: 2, y1: 0, x2: 2, y2: 3, netId: "GND" },
+      { x1: 2.01, y1: 2, x2: 2.01, y2: 6, netId: "GND" },
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.x1).toBeCloseTo(2)
+    expect(result[0]!.x2).toBeCloseTo(2)
+    expect(result[0]!.y1).toBeCloseTo(0)
+    expect(result[0]!.y2).toBeCloseTo(6)
+  })
+
+  test("merges approximately straight same-net segments within tolerance", () => {
+    const result = mergeCloseSameNetTraceSegments([
+      { x1: 0, y1: 1, x2: 3, y2: 1.01, netId: "VCC" },
+      { x1: 2, y1: 1.005, x2: 5, y2: 1.005, netId: "VCC" },
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.x1).toBeCloseTo(0)
+    expect(result[0]!.x2).toBeCloseTo(5)
+    expect(result[0]!.y1).toBeCloseTo(result[0]!.y2)
+  })
+
+  test("does not merge segments on different nets", () => {
+    const result = mergeCloseSameNetTraceSegments([
+      { x1: 0, y1: 0, x2: 3, y2: 0, netId: "VCC" },
+      { x1: 1, y1: 0, x2: 4, y2: 0, netId: "GND" },
+    ])
+
+    expect(result).toHaveLength(2)
+  })
+})

--- a/tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
+++ b/tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test"
+import { SameNetTraceMergeSolver } from "lib/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const trace = (
+  id: string,
+  netId: string,
+  path: Array<{ x: number; y: number }>,
+): SolvedTracePath =>
+  ({
+    mspPairId: id,
+    dcConnNetId: netId,
+    globalConnNetId: netId,
+    pins: [
+      { pinId: `${id}.1`, chipId: "U1", x: path[0]!.x, y: path[0]!.y },
+      {
+        pinId: `${id}.2`,
+        chipId: "U2",
+        x: path[path.length - 1]!.x,
+        y: path[path.length - 1]!.y,
+      },
+    ],
+    tracePath: path,
+    mspConnectionPairIds: [id],
+    pinIds: [`${id}.1`, `${id}.2`],
+  }) as SolvedTracePath
+
+describe("SameNetTraceMergeSolver", () => {
+  test("merges overlapping straight traces on the same net", () => {
+    const solver = new SameNetTraceMergeSolver({
+      traces: [
+        trace("a", "VCC", [
+          { x: 0, y: 0 },
+          { x: 3, y: 0 },
+        ]),
+        trace("b", "VCC", [
+          { x: 2, y: 0 },
+          { x: 5, y: 0 },
+        ]),
+      ],
+    })
+
+    solver.solve()
+
+    const { traces } = solver.getOutput()
+    expect(traces).toHaveLength(1)
+    expect(traces[0]!.tracePath).toEqual([
+      { x: 0, y: 0 },
+      { x: 5, y: 0 },
+    ])
+    expect(traces[0]!.mspConnectionPairIds).toEqual(["a", "b"])
+    expect(traces[0]!.pins[0]).toMatchObject({ pinId: "a.1", x: 0, y: 0 })
+    expect(traces[0]!.pins[1]).toMatchObject({ pinId: "b.2", x: 5, y: 0 })
+  })
+
+  test("does not merge straight traces on different nets", () => {
+    const solver = new SameNetTraceMergeSolver({
+      traces: [
+        trace("a", "VCC", [
+          { x: 0, y: 0 },
+          { x: 3, y: 0 },
+        ]),
+        trace("b", "GND", [
+          { x: 2, y: 0 },
+          { x: 5, y: 0 },
+        ]),
+      ],
+    })
+
+    solver.solve()
+
+    expect(solver.getOutput().traces).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
/claim #34

## Summary

Adds a conservative same-net trace merge pass to reduce duplicate direction changes caused by overlapping straight traces on the same net.

- Adds `SameNetTraceMergeSolver`
- Merges overlapping or near-collinear straight trace segments only when they share the same net
- Preserves source trace metadata by carrying forward source `mspConnectionPairIds`, `pinIds`, and representative pins
- Runs the new solver after `TraceCleanupSolver` and before the second `NetLabelPlacementSolver`
- Exports the solver from `lib/index.ts`

Fixes #34.

## Tests

```bash
bun x tsc --noEmit
bun --config='../.tools/empty-bunfig.toml' test tests/functions/mergeCloseSameNetTraceSegments.test.ts tests/solvers/SameNetTraceMergeSolver/SameNetTraceMergeSolver.test.ts
```

Targeted tests pass: 6 pass, 0 fail.

Note: the repository's default `bun test` preload imports `bun-match-svg`, which currently requires `sharp`; on this Windows environment, `sharp` cannot build because Visual Studio C++ build tools are unavailable. The targeted tests were run with a no-preload Bun config to verify this solver logic without the SVG matcher.

## Bounty Claim Note

This PR targets the `/bounty $100` request in #34 by adding a focused same-net merge stage rather than a broad routing rewrite.

