### PR TITLE
fix connectivity islands for reused net names

### DIFF
--- a/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
+++ b/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
@@ -1,23 +1,36 @@
 import { ConnectivityMap } from "connectivity-map"
 import type { InputProblem } from "lib/types/InputProblem"
 
+const getExistingNetId = (
+  connMap: ConnectivityMap,
+  pinIds: string[],
+): string | undefined => {
+  for (const pinId of pinIds) {
+    const connectedNetId = connMap.getNetConnectedToId(pinId)
+    if (connectedNetId) return connectedNetId
+  }
+
+  return undefined
+}
+
 export const getConnectivityMapsFromInputProblem = (
   inputProblem: InputProblem,
 ): { directConnMap: ConnectivityMap; netConnMap: ConnectivityMap } => {
   const directConnMap = new ConnectivityMap({})
 
-  for (const directConn of inputProblem.directConnections) {
-    directConnMap.addConnections([
-      directConn.netId
-        ? [directConn.netId, ...directConn.pinIds]
-        : directConn.pinIds,
-    ])
+  for (const [index, directConn] of inputProblem.directConnections.entries()) {
+    directConnMap.addConnections([[`dc_${index}`, ...directConn.pinIds]])
   }
 
   const netConnMap = new ConnectivityMap(directConnMap.netMap)
 
-  for (const netConn of inputProblem.netConnections) {
-    netConnMap.addConnections([[netConn.netId, ...netConn.pinIds]])
+  for (const [index, netConn] of inputProblem.netConnections.entries()) {
+    if (netConn.pinIds.length === 0) continue
+
+    const netId =
+      getExistingNetId(netConnMap, netConn.pinIds) ?? `nc_${index}`
+
+    netConnMap.addConnections([[netId, ...netConn.pinIds]])
   }
 
   return { directConnMap, netConnMap }

--- a/tests/solvers/MspConnectionPairSolver/MspConnectionPairSolver_sameNetIdIslands.test.ts
+++ b/tests/solvers/MspConnectionPairSolver/MspConnectionPairSolver_sameNetIdIslands.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import { getConnectivityMapsFromInputProblem } from "lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem"
+import { MspConnectionPairSolver } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+test("separate directConnections with the same netId stay isolated", () => {
+  const inputProblem: InputProblem = {
+    chips: [],
+    directConnections: [
+      { pinIds: ["U1.1", "C1.1"], netId: "GND" },
+      { pinIds: ["U2.1", "C2.1"], netId: "GND" },
+    ],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+
+  const { directConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
+
+  expect(directConnMap.areIdsConnected("U1.1", "C1.1")).toBe(true)
+  expect(directConnMap.areIdsConnected("U2.1", "C2.1")).toBe(true)
+  expect(directConnMap.areIdsConnected("U1.1", "U2.1")).toBe(false)
+  expect(directConnMap.areIdsConnected("C1.1", "C2.1")).toBe(false)
+})
+
+test("separate netConnections with the same netId stay isolated unless they share a pin", () => {
+  const inputProblem: InputProblem = {
+    chips: [],
+    directConnections: [],
+    netConnections: [
+      { pinIds: ["A", "B"], netId: "BUS" },
+      { pinIds: ["C", "D"], netId: "BUS" },
+      { pinIds: ["D", "E"], netId: "BUS" },
+    ],
+    availableNetLabelOrientations: {},
+  }
+
+  const { netConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
+
+  expect(netConnMap.areIdsConnected("A", "B")).toBe(true)
+  expect(netConnMap.areIdsConnected("C", "D")).toBe(true)
+  expect(netConnMap.areIdsConnected("D", "E")).toBe(true)
+  expect(netConnMap.areIdsConnected("C", "E")).toBe(true)
+  expect(netConnMap.areIdsConnected("A", "C")).toBe(false)
+})
+
+test("MspConnectionPairSolver does not create cross-island pairs for reused net names", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U1.1", x: 0, y: 0 }],
+      },
+      {
+        chipId: "C1",
+        center: { x: 0, y: 1 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "C1.1", x: 0, y: 1 }],
+      },
+      {
+        chipId: "U2",
+        center: { x: 3, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U2.1", x: 3, y: 0 }],
+      },
+      {
+        chipId: "C2",
+        center: { x: 3, y: 1 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "C2.1", x: 3, y: 1 }],
+      },
+    ],
+    directConnections: [
+      { pinIds: ["U1.1", "C1.1"], netId: "GND" },
+      { pinIds: ["U2.1", "C2.1"], netId: "GND" },
+    ],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+    maxMspPairDistance: 10,
+  }
+
+  const solver = new MspConnectionPairSolver({ inputProblem })
+  solver.solve()
+
+  expect(solver.mspConnectionPairs).toHaveLength(2)
+  expect(
+    solver.mspConnectionPairs.every((pair) => {
+      const pinIds = pair.pins.map((pin) => pin.pinId).sort()
+      return (
+        pinIds.join(",") === "C1.1,U1.1" || pinIds.join(",") === "C2.1,U2.1"
+      )
+    }),
+  ).toBe(true)
+})


### PR DESCRIPTION
Fixes tscircuit/core#1498.

This change prevents separate direct/net connections from being merged just because they reuse the same user-facing net name.

Summary:
- assign synthetic island ids to direct connections
- assign synthetic island ids to net connections unless they extend an existing island through a shared pin
- preserve legitimate chained connectivity when netConnection entries share a pin
- add focused tests covering isolated same-name nets and valid shared-pin extension

Validation:
- bun test
- bunx tsc --noEmit

/claim #1498