### PR TITLE
Align close same-net trace segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -1,11 +1,11 @@
-import type { InputProblem } from "lib/types/InputProblem"
 import type { GraphicsObject, Line } from "graphics-debug"
-import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
-import { balanceZShapes } from "./balanceZShapes"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { balanceZShapes } from "./balanceZShapes"
+import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -18,8 +18,9 @@ interface TraceCleanupSolverInput {
   paddingBuffer: number
 }
 
-import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
+import { alignSameNetTraceSegments } from "./alignSameNetTraceSegments"
 import { is4PointRectangle } from "./is4PointRectangle"
+import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
@@ -27,6 +28,7 @@ import { is4PointRectangle } from "./is4PointRectangle"
 type PipelineStep =
   | "minimizing_turns"
   | "balancing_l_shapes"
+  | "aligning_same_net_traces"
   | "untangling_traces"
 
 /**
@@ -84,6 +86,9 @@ export class TraceCleanupSolver extends BaseSolver {
       case "balancing_l_shapes":
         this._runBalanceLShapesStep()
         break
+      case "aligning_same_net_traces":
+        this._runAlignSameNetTracesStep()
+        break
     }
   }
 
@@ -108,11 +113,20 @@ export class TraceCleanupSolver extends BaseSolver {
 
   private _runBalanceLShapesStep() {
     if (this.traceIdQueue.length === 0) {
-      this.solved = true
+      this.pipelineStep = "aligning_same_net_traces"
       return
     }
 
     this._processTrace("balancing_l_shapes")
+  }
+
+  private _runAlignSameNetTracesStep() {
+    this.outputTraces = alignSameNetTraceSegments({
+      ...this.input,
+      traces: Array.from(this.tracesMap.values()),
+    })
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.solved = true
   }
 
   private _processTrace(step: "minimizing_turns" | "balancing_l_shapes") {

--- a/lib/solvers/TraceCleanupSolver/alignSameNetTraceSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignSameNetTraceSegments.ts
@@ -1,0 +1,282 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { hasCollisions } from "./hasCollisions"
+import { hasCollisionsWithLabels } from "./hasCollisionsWithLabels"
+import { simplifyPath } from "./simplifyPath"
+
+const EPS = 1e-6
+const TRACE_WIDTH = 0.01
+const DEFAULT_MAX_ALIGNMENT_DISTANCE = 0.075
+
+type Axis = "horizontal" | "vertical"
+
+interface Segment {
+  traceIndex: number
+  segmentIndex: number
+  axis: Axis
+  fixedCoord: number
+  minCoord: number
+  maxCoord: number
+}
+
+const isHorizontal = (a: Point, b: Point) => Math.abs(a.y - b.y) <= EPS
+const isVertical = (a: Point, b: Point) => Math.abs(a.x - b.x) <= EPS
+
+const getSegment = (
+  traceIndex: number,
+  segmentIndex: number,
+  path: Point[],
+): Segment | null => {
+  const start = path[segmentIndex]
+  const end = path[segmentIndex + 1]
+
+  if (!start || !end) return null
+
+  if (isHorizontal(start, end)) {
+    return {
+      traceIndex,
+      segmentIndex,
+      axis: "horizontal",
+      fixedCoord: start.y,
+      minCoord: Math.min(start.x, end.x),
+      maxCoord: Math.max(start.x, end.x),
+    }
+  }
+
+  if (isVertical(start, end)) {
+    return {
+      traceIndex,
+      segmentIndex,
+      axis: "vertical",
+      fixedCoord: start.x,
+      minCoord: Math.min(start.y, end.y),
+      maxCoord: Math.max(start.y, end.y),
+    }
+  }
+
+  return null
+}
+
+const getOverlapLength = (a: Segment, b: Segment) =>
+  Math.min(a.maxCoord, b.maxCoord) - Math.max(a.minCoord, b.minCoord)
+
+const getTraceObstacles = (
+  traces: SolvedTracePath[],
+  targetTrace: SolvedTracePath,
+) =>
+  traces
+    .filter((trace) => trace.globalConnNetId !== targetTrace.globalConnNetId)
+    .flatMap((trace, traceIndex) =>
+      trace.tracePath.slice(0, -1).map((p1, segmentIndex) => {
+        const p2 = trace.tracePath[segmentIndex + 1]!
+
+        return {
+          chipId: `trace-obstacle-${traceIndex}-${segmentIndex}`,
+          minX: Math.min(p1.x, p2.x) - TRACE_WIDTH / 2,
+          minY: Math.min(p1.y, p2.y) - TRACE_WIDTH / 2,
+          maxX: Math.max(p1.x, p2.x) + TRACE_WIDTH / 2,
+          maxY: Math.max(p1.y, p2.y) + TRACE_WIDTH / 2,
+        }
+      }),
+    )
+
+const getLabelBounds = ({
+  labels,
+  targetTrace,
+  mergedLabelNetIdMap,
+  paddingBuffer,
+}: {
+  labels: NetLabelPlacement[]
+  targetTrace: SolvedTracePath
+  mergedLabelNetIdMap: Record<string, Set<string>>
+  paddingBuffer: number
+}) =>
+  labels
+    .filter((label) => {
+      const originalNetIds = mergedLabelNetIdMap[label.globalConnNetId]
+      if (originalNetIds) {
+        return !originalNetIds.has(targetTrace.globalConnNetId)
+      }
+      return label.globalConnNetId !== targetTrace.globalConnNetId
+    })
+    .map((label) => ({
+      minX: label.center.x - label.width / 2 - paddingBuffer,
+      maxX: label.center.x + label.width / 2 + paddingBuffer,
+      minY: label.center.y - label.height / 2 - paddingBuffer,
+      maxY: label.center.y + label.height / 2 + paddingBuffer,
+    }))
+
+const canAlignPath = ({
+  trace,
+  path,
+  traces,
+  inputProblem,
+  allLabelPlacements,
+  mergedLabelNetIdMap,
+  paddingBuffer,
+}: {
+  trace: SolvedTracePath
+  path: Point[]
+  traces: SolvedTracePath[]
+  inputProblem: InputProblem
+  allLabelPlacements: NetLabelPlacement[]
+  mergedLabelNetIdMap: Record<string, Set<string>>
+  paddingBuffer: number
+}) => {
+  const obstacles = [
+    ...getObstacleRects(inputProblem),
+    ...getTraceObstacles(traces, trace),
+  ]
+  const labelBounds = getLabelBounds({
+    labels: allLabelPlacements,
+    targetTrace: trace,
+    mergedLabelNetIdMap,
+    paddingBuffer,
+  })
+
+  return (
+    !hasCollisions(path, obstacles) &&
+    !hasCollisionsWithLabels(path, labelBounds)
+  )
+}
+
+const alignSegmentInPath = ({
+  path,
+  segment,
+  fixedCoord,
+}: {
+  path: Point[]
+  segment: Segment
+  fixedCoord: number
+}): Point[] => {
+  const nextPath = path.map((point) => ({ ...point }))
+  const start = nextPath[segment.segmentIndex]!
+  const end = nextPath[segment.segmentIndex + 1]!
+
+  if (segment.axis === "horizontal") {
+    start.y = fixedCoord
+    end.y = fixedCoord
+  } else {
+    start.x = fixedCoord
+    end.x = fixedCoord
+  }
+
+  return simplifyPath(nextPath)
+}
+
+export const alignSameNetTraceSegments = ({
+  traces,
+  inputProblem,
+  allLabelPlacements,
+  mergedLabelNetIdMap,
+  paddingBuffer,
+  maxAlignmentDistance = DEFAULT_MAX_ALIGNMENT_DISTANCE,
+}: {
+  traces: SolvedTracePath[]
+  inputProblem: InputProblem
+  allLabelPlacements: NetLabelPlacement[]
+  mergedLabelNetIdMap: Record<string, Set<string>>
+  paddingBuffer: number
+  maxAlignmentDistance?: number
+}): SolvedTracePath[] => {
+  const outputTraces = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+
+  for (let traceIndex = 1; traceIndex < outputTraces.length; traceIndex++) {
+    const trace = outputTraces[traceIndex]!
+
+    for (
+      let segmentIndex = 1;
+      segmentIndex < trace.tracePath.length - 2;
+      segmentIndex++
+    ) {
+      const movableSegment = getSegment(
+        traceIndex,
+        segmentIndex,
+        trace.tracePath,
+      )
+
+      if (!movableSegment) continue
+
+      let bestCandidate: Segment | null = null
+      let bestOverlapLength = 0
+      let bestDistance = Infinity
+
+      for (
+        let candidateTraceIndex = 0;
+        candidateTraceIndex < traceIndex;
+        candidateTraceIndex++
+      ) {
+        const candidateTrace = outputTraces[candidateTraceIndex]!
+        if (candidateTrace.globalConnNetId !== trace.globalConnNetId) continue
+
+        for (
+          let candidateSegmentIndex = 0;
+          candidateSegmentIndex < candidateTrace.tracePath.length - 1;
+          candidateSegmentIndex++
+        ) {
+          const candidateSegment = getSegment(
+            candidateTraceIndex,
+            candidateSegmentIndex,
+            candidateTrace.tracePath,
+          )
+
+          if (!candidateSegment) continue
+          if (candidateSegment.axis !== movableSegment.axis) continue
+
+          const distance = Math.abs(
+            candidateSegment.fixedCoord - movableSegment.fixedCoord,
+          )
+          if (distance <= EPS || distance > maxAlignmentDistance) continue
+
+          const overlapLength = getOverlapLength(
+            movableSegment,
+            candidateSegment,
+          )
+          if (overlapLength <= EPS) continue
+
+          if (
+            overlapLength > bestOverlapLength ||
+            (Math.abs(overlapLength - bestOverlapLength) <= EPS &&
+              distance < bestDistance)
+          ) {
+            bestCandidate = candidateSegment
+            bestOverlapLength = overlapLength
+            bestDistance = distance
+          }
+        }
+      }
+
+      if (!bestCandidate) continue
+
+      const alignedPath = alignSegmentInPath({
+        path: trace.tracePath,
+        segment: movableSegment,
+        fixedCoord: bestCandidate.fixedCoord,
+      })
+
+      const alignedTrace = { ...trace, tracePath: alignedPath }
+
+      if (
+        canAlignPath({
+          trace: alignedTrace,
+          path: alignedPath,
+          traces: outputTraces,
+          inputProblem,
+          allLabelPlacements,
+          mergedLabelNetIdMap,
+          paddingBuffer,
+        })
+      ) {
+        outputTraces[traceIndex] = alignedTrace
+      }
+    }
+  }
+
+  return outputTraces
+}

--- a/site/TraceCleanupSolver/align-same-net-trace-segments.page.tsx
+++ b/site/TraceCleanupSolver/align-same-net-trace-segments.page.tsx
@@ -1,0 +1,38 @@
+import { type GraphicsObject, stackGraphicsHorizontally } from "graphics-debug"
+import { InteractiveGraphics } from "graphics-debug/react"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { alignSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/alignSameNetTraceSegments"
+import { useMemo } from "react"
+import inputData from "../../tests/assets/align-same-net-trace-segments.input.json"
+
+const traces = inputData.allTraces as unknown as SolvedTracePath[]
+
+const visualizeTraces = (
+  tracesToVisualize: SolvedTracePath[],
+): GraphicsObject => ({
+  lines: tracesToVisualize.map((trace) => ({
+    points: trace.tracePath,
+    strokeColor: "blue",
+  })),
+})
+
+export default () => {
+  const graphics = useMemo(() => {
+    const alignedTraces = alignSameNetTraceSegments({
+      traces,
+      inputProblem: inputData.inputProblem,
+      allLabelPlacements: [],
+      mergedLabelNetIdMap: {},
+      paddingBuffer: 0,
+    })
+
+    return stackGraphicsHorizontally(
+      [visualizeTraces(traces), visualizeTraces(alignedTraces)],
+      {
+        titles: ["Before: close parallel traces", "After: shared X/Y axes"],
+      },
+    )
+  }, [])
+
+  return <InteractiveGraphics graphics={graphics} />
+}

--- a/tests/assets/align-same-net-trace-segments.input.json
+++ b/tests/assets/align-same-net-trace-segments.input.json
@@ -1,0 +1,59 @@
+{
+  "inputProblem": {
+    "chips": [],
+    "directConnections": [],
+    "netConnections": [],
+    "availableNetLabelOrientations": {}
+  },
+  "allTraces": [
+    {
+      "mspPairId": "horizontal-anchor",
+      "dcConnNetId": "horizontal-net",
+      "globalConnNetId": "horizontal-net",
+      "tracePath": [{ "x": 0, "y": 0 }, { "x": 4, "y": 0 }],
+      "mspConnectionPairIds": ["horizontal-anchor"],
+      "pinIds": [],
+      "pins": []
+    },
+    {
+      "mspPairId": "horizontal-nearby",
+      "dcConnNetId": "horizontal-net",
+      "globalConnNetId": "horizontal-net",
+      "tracePath": [
+        { "x": 0.5, "y": 1 },
+        { "x": 0.5, "y": 0.05 },
+        { "x": 3.5, "y": 0.05 },
+        { "x": 3.5, "y": 1 }
+      ],
+      "mspConnectionPairIds": ["horizontal-nearby"],
+      "pinIds": [],
+      "pins": []
+    },
+    {
+      "mspPairId": "vertical-anchor",
+      "dcConnNetId": "vertical-net",
+      "globalConnNetId": "vertical-net",
+      "tracePath": [{ "x": 6, "y": 0 }, { "x": 6, "y": 4 }],
+      "mspConnectionPairIds": ["vertical-anchor"],
+      "pinIds": [],
+      "pins": []
+    },
+    {
+      "mspPairId": "vertical-nearby",
+      "dcConnNetId": "vertical-net",
+      "globalConnNetId": "vertical-net",
+      "tracePath": [
+        { "x": 7, "y": 0.5 },
+        { "x": 6.05, "y": 0.5 },
+        { "x": 6.05, "y": 3.5 },
+        { "x": 7, "y": 3.5 }
+      ],
+      "mspConnectionPairIds": ["vertical-nearby"],
+      "pinIds": [],
+      "pins": []
+    }
+  ],
+  "allLabelPlacements": [],
+  "mergedLabelNetIdMap": {},
+  "paddingBuffer": 0
+}

--- a/tests/functions/align-same-net-trace-segments.test.ts
+++ b/tests/functions/align-same-net-trace-segments.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { alignSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/alignSameNetTraceSegments"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const emptyInputProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+const createTrace = ({
+  mspPairId,
+  globalConnNetId,
+  tracePath,
+}: Pick<SolvedTracePath, "mspPairId" | "globalConnNetId" | "tracePath">) =>
+  ({
+    mspPairId,
+    globalConnNetId,
+    tracePath,
+    mspConnectionPairIds: [mspPairId],
+    pinIds: [],
+    pins: [],
+  }) as unknown as SolvedTracePath
+
+test("alignSameNetTraceSegments aligns close horizontal segments on the same net", () => {
+  const traces = [
+    createTrace({
+      mspPairId: "trace-a",
+      globalConnNetId: "net-a",
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 2, y: 0 },
+      ],
+    }),
+    createTrace({
+      mspPairId: "trace-b",
+      globalConnNetId: "net-a",
+      tracePath: [
+        { x: 0.5, y: 1 },
+        { x: 0.5, y: 0.04 },
+        { x: 1.5, y: 0.04 },
+        { x: 1.5, y: 1 },
+      ],
+    }),
+  ]
+
+  const aligned = alignSameNetTraceSegments({
+    traces,
+    inputProblem: emptyInputProblem,
+    allLabelPlacements: [],
+    mergedLabelNetIdMap: {},
+    paddingBuffer: 0,
+  })
+
+  expect(aligned[1]!.tracePath).toEqual([
+    { x: 0.5, y: 1 },
+    { x: 0.5, y: 0 },
+    { x: 1.5, y: 0 },
+    { x: 1.5, y: 1 },
+  ])
+})
+
+test("alignSameNetTraceSegments aligns close vertical segments on the same net", () => {
+  const traces = [
+    createTrace({
+      mspPairId: "trace-a",
+      globalConnNetId: "net-a",
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 0, y: 2 },
+      ],
+    }),
+    createTrace({
+      mspPairId: "trace-b",
+      globalConnNetId: "net-a",
+      tracePath: [
+        { x: 1, y: 0.5 },
+        { x: 0.04, y: 0.5 },
+        { x: 0.04, y: 1.5 },
+        { x: 1, y: 1.5 },
+      ],
+    }),
+  ]
+
+  const aligned = alignSameNetTraceSegments({
+    traces,
+    inputProblem: emptyInputProblem,
+    allLabelPlacements: [],
+    mergedLabelNetIdMap: {},
+    paddingBuffer: 0,
+  })
+
+  expect(aligned[1]!.tracePath).toEqual([
+    { x: 1, y: 0.5 },
+    { x: 0, y: 0.5 },
+    { x: 0, y: 1.5 },
+    { x: 1, y: 1.5 },
+  ])
+})
+
+test("alignSameNetTraceSegments does not align different nets", () => {
+  const traces = [
+    createTrace({
+      mspPairId: "trace-a",
+      globalConnNetId: "net-a",
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 2, y: 0 },
+      ],
+    }),
+    createTrace({
+      mspPairId: "trace-b",
+      globalConnNetId: "net-b",
+      tracePath: [
+        { x: 0.5, y: 1 },
+        { x: 0.5, y: 0.04 },
+        { x: 1.5, y: 0.04 },
+        { x: 1.5, y: 1 },
+      ],
+    }),
+  ]
+
+  const aligned = alignSameNetTraceSegments({
+    traces,
+    inputProblem: emptyInputProblem,
+    allLabelPlacements: [],
+    mergedLabelNetIdMap: {},
+    paddingBuffer: 0,
+  })
+
+  expect(aligned[1]!.tracePath).toEqual(traces[1]!.tracePath)
+})

--- a/tests/solvers/TraceCleanupSolver/__snapshots__/align-same-net-trace-segments.before-after.snap.svg
+++ b/tests/solvers/TraceCleanupSolver/__snapshots__/align-same-net-trace-segments.before-after.snap.svg
@@ -1,0 +1,84 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <polyline data-points="0,0 4,0" data-type="line" data-label="" points="40,398.1111111111111 182.22222222222223,398.1111111111111" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.5,1 0.5,0.05 3.5,0.05 3.5,1" data-type="line" data-label="" points="57.77777777777778,362.55555555555554 57.77777777777778,396.3333333333333 164.44444444444446,396.3333333333333 164.44444444444446,362.55555555555554" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="6,0 6,4" data-type="line" data-label="" points="253.33333333333334,398.1111111111111 253.33333333333334,255.88888888888886" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="7,0.5 6.05,0.5 6.05,3.5 7,3.5" data-type="line" data-label="" points="288.8888888888889,380.3333333333333 255.11111111111111,380.3333333333333 255.11111111111111,273.66666666666663 288.8888888888889,273.66666666666663" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="8.75,0 12.75,0" data-type="line" data-label="" points="351.11111111111114,398.1111111111111 493.33333333333337,398.1111111111111" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="9.25,1 9.25,0 12.25,0 12.25,1" data-type="line" data-label="" points="368.8888888888889,362.55555555555554 368.8888888888889,398.1111111111111 475.5555555555556,398.1111111111111 475.5555555555556,362.55555555555554" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="14.75,0 14.75,4" data-type="line" data-label="" points="564.4444444444445,398.1111111111111 564.4444444444445,255.88888888888886" fill="none" stroke="blue" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="15.75,0.5 14.75,0.5 14.75,3.5 15.75,3.5" data-type="line" data-label="" points="600,380.3333333333333 564.4444444444445,380.3333333333333 564.4444444444445,273.66666666666663 600,273.66666666666663" fill="none" stroke="blue" stroke-width="1" />
+  </g><text data-type="text" data-label="Before: close parallel traces" data-x="3.5" data-y="4.39375" x="164.44444444444446" y="241.88888888888886" fill="black" font-size="14.000000000000002" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Before: close parallel traces</text><text data-type="text" data-label="After: shared X/Y axes" data-x="12.25" data-y="4.39375" x="475.5555555555556" y="241.88888888888886" fill="black" font-size="14.000000000000002" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">After: shared X/Y axes</text>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 35.55555555555556,
+        "c": 0,
+        "e": 40,
+        "b": 0,
+        "d": -35.55555555555556,
+        "f": 398.1111111111111
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/solvers/TraceCleanupSolver/align-same-net-trace-segments.before-after.test.ts
+++ b/tests/solvers/TraceCleanupSolver/align-same-net-trace-segments.before-after.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import {
+  type GraphicsObject,
+  getSvgFromGraphicsObject,
+  stackGraphicsHorizontally,
+} from "graphics-debug"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { alignSameNetTraceSegments } from "lib/solvers/TraceCleanupSolver/alignSameNetTraceSegments"
+import inputData from "../../assets/align-same-net-trace-segments.input.json"
+
+const traces = inputData.allTraces as unknown as SolvedTracePath[]
+
+const visualizeTraces = (
+  tracesToVisualize: SolvedTracePath[],
+): GraphicsObject => ({
+  lines: tracesToVisualize.map((trace) => ({
+    points: trace.tracePath,
+    strokeColor: "blue",
+  })),
+})
+
+test("alignSameNetTraceSegments before and after", () => {
+  const alignedTraces = alignSameNetTraceSegments({
+    traces,
+    inputProblem: inputData.inputProblem,
+    allLabelPlacements: [],
+    mergedLabelNetIdMap: {},
+    paddingBuffer: 0,
+  })
+
+  expect(alignedTraces[1]!.tracePath).toEqual([
+    { x: 0.5, y: 1 },
+    { x: 0.5, y: 0 },
+    { x: 3.5, y: 0 },
+    { x: 3.5, y: 1 },
+  ])
+  expect(alignedTraces[3]!.tracePath).toEqual([
+    { x: 7, y: 0.5 },
+    { x: 6, y: 0.5 },
+    { x: 6, y: 3.5 },
+    { x: 7, y: 3.5 },
+  ])
+
+  const comparison = getSvgFromGraphicsObject(
+    stackGraphicsHorizontally(
+      [visualizeTraces(traces), visualizeTraces(alignedTraces)],
+      {
+        titles: ["Before: close parallel traces", "After: shared X/Y axes"],
+      },
+    ),
+    { backgroundColor: "white" },
+  )
+
+  expect(comparison).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
/claim #34

## Summary

- Add a cleanup pass that aligns close, overlapping same-net trace segments onto the same X/Y coordinate.
- Run that pass after turn minimization and Z-shape balancing in `TraceCleanupSolver`.
- Cover horizontal alignment, vertical alignment, and different-net non-alignment with focused tests.

## Why

Fixes tscircuit/schematic-trace-solver#34. Same-net traces that are already close should visually merge by sharing a coordinate instead of remaining as near-parallel lines.

## Validation

- `bun test`
- `bun run build`
- `bunx biome check --write lib\solvers\TraceCleanupSolver\alignSameNetTraceSegments.ts lib\solvers\TraceCleanupSolver\TraceCleanupSolver.ts tests\functions\align-same-net-trace-segments.test.ts`