### PR TITLE
feat: add getOutput() to SchematicTracePipelineSolver

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
 export * from "./solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 export * from "./types/InputProblem"
 export { SchematicTraceSingleLineSolver2 } from "./solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+export type { SolvedTracePath } from "./solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+export type { NetLabelPlacement } from "./solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -12,7 +12,7 @@ import {
   type SolvedTracePath,
 } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
-import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { NetLabelPlacementSolver, type NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
 import { visualizeInputProblem } from "./visualizeInputProblem"
 import { TraceLabelOverlapAvoidanceSolver } from "../TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver"
@@ -436,6 +436,51 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     }
     colorAvailableNetOrientationLabels(finalGraphics, this.inputProblem)
     return finalGraphics
+  }
+
+  /**
+   * Returns the final output of the pipeline after solving.
+   *
+   * The output contains the fully-routed traces (after label-collision
+   * rerouting) and the final net-label placements (after label–label
+   * collision resolution).
+   *
+   * The method walks backwards through the pipeline stages so that it
+   * works even if intermediate stages were skipped or haven't been reached
+   * yet (in which case earlier stages supply the data).
+   */
+  getOutput(): {
+    traces: SolvedTracePath[]
+    netLabelPlacements: NetLabelPlacement[]
+  } {
+    // Traces: the last solver that modifies traces is NetLabelTraceCollisionSolver.
+    // Fall back through earlier stages if later ones haven't run.
+    const traces: SolvedTracePath[] =
+      this.netLabelTraceCollisionSolver?.getOutput().traces ??
+      this.availableNetOrientationSolver?.traces ??
+      this.example28Solver?.outputTraces ??
+      this.traceCleanupSolver?.getOutput().traces ??
+      this.traceLabelOverlapAvoidanceSolver?.getOutput().traces ??
+      (this.traceOverlapShiftSolver?.correctedTraceMap
+        ? Object.values(this.traceOverlapShiftSolver.correctedTraceMap)
+        : undefined) ??
+      this.longDistancePairSolver?.getOutput().allTracesMerged ??
+      this.schematicTraceLinesSolver?.solvedTracePaths ??
+      []
+
+    // Net label placements: the last solver that modifies placements is
+    // NetLabelNetLabelCollisionSolver.
+    const netLabelPlacements: NetLabelPlacement[] =
+      this.netLabelNetLabelCollisionSolver?.getOutput().netLabelPlacements ??
+      this.netLabelTraceCollisionSolver?.getOutput().netLabelPlacements ??
+      this.traceAnchoredNetLabelOverlapSolver?.outputNetLabelPlacements ??
+      this.vccNetLabelCornerPlacementSolver?.outputNetLabelPlacements ??
+      this.availableNetOrientationSolver?.outputNetLabelPlacements ??
+      this.example28Solver?.outputNetLabelPlacements ??
+      this.netLabelPlacementSolver?.netLabelPlacements ??
+      []
+
+    return { traces, netLabelPlacements }
   }
 
   /**

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -12,7 +12,10 @@ import {
   type SolvedTracePath,
 } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
-import { NetLabelPlacementSolver, type NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import {
+  NetLabelPlacementSolver,
+  type NetLabelPlacement,
+} from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
 import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
 import { visualizeInputProblem } from "./visualizeInputProblem"
 import { TraceLabelOverlapAvoidanceSolver } from "../TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver"

--- a/tests/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver_getOutput.test.ts
+++ b/tests/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver_getOutput.test.ts
@@ -1,0 +1,167 @@
+import type { InputProblem } from "lib/types/InputProblem"
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/index"
+
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "U1",
+      center: { x: 0, y: 0 },
+      width: 1.6,
+      height: 0.6,
+      pins: [
+        {
+          pinId: "U1.1",
+          x: -0.8,
+          y: 0.2,
+        },
+        {
+          pinId: "U1.2",
+          x: -0.8,
+          y: 0,
+        },
+        {
+          pinId: "U1.3",
+          x: -0.8,
+          y: -0.2,
+        },
+        {
+          pinId: "U1.4",
+          x: 0.8,
+          y: -0.2,
+        },
+        {
+          pinId: "U1.5",
+          x: 0.8,
+          y: 0,
+        },
+        {
+          pinId: "U1.6",
+          x: 0.8,
+          y: 0.2,
+        },
+      ],
+    },
+    {
+      chipId: "C1",
+      center: { x: -2, y: 0 },
+      width: 0.5,
+      height: 1,
+      pins: [
+        {
+          pinId: "C1.1",
+          x: -2,
+          y: 0.5,
+        },
+        {
+          pinId: "C1.2",
+          x: -2,
+          y: -0.5,
+        },
+      ],
+    },
+    {
+      chipId: "C2",
+      center: { x: -4, y: 0 },
+      width: 0.5,
+      height: 1,
+      pins: [
+        {
+          pinId: "C2.1",
+          x: -4,
+          y: 0.5,
+        },
+        {
+          pinId: "C2.2",
+          x: -4,
+          y: -0.5,
+        },
+      ],
+    },
+  ],
+  directConnections: [
+    {
+      pinIds: ["U1.1", "C1.1"],
+      netId: "VCC",
+    },
+    {
+      pinIds: ["U1.2", "C2.1"],
+      netId: "EN",
+    },
+  ],
+  netConnections: [
+    {
+      pinIds: ["U1.3", "C2.2", "C1.2"],
+      netId: "GND",
+    },
+  ],
+  availableNetLabelOrientations: {
+    VCC: ["y+"],
+    EN: ["x+", "x-"],
+    GND: ["y-"],
+  },
+  maxMspPairDistance: 2,
+}
+
+test("SchematicTracePipelineSolver.getOutput() returns traces and netLabelPlacements", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+
+  const output = solver.getOutput()
+
+  // Should have the output shape
+  expect(output).toHaveProperty("traces")
+  expect(output).toHaveProperty("netLabelPlacements")
+
+  // traces should be an array of SolvedTracePath
+  expect(Array.isArray(output.traces)).toBe(true)
+  expect(output.traces.length).toBeGreaterThan(0)
+
+  // Each trace should have the expected properties
+  for (const trace of output.traces) {
+    expect(trace).toHaveProperty("tracePath")
+    expect(trace).toHaveProperty("mspPairId")
+    expect(Array.isArray(trace.tracePath)).toBe(true)
+    expect(trace.tracePath.length).toBeGreaterThanOrEqual(2)
+  }
+
+  // netLabelPlacements should be an array of NetLabelPlacement
+  expect(Array.isArray(output.netLabelPlacements)).toBe(true)
+  expect(output.netLabelPlacements.length).toBeGreaterThan(0)
+
+  // Each placement should have the expected properties
+  for (const placement of output.netLabelPlacements) {
+    expect(placement).toHaveProperty("globalConnNetId")
+    expect(placement).toHaveProperty("orientation")
+    expect(placement).toHaveProperty("anchorPoint")
+    expect(placement).toHaveProperty("center")
+    expect(placement).toHaveProperty("width")
+    expect(placement).toHaveProperty("height")
+    expect(typeof placement.width).toBe("number")
+    expect(typeof placement.height).toBe("number")
+    expect(placement.center).toHaveProperty("x")
+    expect(placement.center).toHaveProperty("y")
+  }
+})
+
+test("SchematicTracePipelineSolver.getOutput() matches final sub-solver outputs", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  solver.solve()
+
+  const output = solver.getOutput()
+
+  // Traces should match the netLabelTraceCollisionSolver output
+  if (solver.netLabelTraceCollisionSolver) {
+    const directTraces = solver.netLabelTraceCollisionSolver.getOutput().traces
+    expect(output.traces).toEqual(directTraces)
+  }
+
+  // Net label placements should match the netLabelNetLabelCollisionSolver output
+  if (solver.netLabelNetLabelCollisionSolver) {
+    const directPlacements =
+      solver.netLabelNetLabelCollisionSolver.getOutput().netLabelPlacements
+    expect(output.netLabelPlacements).toEqual(directPlacements)
+  }
+})


### PR DESCRIPTION
## Summary

Adds a `getOutput()` method to `SchematicTracePipelineSolver` that returns the final pipeline output after solving.

/claim #38 
## Changes

- **`SchematicTracePipelineSolver.ts`**: Added `getOutput()` method returning `{ traces: SolvedTracePath[], netLabelPlacements: NetLabelPlacement[] }`
-   - Uses a fallback chain through pipeline stages (latest -> earliest) so it works even if intermediate stages were skipped
-   - Traces come from `NetLabelTraceCollisionSolver` (last stage modifying traces)
-   - NetLabelPlacements come from `NetLabelNetLabelCollisionSolver` (very last stage)
- - **`lib/index.ts`**: Exported `SolvedTracePath` and `NetLabelPlacement` types for consumers
- - **New test**: `SchematicTracePipelineSolver_getOutput.test.ts` with 2 test cases:
-   1. Validates output structure (traces array + netLabelPlacements array with correct properties)
-   2. Verifies consistency with direct sub-solver outputs
## Test Results

All 5 tests pass (3 existing + 2 new):
```
5 pass, 0 fail, 66 expect() calls
```
