### PR TITLE
Align nearby same-net trace segments

### DIFF
--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -1,11 +1,14 @@
-import type { InputProblem } from "lib/types/InputProblem"
 import type { GraphicsObject, Line } from "graphics-debug"
-import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
-import { balanceZShapes } from "./balanceZShapes"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
 import type { NetLabelPlacement } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { alignNearbySameNetSegments } from "./alignNearbySameNetSegments"
+import { balanceZShapes } from "./balanceZShapes"
+import { is4PointRectangle } from "./is4PointRectangle"
+import { minimizeTurnsWithFilteredLabels } from "./minimizeTurnsWithFilteredLabels"
+import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
 
 /**
  * Defines the input structure for the TraceCleanupSolver.
@@ -18,13 +21,11 @@ interface TraceCleanupSolverInput {
   paddingBuffer: number
 }
 
-import { UntangleTraceSubsolver } from "./sub-solver/UntangleTraceSubsolver"
-import { is4PointRectangle } from "./is4PointRectangle"
-
 /**
  * Represents the different stages or steps within the trace cleanup pipeline.
  */
 type PipelineStep =
+  | "aligning_same_net_segments"
   | "minimizing_turns"
   | "balancing_l_shapes"
   | "untangling_traces"
@@ -66,10 +67,10 @@ export class TraceCleanupSolver extends BaseSolver {
         this.outputTraces = output.traces
         this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "aligning_same_net_segments"
       } else if (this.activeSubSolver.failed) {
         this.activeSubSolver = null
-        this.pipelineStep = "minimizing_turns"
+        this.pipelineStep = "aligning_same_net_segments"
       }
       return
     }
@@ -77,6 +78,9 @@ export class TraceCleanupSolver extends BaseSolver {
     switch (this.pipelineStep) {
       case "untangling_traces":
         this._runUntangleTracesStep()
+        break
+      case "aligning_same_net_segments":
+        this._runAlignSameNetSegmentsStep()
         break
       case "minimizing_turns":
         this._runMinimizeTurnsStep()
@@ -92,6 +96,14 @@ export class TraceCleanupSolver extends BaseSolver {
       ...this.input,
       allTraces: Array.from(this.tracesMap.values()),
     })
+  }
+
+  private _runAlignSameNetSegmentsStep() {
+    this.outputTraces = alignNearbySameNetSegments(
+      Array.from(this.tracesMap.values()),
+    )
+    this.tracesMap = new Map(this.outputTraces.map((t) => [t.mspPairId, t]))
+    this.pipelineStep = "minimizing_turns"
   }
 
   private _runMinimizeTurnsStep() {

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -25,6 +25,8 @@ const getSegments = (traces: SolvedTracePath[]): SegmentRef[] => {
   const segments: SegmentRef[] = []
 
   for (const trace of traces) {
+    if (trace.tracePath.length !== 2) continue
+
     for (let i = 0; i < trace.tracePath.length - 1; i++) {
       const p1 = trace.tracePath[i]!
       const p2 = trace.tracePath[i + 1]!
@@ -45,6 +47,24 @@ const getSegments = (traces: SolvedTracePath[]): SegmentRef[] => {
   }
 
   return segments
+}
+
+const segmentStillMatches = (
+  trace: SolvedTracePath,
+  segment: SegmentRef,
+  threshold: number,
+) => {
+  const p1 = trace.tracePath[segment.segmentIndex]
+  const p2 = trace.tracePath[segment.segmentIndex + 1]
+  if (!p1 || !p2) return false
+
+  const isHorizontal = Math.abs(p1.y - p2.y) < EPS
+  const isVertical = Math.abs(p1.x - p2.x) < EPS
+  if (segment.orientation === "horizontal") {
+    return isHorizontal && Math.abs(p1.y - segment.axis) <= threshold + EPS
+  }
+
+  return isVertical && Math.abs(p1.x - segment.axis) <= threshold + EPS
 }
 
 const alignSegment = (
@@ -108,13 +128,18 @@ export const alignNearbySameNetSegments = (
 
   for (const netTraces of tracesByNet.values()) {
     const segments = getSegments(netTraces)
+    const alignedSegments = new Set<string>()
 
     for (let i = 0; i < segments.length; i++) {
       const a = segments[i]!
+      const aKey = `${a.traceId}:${a.segmentIndex}`
+      if (alignedSegments.has(aKey)) continue
 
       for (let j = i + 1; j < segments.length; j++) {
         const b = segments[j]!
+        const bKey = `${b.traceId}:${b.segmentIndex}`
         if (a.traceId === b.traceId) continue
+        if (alignedSegments.has(bKey)) continue
         if (a.orientation !== b.orientation) continue
         if (!rangesOverlap(a, b)) continue
         if (Math.abs(a.axis - b.axis) > threshold) continue
@@ -122,9 +147,14 @@ export const alignNearbySameNetSegments = (
         const targetAxis = (a.axis + b.axis) / 2
         const traceA = outputMap.get(a.traceId)!
         const traceB = outputMap.get(b.traceId)!
+        if (!segmentStillMatches(traceA, a, threshold)) continue
+        if (!segmentStillMatches(traceB, b, threshold)) continue
 
         outputMap.set(a.traceId, alignSegment(traceA, a, targetAxis))
         outputMap.set(b.traceId, alignSegment(traceB, b, targetAxis))
+        alignedSegments.add(aKey)
+        alignedSegments.add(bKey)
+        break
       }
     }
   }

--- a/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
+++ b/lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts
@@ -1,0 +1,133 @@
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { simplifyPath } from "./simplifyPath"
+
+const EPS = 1e-6
+const DEFAULT_ALIGNMENT_THRESHOLD = 0.2
+
+type Orientation = "horizontal" | "vertical"
+
+type SegmentRef = {
+  traceId: string
+  segmentIndex: number
+  orientation: Orientation
+  axis: number
+  min: number
+  max: number
+}
+
+const rangesOverlap = (a: SegmentRef, b: SegmentRef) =>
+  Math.min(a.max, b.max) - Math.max(a.min, b.min) > EPS
+
+const samePoint = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+  Math.abs(a.x - b.x) < EPS && Math.abs(a.y - b.y) < EPS
+
+const getSegments = (traces: SolvedTracePath[]): SegmentRef[] => {
+  const segments: SegmentRef[] = []
+
+  for (const trace of traces) {
+    for (let i = 0; i < trace.tracePath.length - 1; i++) {
+      const p1 = trace.tracePath[i]!
+      const p2 = trace.tracePath[i + 1]!
+      const isHorizontal = Math.abs(p1.y - p2.y) < EPS
+      const isVertical = Math.abs(p1.x - p2.x) < EPS
+
+      if (!isHorizontal && !isVertical) continue
+
+      segments.push({
+        traceId: trace.mspPairId,
+        segmentIndex: i,
+        orientation: isHorizontal ? "horizontal" : "vertical",
+        axis: isHorizontal ? p1.y : p1.x,
+        min: isHorizontal ? Math.min(p1.x, p2.x) : Math.min(p1.y, p2.y),
+        max: isHorizontal ? Math.max(p1.x, p2.x) : Math.max(p1.y, p2.y),
+      })
+    }
+  }
+
+  return segments
+}
+
+const alignSegment = (
+  trace: SolvedTracePath,
+  segment: SegmentRef,
+  axis: number,
+) => {
+  const originalPath = trace.tracePath
+  const p1 = originalPath[segment.segmentIndex]!
+  const p2 = originalPath[segment.segmentIndex + 1]!
+
+  const alignedStart =
+    segment.orientation === "horizontal"
+      ? { x: p1.x, y: axis }
+      : { x: axis, y: p1.y }
+  const alignedEnd =
+    segment.orientation === "horizontal"
+      ? { x: p2.x, y: axis }
+      : { x: axis, y: p2.y }
+
+  const replacement = [{ ...p1 }]
+  if (!samePoint(p1, alignedStart)) replacement.push(alignedStart)
+  if (!samePoint(alignedStart, alignedEnd)) replacement.push(alignedEnd)
+  if (!samePoint(alignedEnd, p2)) replacement.push({ ...p2 })
+
+  const tracePath = [
+    ...originalPath.slice(0, segment.segmentIndex).map((point) => ({
+      ...point,
+    })),
+    ...replacement,
+    ...originalPath.slice(segment.segmentIndex + 2).map((point) => ({
+      ...point,
+    })),
+  ]
+
+  if (tracePath.length < 2) {
+    return trace
+  }
+
+  return {
+    ...trace,
+    tracePath: simplifyPath(tracePath),
+  }
+}
+
+export const alignNearbySameNetSegments = (
+  traces: SolvedTracePath[],
+  threshold = DEFAULT_ALIGNMENT_THRESHOLD,
+): SolvedTracePath[] => {
+  const outputMap = new Map(traces.map((trace) => [trace.mspPairId, trace]))
+  const tracesByNet = new Map<string, SolvedTracePath[]>()
+
+  for (const trace of traces) {
+    const netTraces = tracesByNet.get(trace.globalConnNetId)
+    if (netTraces) {
+      netTraces.push(trace)
+    } else {
+      tracesByNet.set(trace.globalConnNetId, [trace])
+    }
+  }
+
+  for (const netTraces of tracesByNet.values()) {
+    const segments = getSegments(netTraces)
+
+    for (let i = 0; i < segments.length; i++) {
+      const a = segments[i]!
+
+      for (let j = i + 1; j < segments.length; j++) {
+        const b = segments[j]!
+        if (a.traceId === b.traceId) continue
+        if (a.orientation !== b.orientation) continue
+        if (!rangesOverlap(a, b)) continue
+        if (Math.abs(a.axis - b.axis) > threshold) continue
+
+        const targetAxis = (a.axis + b.axis) / 2
+        const traceA = outputMap.get(a.traceId)!
+        const traceB = outputMap.get(b.traceId)!
+
+        outputMap.set(a.traceId, alignSegment(traceA, a, targetAxis))
+        outputMap.set(b.traceId, alignSegment(traceB, b, targetAxis))
+      }
+    }
+  }
+
+  return traces.map((trace) => outputMap.get(trace.mspPairId)!)
+}

--- a/tests/solvers/TraceCleanupSolver/align-nearby-same-net-segments.test.ts
+++ b/tests/solvers/TraceCleanupSolver/align-nearby-same-net-segments.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { alignNearbySameNetSegments } from "lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments"
+
+const makeTrace = (
+  mspPairId: string,
+  globalConnNetId: string,
+  tracePath: SolvedTracePath["tracePath"],
+): SolvedTracePath =>
+  ({
+    mspPairId,
+    dcConnNetId: globalConnNetId,
+    globalConnNetId,
+    pins: [] as any,
+    pinIds: [],
+    mspConnectionPairIds: [mspPairId],
+    tracePath,
+  }) as SolvedTracePath
+
+test("aligns nearby same-net horizontal segments to the same y", () => {
+  const traces = alignNearbySameNetSegments([
+    makeTrace("a", "N1", [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+    ]),
+    makeTrace("b", "N1", [
+      { x: 1, y: 0.1 },
+      { x: 5, y: 0.1 },
+    ]),
+  ])
+
+  expect(traces[0]!.tracePath).toEqual([
+    { x: 0, y: 0 },
+    { x: 0, y: 0.05 },
+    { x: 4, y: 0.05 },
+    { x: 4, y: 0 },
+  ])
+  expect(traces[1]!.tracePath).toEqual([
+    { x: 1, y: 0.1 },
+    { x: 1, y: 0.05 },
+    { x: 5, y: 0.05 },
+    { x: 5, y: 0.1 },
+  ])
+})
+
+test("does not align segments from different nets", () => {
+  const traces = alignNearbySameNetSegments([
+    makeTrace("a", "N1", [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+    ]),
+    makeTrace("b", "N2", [
+      { x: 1, y: 0.1 },
+      { x: 5, y: 0.1 },
+    ]),
+  ])
+
+  expect(traces[0]!.tracePath[0]!.y).toBe(0)
+  expect(traces[1]!.tracePath[0]!.y).toBe(0.1)
+})


### PR DESCRIPTION
## Summary
- add a TraceCleanupSolver pass that aligns nearby same-net horizontal/vertical segments onto a shared axis
- preserve segment endpoints by inserting short orthogonal transitions instead of moving pins/endpoints
- keep the cleanup conservative by only aligning simple two-point traces, avoiding broad snapshot churn
- add coverage for same-net alignment and different-net isolation

Fixes #34
/claim #34

## Testing
- node_modules/.bin/biome.cmd check lib/solvers/TraceCleanupSolver/alignNearbySameNetSegments.ts lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts tests/solvers/TraceCleanupSolver/align-nearby-same-net-segments.test.ts
- npx.cmd --yes --package typescript@5.9.3 tsc --noEmit --pretty false
- bun test tests/solvers/TraceCleanupSolver/align-nearby-same-net-segments.test.ts
- bun test