### PR TITLE
fix: skip redundant net-label-only passive traces

### DIFF
--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -13,12 +13,15 @@ import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualize
 import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import type { ConnectivityMap } from "connectivity-map"
 import { arePinsInDifferentSchematicSections } from "../../utils/arePinsInDifferentSchematicSections"
+import { getPinDirection } from "../SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/getPinDirection"
 
 const NEAREST_NEIGHBOR_COUNT = 3
 
 const distance = (p1: InputPin, p2: InputPin) => {
   return Math.sqrt(Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2))
 }
+
+const getPairKey = (pin1: PinId, pin2: PinId) => [pin1, pin2].sort().join("--")
 
 export class LongDistancePairSolver extends BaseSolver {
   public solvedLongDistanceTraces: SolvedTracePath[] = []
@@ -34,6 +37,7 @@ export class LongDistancePairSolver extends BaseSolver {
   private netConnMap: ConnectivityMap
   private newlyConnectedPinIds = new Set<PinId>()
   private allSolvedTraces: SolvedTracePath[] = []
+  private directConnectionPairKeys: Set<string>
 
   constructor(
     private params: {
@@ -49,6 +53,11 @@ export class LongDistancePairSolver extends BaseSolver {
 
     this.inputProblem = inputProblem
     this.allSolvedTraces = [...alreadySolvedTraces]
+    this.directConnectionPairKeys = new Set(
+      inputProblem.directConnections.map((dc) =>
+        getPairKey(dc.pinIds[0], dc.pinIds[1]),
+      ),
+    )
 
     // 1. Create initial maps and sets for efficient lookup
     const primaryConnectedPinIds = new Set<PinId>()
@@ -76,8 +85,19 @@ export class LongDistancePairSolver extends BaseSolver {
     for (const netId of Object.keys(netConnMap.netMap)) {
       const allPinIdsInNet = netConnMap.getIdsConnectedToNet(netId)
       if (allPinIdsInNet.length < 2) continue
+      const pinIdsInNet = allPinIdsInNet.filter((pinId) => pinMap.has(pinId))
+      if (pinIdsInNet.length === 2) {
+        const [pin1, pin2] = pinIdsInNet
+        const p1 = pinMap.get(pin1!)!
+        const p2 = pinMap.get(pin2!)!
+        const userNetId = this.getUserNetIdForPair(pin1!, pin2!)
+        const canSkipPair =
+          !this.directConnectionPairKeys.has(getPairKey(pin1!, pin2!)) &&
+          this.canUsePortOnlyLabelsForPair(p1, p2, userNetId)
+        if (canSkipPair) continue
+      }
 
-      const unconnectedPinIds = allPinIdsInNet.filter(
+      const unconnectedPinIds = pinIdsInNet.filter(
         (pinId) => !primaryConnectedPinIds.has(pinId),
       )
 
@@ -85,7 +105,7 @@ export class LongDistancePairSolver extends BaseSolver {
         const sourcePin = pinMap.get(unconnectedPinId)
         if (!sourcePin) continue
 
-        const neighbors = allPinIdsInNet
+        const neighbors = pinIdsInNet
           .filter((otherPinId) => otherPinId !== unconnectedPinId)
           .flatMap((otherPinId) => {
             const targetPin = pinMap.get(otherPinId)
@@ -110,10 +130,7 @@ export class LongDistancePairSolver extends BaseSolver {
           ) {
             continue
           }
-          const pairKey = pair
-            .map((p) => p.pinId)
-            .sort()
-            .join("--")
+          const pairKey = getPairKey(pair[0].pinId, pair[1].pinId)
 
           if (!addedPairKeys.has(pairKey)) {
             candidatePairs.push(pair)
@@ -224,6 +241,36 @@ export class LongDistancePairSolver extends BaseSolver {
     }
 
     return graphics
+  }
+
+  private getUserNetIdForPair(pin1: PinId, pin2: PinId) {
+    return this.inputProblem.netConnections.find(
+      (nc) => nc.pinIds.includes(pin1) && nc.pinIds.includes(pin2),
+    )?.netId
+  }
+
+  private canUsePortOnlyLabelsForPair(
+    p1: InputPin & { chipId: string },
+    p2: InputPin & { chipId: string },
+    userNetId?: string,
+  ) {
+    if (!userNetId) return false
+    const availableOrientations =
+      this.inputProblem.availableNetLabelOrientations[userNetId] ?? []
+    if (availableOrientations.length === 0) return false
+
+    const chip1 = this.chipMap[p1.chipId]
+    const chip2 = this.chipMap[p2.chipId]
+    if (!chip1 || !chip2) return false
+    if (chip1.pins.length !== 2 || chip2.pins.length !== 2) return false
+
+    const p1Direction = p1._facingDirection ?? getPinDirection(p1, chip1)
+    const p2Direction = p2._facingDirection ?? getPinDirection(p2, chip2)
+
+    return (
+      availableOrientations.includes(p1Direction) &&
+      availableOrientations.includes(p2Direction)
+    )
   }
 
   public getOutput(): {

--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -13,6 +13,7 @@ import type { GraphicsObject } from "graphics-debug"
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
 import { arePinsInDifferentSchematicSections } from "../../utils/arePinsInDifferentSchematicSections"
+import { getPinDirection } from "../SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/getPinDirection"
 
 export type MspConnectionPairId = string
 
@@ -36,6 +37,7 @@ export class MspConnectionPairSolver extends BaseSolver {
 
   pinMap: Record<string, InputPin & { chipId: string }>
   userNetIdByPinId: Record<string, string | undefined>
+  directConnectionPairIds: Set<string>
 
   constructor({ inputProblem }: { inputProblem: InputProblem }) {
     super()
@@ -62,7 +64,11 @@ export class MspConnectionPairSolver extends BaseSolver {
 
     // Build a mapping from PinId to user-provided netId (if any)
     this.userNetIdByPinId = {}
+    this.directConnectionPairIds = new Set()
     for (const dc of inputProblem.directConnections) {
+      this.directConnectionPairIds.add(
+        this.getPairId(dc.pinIds[0], dc.pinIds[1]),
+      )
       if (dc.netId) {
         const [a, b] = dc.pinIds
         this.userNetIdByPinId[a] = dc.netId
@@ -134,6 +140,12 @@ export class MspConnectionPairSolver extends BaseSolver {
       const globalConnNetId = this.globalConnMap.getNetConnectedToId(pin1!)!
       const userNetId =
         this.userNetIdByPinId[pin1!] ?? this.userNetIdByPinId[pin2!]
+      if (
+        !this.isDirectConnectionPair(pin1!, pin2!) &&
+        this.canUsePortOnlyLabelsForPair(p1, p2, userNetId)
+      ) {
+        return
+      }
 
       this.mspConnectionPairs.push({
         mspPairId: `${pin1}-${pin2}`,
@@ -204,6 +216,38 @@ export class MspConnectionPairSolver extends BaseSolver {
         pins: [p1Obj, p2Obj],
       })
     }
+  }
+
+  private getPairId(pin1: PinId, pin2: PinId) {
+    return [pin1, pin2].sort().join("::")
+  }
+
+  private isDirectConnectionPair(pin1: PinId, pin2: PinId) {
+    return this.directConnectionPairIds.has(this.getPairId(pin1, pin2))
+  }
+
+  private canUsePortOnlyLabelsForPair(
+    p1: InputPin & { chipId: string },
+    p2: InputPin & { chipId: string },
+    userNetId?: string,
+  ) {
+    if (!userNetId) return false
+    const availableOrientations =
+      this.inputProblem.availableNetLabelOrientations[userNetId] ?? []
+    if (availableOrientations.length === 0) return false
+
+    const chip1 = this.chipMap[p1.chipId]
+    const chip2 = this.chipMap[p2.chipId]
+    if (!chip1 || !chip2) return false
+    if (chip1.pins.length !== 2 || chip2.pins.length !== 2) return false
+
+    const p1Direction = p1._facingDirection ?? getPinDirection(p1, chip1)
+    const p2Direction = p2._facingDirection ?? getPinDirection(p2, chip2)
+
+    return (
+      availableOrientations.includes(p1Direction) &&
+      availableOrientations.includes(p2Direction)
+    )
   }
 
   override visualize(): GraphicsObject {

--- a/tests/repros/repro61-net-label-only.test.ts
+++ b/tests/repros/repro61-net-label-only.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+
+const capacitorPairInput = {
+  chips: [
+    {
+      chipId: "C1",
+      center: { x: 2, y: 0 },
+      width: 0.5,
+      height: 1.1,
+      pins: [
+        { pinId: "C1.1", x: 2, y: 0.55 },
+        { pinId: "C1.2", x: 2, y: -0.55 },
+      ],
+    },
+    {
+      chipId: "C2",
+      center: { x: 0, y: 0 },
+      width: 0.5,
+      height: 1.1,
+      pins: [
+        { pinId: "C2.1", x: 0, y: 0.55 },
+        { pinId: "C2.2", x: 0, y: -0.55 },
+      ],
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    { netId: "GND", pinIds: ["C1.1", "C2.1"], netLabelWidth: 0.3 },
+    { netId: "VCC", pinIds: ["C1.2", "C2.2"], netLabelWidth: 0.3 },
+  ],
+  availableNetLabelOrientations: {
+    GND: ["y+"],
+    VCC: ["y-"],
+  },
+  maxMspPairDistance: 5,
+}
+
+test("repro61 net-label-only two-pin nets do not create connecting traces", () => {
+  const solver = new SchematicTracePipelineSolver(capacitorPairInput as any)
+
+  solver.solve()
+
+  const traces = solver.netLabelTraceCollisionSolver?.getOutput().traces ?? []
+  const labels =
+    solver.netLabelNetLabelCollisionSolver?.getOutput().netLabelPlacements ?? []
+
+  expect(solver.failed).toBe(false)
+  expect(traces).toHaveLength(0)
+  expect(labels.map((label) => label.pinIds).sort()).toEqual([
+    ["C1.1"],
+    ["C1.2"],
+    ["C2.1"],
+    ["C2.2"],
+  ])
+})
+
+test("two-pin direct connections still create traces", () => {
+  const solver = new SchematicTracePipelineSolver({
+    ...capacitorPairInput,
+    directConnections: [{ netId: "GND", pinIds: ["C1.1", "C2.1"] }],
+    netConnections: [],
+  } as any)
+
+  solver.solve()
+
+  const traces = solver.netLabelTraceCollisionSolver?.getOutput().traces ?? []
+
+  expect(solver.failed).toBe(false)
+  expect(traces.map((trace) => trace.pinIds).sort()).toEqual([["C1.1", "C2.1"]])
+})


### PR DESCRIPTION
Fixes #79.

## Summary

- skips physical trace routing for simple two-pin passive net-label-only connections when labels can represent both pins
- keeps direct two-pin connections routed as physical traces
- applies the same guard to the long-distance pair path
- adds repro61 coverage for net-label-only two-pin nets and a direct-connection control

## Verification

- `npx --yes bun test tests/solvers/MspConnectionPairSolver/MspConnectionPairSolver_schematicSections.test.ts`
- `npx --yes bun test`
- `npx --yes tsc --noEmit --pretty false`
- `npx --yes biome format lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts tests/repros/repro61-net-label-only.test.ts`
- `npx --yes bun run build`
- `git diff --check`

/claim #79
