### PR TITLE
add spec for adding textBoxes to the InputProblem

### DIFF
--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -1,3 +1,4 @@
+import type { Box } from "@tscircuit/math-utils"
 import type { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
 import type { FacingDirection } from "lib/utils/dir"
 
@@ -38,6 +39,7 @@ export interface InputProblem {
   chips: Array<InputChip>
   directConnections: Array<InputDirectConnection>
   netConnections: Array<InputNetConnection>
+  obstacles?: Array<Box>
 
   availableNetLabelOrientations: Record<NetId, FacingDirection[]>
   maxMspPairDistance?: number

--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -15,11 +15,11 @@ export interface InputPin {
 }
 
 export interface TextBoxes {
-  chipId: ChipId
+  chipId?: ChipId
   center: { x: number; y: number }
   width: number
   height: number
-  text: string
+  text?: string
 }
 
 export interface InputChip {

--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -1,4 +1,3 @@
-import type { Box } from "@tscircuit/math-utils"
 import type { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
 import type { FacingDirection } from "lib/utils/dir"
 
@@ -14,6 +13,15 @@ export interface InputPin {
 
   _facingDirection?: "x+" | "x-" | "y+" | "y-"
 }
+
+export interface TextBoxes {
+  chipId: ChipId
+  center: { x: number; y: number }
+  width: number
+  height: number
+  text: string
+}
+
 export interface InputChip {
   chipId: ChipId
   center: { x: number; y: number }
@@ -39,7 +47,7 @@ export interface InputProblem {
   chips: Array<InputChip>
   directConnections: Array<InputDirectConnection>
   netConnections: Array<InputNetConnection>
-  obstacles?: Array<Box>
+  textBoxes?: Array<TextBoxes>
 
   availableNetLabelOrientations: Record<NetId, FacingDirection[]>
   maxMspPairDistance?: number


### PR DESCRIPTION
### Add spec for obstacles:

### What are obstacle?
- Schematic Components have text around them which is not passed to the schematic trace solver, which means the solver doesn't know that they exist, and the traces can go through the texts which make them unreadable.

### Why this?

- We can pass the text bounds as an ```Obstacle``` which will prevent the collisions from happening.

Repro:
<img width="82" height="92" alt="Screenshot 2026-06-29 at 11 39 27 PM" src="https://github.com/user-attachments/assets/d8764e52-51cd-49c1-abfa-cc428cb47f11" />
