### PR TITLE
fix: align close same-net trace segments

### DIFF
--- a/lib/solvers/SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver.ts
+++ b/lib/solvers/SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver.ts
@@ -1,0 +1,230 @@
+import type { GraphicsObject, Line, Point } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { simplifyPath } from "../TraceCleanupSolver/simplifyPath"
+
+type SegmentOrientation = "horizontal" | "vertical"
+
+type TraceSegment = {
+  traceIndex: number
+  segmentIndex: number
+  orientation: SegmentOrientation
+  coord: number
+  spanStart: number
+  spanEnd: number
+  length: number
+  netId: string
+}
+
+interface SameNetTraceAlignmentSolverInput {
+  inputProblem: InputProblem
+  traces: SolvedTracePath[]
+  alignmentThreshold?: number
+}
+
+function median(values: number[]) {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) return sorted[mid]!
+  return (sorted[mid - 1]! + sorted[mid]!) / 2
+}
+
+function getOrientation(a: Point, b: Point): SegmentOrientation | null {
+  if (Math.abs(a.y - b.y) < 1e-6) return "horizontal"
+  if (Math.abs(a.x - b.x) < 1e-6) return "vertical"
+  return null
+}
+
+function getSegments(
+  trace: SolvedTracePath,
+  traceIndex: number,
+): TraceSegment[] {
+  const segments: TraceSegment[] = []
+  for (let i = 0; i < trace.tracePath.length - 1; i++) {
+    const p1 = trace.tracePath[i]!
+    const p2 = trace.tracePath[i + 1]!
+    const orientation = getOrientation(p1, p2)
+    if (!orientation) continue
+
+    const isEndpointSegment = i === 0 || i === trace.tracePath.length - 2
+    if (isEndpointSegment) continue
+
+    const coord = orientation === "horizontal" ? p1.y : p1.x
+    const spanStart =
+      orientation === "horizontal" ? Math.min(p1.x, p2.x) : Math.min(p1.y, p2.y)
+    const spanEnd =
+      orientation === "horizontal" ? Math.max(p1.x, p2.x) : Math.max(p1.y, p2.y)
+    const length = spanEnd - spanStart
+
+    segments.push({
+      traceIndex,
+      segmentIndex: i,
+      orientation,
+      coord,
+      spanStart,
+      spanEnd,
+      length,
+      netId: trace.globalConnNetId,
+    })
+  }
+  return segments
+}
+
+function spansOverlap(a: TraceSegment, b: TraceSegment) {
+  const overlap =
+    Math.min(a.spanEnd, b.spanEnd) - Math.max(a.spanStart, b.spanStart)
+  return overlap
+}
+
+class UnionFind {
+  private parent: number[]
+
+  constructor(size: number) {
+    this.parent = Array.from({ length: size }, (_, i) => i)
+  }
+
+  find(value: number): number {
+    if (this.parent[value] !== value) {
+      this.parent[value] = this.find(this.parent[value]!)
+    }
+    return this.parent[value]!
+  }
+
+  union(a: number, b: number) {
+    const rootA = this.find(a)
+    const rootB = this.find(b)
+    if (rootA !== rootB) {
+      this.parent[rootB] = rootA
+    }
+  }
+}
+
+export class SameNetTraceAlignmentSolver extends BaseSolver {
+  private input: SameNetTraceAlignmentSolverInput
+  private outputTraces: SolvedTracePath[]
+  private alignmentThreshold: number
+
+  constructor(input: SameNetTraceAlignmentSolverInput) {
+    super()
+    this.input = input
+    this.outputTraces = structuredClone(input.traces)
+    this.alignmentThreshold = input.alignmentThreshold ?? 0.08
+  }
+
+  override getConstructorParams(): ConstructorParameters<
+    typeof SameNetTraceAlignmentSolver
+  >[0] {
+    return this.input
+  }
+
+  private alignSegments() {
+    const segmentsByNet = new Map<string, TraceSegment[]>()
+    const modifiedTraceIndexes = new Set<number>()
+
+    this.outputTraces.forEach((trace, traceIndex) => {
+      for (const segment of getSegments(trace, traceIndex)) {
+        if (!segmentsByNet.has(segment.netId)) {
+          segmentsByNet.set(segment.netId, [])
+        }
+        segmentsByNet.get(segment.netId)!.push(segment)
+      }
+    })
+
+    for (const segments of segmentsByNet.values()) {
+      const byOrientation: Record<SegmentOrientation, TraceSegment[]> = {
+        horizontal: [],
+        vertical: [],
+      }
+      for (const segment of segments) {
+        byOrientation[segment.orientation].push(segment)
+      }
+
+      for (const orientedSegments of Object.values(byOrientation)) {
+        if (orientedSegments.length < 2) continue
+
+        const uf = new UnionFind(orientedSegments.length)
+
+        for (let i = 0; i < orientedSegments.length; i++) {
+          for (let j = i + 1; j < orientedSegments.length; j++) {
+            const a = orientedSegments[i]!
+            const b = orientedSegments[j]!
+            if (Math.abs(a.coord - b.coord) > this.alignmentThreshold) continue
+
+            const overlap = spansOverlap(a, b)
+            const minRequiredOverlap = Math.min(a.length, b.length) * 0.25
+            if (overlap < minRequiredOverlap) continue
+
+            uf.union(i, j)
+          }
+        }
+
+        const clusters = new Map<number, TraceSegment[]>()
+        orientedSegments.forEach((segment, index) => {
+          const root = uf.find(index)
+          if (!clusters.has(root)) clusters.set(root, [])
+          clusters.get(root)!.push(segment)
+        })
+
+        for (const cluster of clusters.values()) {
+          if (cluster.length < 2) continue
+
+          const targetCoord = median(cluster.map((segment) => segment.coord))
+
+          for (const segment of cluster) {
+            const trace = this.outputTraces[segment.traceIndex]!
+            const path = trace.tracePath
+            const start = path[segment.segmentIndex]!
+            const end = path[segment.segmentIndex + 1]!
+
+            if (segment.orientation === "horizontal") {
+              start.y = targetCoord
+              end.y = targetCoord
+            } else {
+              start.x = targetCoord
+              end.x = targetCoord
+            }
+            modifiedTraceIndexes.add(segment.traceIndex)
+          }
+        }
+      }
+    }
+
+    for (const traceIndex of modifiedTraceIndexes) {
+      const trace = this.outputTraces[traceIndex]!
+      trace.tracePath = simplifyPath(trace.tracePath)
+    }
+  }
+
+  override _step() {
+    if (this.solved) return
+    this.alignSegments()
+    this.solved = true
+  }
+
+  getOutput() {
+    return {
+      traces: this.outputTraces,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    const graphics = visualizeInputProblem(this.input.inputProblem, {
+      chipAlpha: 0.1,
+      connectionAlpha: 0.1,
+    })
+
+    if (!graphics.lines) graphics.lines = []
+
+    for (const trace of this.outputTraces) {
+      const line: Line = {
+        points: trace.tracePath.map((point) => ({ x: point.x, y: point.y })),
+        strokeColor: "blue",
+      }
+      graphics.lines.push(line)
+    }
+
+    return graphics
+  }
+}

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -6,27 +6,28 @@
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { InputProblem } from "lib/types/InputProblem"
+import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
+import { Example28Solver } from "../Example28Solver/Example28Solver"
+import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
 import { MspConnectionPairSolver } from "../MspConnectionPairSolver/MspConnectionPairSolver"
+import { NetLabelNetLabelCollisionSolver } from "../NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver"
+import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { SameNetTraceAlignmentSolver } from "../SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver"
 import {
   SchematicTraceLinesSolver,
   type SolvedTracePath,
 } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
-import { NetLabelPlacementSolver } from "../NetLabelPlacementSolver/NetLabelPlacementSolver"
-import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
-import { visualizeInputProblem } from "./visualizeInputProblem"
+import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
+import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
+import type { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
 import { TraceLabelOverlapAvoidanceSolver } from "../TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver"
+import { TraceOverlapShiftSolver } from "../TraceOverlapShiftSolver/TraceOverlapShiftSolver"
+import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
+import { colorAvailableNetOrientationLabels } from "./colorAvailableNetOrientationLabels"
 import { correctPinsInsideChips } from "./correctPinsInsideChip"
 import { expandChipsToFitPins } from "./expandChipsToFitPins"
-import { LongDistancePairSolver } from "../LongDistancePairSolver/LongDistancePairSolver"
-import { MergedNetLabelObstacleSolver } from "../TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver"
-import { TraceCleanupSolver } from "../TraceCleanupSolver/TraceCleanupSolver"
-import { Example28Solver } from "../Example28Solver/Example28Solver"
-import { AvailableNetOrientationSolver } from "../AvailableNetOrientationSolver/AvailableNetOrientationSolver"
-import { VccNetLabelCornerPlacementSolver } from "../VccNetLabelCornerPlacementSolver/VccNetLabelCornerPlacementSolver"
-import { TraceAnchoredNetLabelOverlapSolver } from "../TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
-import { NetLabelTraceCollisionSolver } from "../NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
-import { NetLabelNetLabelCollisionSolver } from "../NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver"
+import { visualizeInputProblem } from "./visualizeInputProblem"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -76,6 +77,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
   labelMergingSolver?: MergedNetLabelObstacleSolver
   traceLabelOverlapAvoidanceSolver?: TraceLabelOverlapAvoidanceSolver
   traceCleanupSolver?: TraceCleanupSolver
+  sameNetTraceAlignmentSolver?: SameNetTraceAlignmentSolver
   example28Solver?: Example28Solver
   availableNetOrientationSolver?: AvailableNetOrientationSolver
   vccNetLabelCornerPlacementSolver?: VccNetLabelCornerPlacementSolver
@@ -96,7 +98,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       MspConnectionPairSolver,
       () => [{ inputProblem: this.inputProblem }],
       {
-        onSolved: (mspSolver) => {},
+        onSolved: (_mspSolver) => {},
       },
     ),
     // definePipelineStep(
@@ -138,7 +140,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
         },
       ],
       {
-        onSolved: (schematicTraceLinesSolver) => {},
+        onSolved: (_schematicTraceLinesSolver) => {},
       },
     ),
     definePipelineStep(
@@ -148,7 +150,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
         {
           inputProblem: this.inputProblem,
           inputTracePaths:
-            this.longDistancePairSolver?.getOutput().allTracesMerged!,
+            this.longDistancePairSolver?.getOutput().allTracesMerged ?? [],
           globalConnMap: this.mspConnectionPairSolver!.globalConnMap,
         },
       ],
@@ -220,10 +222,27 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       ]
     }),
     definePipelineStep(
+      "sameNetTraceAlignmentSolver",
+      SameNetTraceAlignmentSolver,
+      (instance) => {
+        const traces =
+          instance.traceCleanupSolver?.getOutput().traces ??
+          instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
+
+        return [
+          {
+            inputProblem: instance.inputProblem,
+            traces,
+          },
+        ]
+      },
+    ),
+    definePipelineStep(
       "netLabelPlacementSolver",
       NetLabelPlacementSolver,
       (instance) => {
         const traces =
+          instance.sameNetTraceAlignmentSolver?.getOutput().traces ??
           instance.traceCleanupSolver?.getOutput().traces ??
           instance.traceLabelOverlapAvoidanceSolver!.getOutput().traces
 
@@ -375,7 +394,7 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     }
 
     const constructorParams = pipelineStepDef.getConstructorParams(this)
-    // @ts-ignore
+    // @ts-expect-error pipeline step construction is intentionally dynamic
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
     ;(this as any)[pipelineStepDef.solverName] = this.activeSubSolver
     this.timeSpentOnPhase[pipelineStepDef.solverName] = 0

--- a/tests/solvers/SameNetTraceAlignmentSolver/same-net-trace-alignment-solver.test.ts
+++ b/tests/solvers/SameNetTraceAlignmentSolver/same-net-trace-alignment-solver.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import { SameNetTraceAlignmentSolver } from "lib/solvers/SameNetTraceAlignmentSolver/SameNetTraceAlignmentSolver"
+
+test("SameNetTraceAlignmentSolver aligns close same-net segments", () => {
+  const inputProblem = {
+    chips: [],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  } as any
+
+  const traces = [
+    {
+      mspPairId: "N1-1",
+      dcConnNetId: "N1",
+      globalConnNetId: "N1",
+      pins: [],
+      pinIds: [],
+      mspConnectionPairIds: ["N1-1"],
+      tracePath: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 1, y: 1 },
+        { x: 3, y: 1 },
+        { x: 3, y: 2 },
+      ],
+    },
+    {
+      mspPairId: "N1-2",
+      dcConnNetId: "N1",
+      globalConnNetId: "N1",
+      pins: [],
+      pinIds: [],
+      mspConnectionPairIds: ["N1-2"],
+      tracePath: [
+        { x: 0, y: 0.05 },
+        { x: 1, y: 0.05 },
+        { x: 1, y: 1.05 },
+        { x: 3, y: 1.05 },
+        { x: 3, y: 2.05 },
+      ],
+    },
+    {
+      mspPairId: "N2-1",
+      dcConnNetId: "N2",
+      globalConnNetId: "N2",
+      pins: [],
+      pinIds: [],
+      mspConnectionPairIds: ["N2-1"],
+      tracePath: [
+        { x: 0, y: 5 },
+        { x: 1, y: 5 },
+        { x: 1, y: 6 },
+        { x: 3, y: 6 },
+        { x: 3, y: 7 },
+      ],
+    },
+  ] as any
+
+  const solver = new SameNetTraceAlignmentSolver({
+    inputProblem,
+    traces,
+  })
+
+  solver.solve()
+
+  const output = solver.getOutput().traces
+
+  expect(output[0]!.tracePath[2]!.y).toBeCloseTo(output[1]!.tracePath[2]!.y, 10)
+  expect(output[0]!.tracePath[3]!.y).toBeCloseTo(output[1]!.tracePath[3]!.y, 10)
+  expect(output[0]!.tracePath[2]!.y).toBeCloseTo(1.025, 3)
+
+  expect(output[2]!.tracePath[2]!.y).toBe(6)
+  expect(output[2]!.tracePath[3]!.y).toBe(6)
+})


### PR DESCRIPTION
Implements a small alignment pass that snaps nearby same-net trace segments to the same X/Y before the final label placement phase.

Verified with:
- bun test tests/solvers/SameNetTraceAlignmentSolver/same-net-trace-alignment-solver.test.ts
- bun test tests/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver_repro03.test.ts
- bun run build

/claim #34