### PR TITLE
fix: don't hard-wire passive components joined only by net labels

### DIFF
--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -13,6 +13,7 @@ import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualize
 import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import type { ConnectivityMap } from "connectivity-map"
 import { arePinsInDifferentSchematicSections } from "../../utils/arePinsInDifferentSchematicSections"
+import { isNetLabelOnlyPassiveNet } from "../../utils/isNetLabelOnlyPassiveNet"
 
 const NEAREST_NEIGHBOR_COUNT = 3
 
@@ -76,6 +77,12 @@ export class LongDistancePairSolver extends BaseSolver {
     for (const netId of Object.keys(netConnMap.netMap)) {
       const allPinIdsInNet = netConnMap.getIdsConnectedToNet(netId)
       if (allPinIdsInNet.length < 2) continue
+
+      // Passive components joined exclusively through net labels shouldn't be
+      // hard-wired together — every pin gets a net label instead (issue #79)
+      if (isNetLabelOnlyPassiveNet({ inputProblem, pinIds: allPinIdsInNet })) {
+        continue
+      }
 
       const unconnectedPinIds = allPinIdsInNet.filter(
         (pinId) => !primaryConnectedPinIds.has(pinId),

--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -13,6 +13,7 @@ import type { GraphicsObject } from "graphics-debug"
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
 import { arePinsInDifferentSchematicSections } from "../../utils/arePinsInDifferentSchematicSections"
+import { isNetLabelOnlyPassiveNet } from "../../utils/isNetLabelOnlyPassiveNet"
 
 export type MspConnectionPairId = string
 
@@ -98,6 +99,17 @@ export class MspConnectionPairSolver extends BaseSolver {
     const directlyConnectedPins = allIds.filter((id) => !!this.pinMap[id])
 
     if (directlyConnectedPins.length <= 1) {
+      return
+    }
+
+    // Passive components joined exclusively through net labels shouldn't be
+    // hard-wired together — every pin gets a net label instead (issue #79)
+    if (
+      isNetLabelOnlyPassiveNet({
+        inputProblem: this.inputProblem,
+        pinIds: directlyConnectedPins,
+      })
+    ) {
       return
     }
 

--- a/lib/utils/isNetLabelOnlyPassiveNet.ts
+++ b/lib/utils/isNetLabelOnlyPassiveNet.ts
@@ -1,0 +1,69 @@
+import type { InputChip, InputProblem, PinId } from "lib/types/InputProblem"
+
+/**
+ * Returns true when a group of same-net pins should NOT be connected with
+ * wire traces and should instead be represented purely by net labels.
+ *
+ * This targets the repro61 case (issue #79): passive two-terminal components
+ * (e.g. parallel decoupling capacitors) whose pins are joined exclusively
+ * through net labels. Routing a wire between such pins is redundant — every
+ * pin already gets a net label — and it makes independently-labeled
+ * components look hard-wired together (see tscircuit/core#1503).
+ *
+ * The check is intentionally narrow so that nets which mix net labels with
+ * real (direct) wiring, or that involve multi-pin chips, continue to be
+ * routed exactly as before:
+ *
+ *   1. No pin in the group participates in any direct (wire) connection.
+ *   2. Every pin in the group belongs to a two-pin passive component.
+ *   3. None of those components has any directly-wired pin, i.e. the
+ *      components are attached to the schematic exclusively via net labels.
+ */
+export const isNetLabelOnlyPassiveNet = (params: {
+  inputProblem: InputProblem
+  pinIds: PinId[]
+}): boolean => {
+  const { inputProblem, pinIds } = params
+
+  if (pinIds.length < 2) return false
+
+  const directlyWiredPinIds = new Set<PinId>()
+  for (const directConnection of inputProblem.directConnections) {
+    for (const pinId of directConnection.pinIds) {
+      directlyWiredPinIds.add(pinId)
+    }
+  }
+
+  const chipByPinId = new Map<PinId, InputChip>()
+  for (const chip of inputProblem.chips) {
+    for (const pin of chip.pins) {
+      chipByPinId.set(pin.pinId, chip)
+    }
+  }
+
+  const chipIdsInNet = new Set<string>()
+
+  for (const pinId of pinIds) {
+    // 1. The group must be net-label-only (no direct/wire connections)
+    if (directlyWiredPinIds.has(pinId)) return false
+
+    const chip = chipByPinId.get(pinId)
+    if (!chip) continue
+    chipIdsInNet.add(chip.chipId)
+
+    // 2. Only two-pin passive components qualify
+    if (chip.pins.length !== 2) return false
+
+    // 3. The component itself must not be wired to anything else
+    for (const pin of chip.pins) {
+      if (directlyWiredPinIds.has(pin.pinId)) return false
+    }
+  }
+
+  // 4. Only skip wiring when the net spans multiple components: same-net
+  // pins on a single component (e.g. repro142) should still get a stub
+  // trace and a single shared net label.
+  if (chipIdsInNet.size < 2) return false
+
+  return true
+}

--- a/tests/repros/__snapshots__/repro61-net-label-only-passive-net.snap.svg
+++ b/tests/repros/__snapshots__/repro61-net-label-only-passive-net.snap.svg
@@ -1,0 +1,120 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="C1.1
+y-" data-x="2" data-y="-0.55" cx="541.3438735177865" cy="439.52569169960475" r="3" fill="hsl(121, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C1.2
+y+" data-x="2" data-y="0.55" cx="541.3438735177865" cy="196.0474308300395" r="3" fill="hsl(122, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C2.1
+y-" data-x="0" data-y="-0.55" cx="98.65612648221347" cy="439.52569169960475" r="3" fill="hsl(2, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="C2.2
+y+" data-x="0" data-y="0.55" cx="98.65612648221347" cy="196.0474308300395" r="3" fill="hsl(3, 100%, 50%, 0.8)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="2" data-y="-0.55" cx="541.3438735177865" cy="439.52569169960475" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="0" data-y="-0.55" cx="98.65612648221347" cy="439.52569169960475" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="2" data-y="0.55" cx="541.3438735177865" cy="196.0474308300395" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="0" data-y="0.55" cx="98.65612648221347" cy="196.0474308300395" r="3" fill="hsl(40, 100%, 50%, 0.9)" />
+  </g>
+  <g>
+    <polyline data-points="2,-0.55 0,-0.55" data-type="line" data-label="" points="541.3438735177865,439.52569169960475 98.65612648221347,439.52569169960475" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <polyline data-points="2,0.55 0,0.55" data-type="line" data-label="" points="541.3438735177865,196.0474308300395 98.65612648221347,196.0474308300395" fill="none" stroke="hsl(190, 100%, 50%, 0.8)" stroke-width="1" stroke-dasharray="4 2" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_0" data-x="2" data-y="0" x="482.6877470355731" y="196.0474308300395" width="117.31225296442688" height="243.47826086956525" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.004517857142857144" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="schematic_component_1" data-x="0" data-y="0" x="40.00000000000003" y="196.0474308300395" width="117.31225296442688" height="243.47826086956525" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.004517857142857144" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net0" data-x="2" data-y="-0.7060000000000001" x="519.2094861660079" y="439.7470355731225" width="44.26877470355737" height="68.61660079051387" fill="#00000066" stroke="#000000" stroke-width="0.004517857142857144" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net0" data-x="0" data-y="-0.7060000000000001" x="76.52173913043481" y="439.7470355731225" width="44.26877470355731" height="68.61660079051387" fill="#00000066" stroke="#000000" stroke-width="0.004517857142857144" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net1" data-x="2" data-y="0.6960000000000001" x="519.2094861660079" y="131.63636363636363" width="44.26877470355737" height="64.18972332015812" fill="#ef444466" stroke="#ef4444" stroke-width="0.004517857142857144" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="netId: VCC
+globalConnNetId: connectivity_net1" data-x="0" data-y="0.6960000000000001" x="76.52173913043481" y="131.63636363636363" width="44.26877470355731" height="64.18972332015812" fill="#ef444466" stroke="#ef4444" stroke-width="0.004517857142857144" />
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 221.34387351778653,
+        "c": 0,
+        "e": 98.65612648221347,
+        "b": 0,
+        "d": -221.34387351778653,
+        "f": 317.7865612648221
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/repros/repro61-net-label-only-passive-net.test.ts
+++ b/tests/repros/repro61-net-label-only-passive-net.test.ts
@@ -59,10 +59,16 @@ test("repro61 net-label-only passive nets are not hard-wired together", () => {
     expect(placement.pinIds).toHaveLength(1)
   }
   expect(
-    placements.filter((p) => p.netId === "GND").map((p) => p.pinIds[0]).sort(),
+    placements
+      .filter((p) => p.netId === "GND")
+      .map((p) => p.pinIds[0])
+      .sort(),
   ).toEqual(["C1.1", "C2.1"])
   expect(
-    placements.filter((p) => p.netId === "VCC").map((p) => p.pinIds[0]).sort(),
+    placements
+      .filter((p) => p.netId === "VCC")
+      .map((p) => p.pinIds[0])
+      .sort(),
   ).toEqual(["C1.2", "C2.2"])
 
   expect(solver).toMatchSolverSnapshot(import.meta.path)

--- a/tests/repros/repro61-net-label-only-passive-net.test.ts
+++ b/tests/repros/repro61-net-label-only-passive-net.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import "tests/fixtures/matcher"
+
+// Mirrors tscircuit/core repro61 (tscircuit/core#1503): two capacitors whose
+// pins are joined exclusively through net labels. The components must not be
+// hard-wired together with a trace — each pin gets its own net label instead.
+// https://github.com/tscircuit/schematic-trace-solver/issues/79
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "schematic_component_0", // C1
+      center: { x: 2, y: 0 },
+      width: 0.53,
+      height: 1.1,
+      pins: [
+        { pinId: "C1.1", x: 2, y: -0.55 },
+        { pinId: "C1.2", x: 2, y: 0.55 },
+      ],
+    },
+    {
+      chipId: "schematic_component_1", // C2
+      center: { x: 0, y: 0 },
+      width: 0.53,
+      height: 1.1,
+      pins: [
+        { pinId: "C2.1", x: 0, y: -0.55 },
+        { pinId: "C2.2", x: 0, y: 0.55 },
+      ],
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    { netId: "GND", pinIds: ["C1.1", "C2.1"], netLabelWidth: 0.31 },
+    { netId: "VCC", pinIds: ["C1.2", "C2.2"], netLabelWidth: 0.29 },
+  ],
+  availableNetLabelOrientations: {
+    GND: ["y-"],
+    VCC: ["y+"],
+  },
+  maxMspPairDistance: 2.4,
+}
+
+test("repro61 net-label-only passive nets are not hard-wired together", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  solver.solve()
+
+  // No traces between the two capacitors
+  expect(solver.netLabelTraceCollisionSolver!.getOutput().traces).toHaveLength(
+    0,
+  )
+
+  // Every pin gets its own net label
+  const placements =
+    solver.netLabelNetLabelCollisionSolver!.getOutput().netLabelPlacements
+  expect(placements).toHaveLength(4)
+  for (const placement of placements) {
+    expect(placement.pinIds).toHaveLength(1)
+  }
+  expect(
+    placements.filter((p) => p.netId === "GND").map((p) => p.pinIds[0]).sort(),
+  ).toEqual(["C1.1", "C2.1"])
+  expect(
+    placements.filter((p) => p.netId === "VCC").map((p) => p.pinIds[0]).sort(),
+  ).toEqual(["C1.2", "C2.2"])
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Problem

In repro61 (tscircuit/core#1503), two capacitors whose pins are connected exclusively through net labels get a wire trace routed between them, making independently-labeled components look hard-wired together with an extra shared net label. Both `MspConnectionPairSolver` and `LongDistancePairSolver` created these pairs (the latter sweeps up pins the first one skips, so both need the guard).

## Fix

New `isNetLabelOnlyPassiveNet` check — a net's trace routing is skipped only when **all** of these hold:

1. No pin in the net has any direct (wire) connection
2. Every pin belongs to a two-pin passive component
3. None of those components has any directly-wired pin
4. The net spans **multiple** components

Each pin then gets its own net label and no trace is drawn. Condition 4 keeps same-net pins on a single component (repro142) getting their stub trace + single shared label as before.

## Verification

- New repro test `tests/repros/repro61-net-label-only-passive-net.test.ts` mirroring core's repro61: asserts 0 traces, 4 per-pin labels (2×GND, 2×VCC), plus solver snapshot
- `bun test`: 76 pass / 0 fail (repro142 unaffected)
- `bunx tsc --noEmit`: clean

Fixes #79

/claim #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)