### PR TITLE
 Respect provided pin facingDirection when correcting pins inside expanded chip boxes

### DIFF
--- a/lib/solvers/SchematicTracePipelineSolver/correctPinsInsideChip.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/correctPinsInsideChip.ts
@@ -13,6 +13,25 @@ export const correctPinsInsideChips = (problem: InputProblem) => {
 
       if (!isInside) continue
 
+      // When the pin already knows which way it faces (e.g. the consumer set it
+      // from the schematic symbol), snap it to the edge along that direction and
+      // keep the facing. A pin can end up inside the box when the box was
+      // expanded to include the component's reference-designator text; snapping
+      // to the nearest edge would move it to the wrong side (e.g. a horizontal
+      // resistor whose wide ref text makes the bottom edge the closest one).
+      if (pin._facingDirection) {
+        if (pin._facingDirection === "x-") {
+          pin.x = bounds.minX
+        } else if (pin._facingDirection === "x+") {
+          pin.x = bounds.maxX
+        } else if (pin._facingDirection === "y-") {
+          pin.y = bounds.minY
+        } else {
+          pin.y = bounds.maxY
+        }
+        continue
+      }
+
       const distLeft = pin.x - bounds.minX
       const distRight = bounds.maxX - pin.x
       const distBottom = pin.y - bounds.minY

--- a/tests/repros/__snapshots__/small-variant-resistor-facing-direction.snap.svg
+++ b/tests/repros/__snapshots__/small-variant-resistor-facing-direction.snap.svg
@@ -1,0 +1,86 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="8.9,15.1 8.9,14.7" data-type="line" data-label="" points="100.44213263979202,152.50975292587782 100.44213263979202,181.63849154746435" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="8.9,15.1 11.1,13.3" data-type="line" data-label="" points="100.44213263979202,152.50975292587782 260.6501950585176,283.5890767230169" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="8.9,14.7 11.1,13.3" data-type="line" data-label="" points="100.44213263979202,181.63849154746435 260.6501950585176,283.5890767230169" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="8.9,14.9 8.9,14.5" data-type="line" data-label="" points="100.44213263979202,167.07412223667097 100.44213263979202,196.2028608582575" fill="none" stroke="hsl(23, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="8.9,14.9 11.1,12.7" data-type="line" data-label="" points="100.44213263979202,167.07412223667097 260.6501950585176,327.2821846553967" fill="none" stroke="hsl(23, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="8.9,14.9 13.16,10" data-type="line" data-label="" points="100.44213263979202,167.07412223667097 410.663198959688,523.9011703511054" fill="none" stroke="hsl(23, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="8.9,14.5 11.1,12.7" data-type="line" data-label="" points="100.44213263979202,196.2028608582575 260.6501950585176,327.2821846553967" fill="none" stroke="hsl(23, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="8.9,14.5 13.16,10" data-type="line" data-label="" points="100.44213263979202,196.2028608582575 410.663198959688,523.9011703511054" fill="none" stroke="hsl(23, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="11.1,12.7 13.16,10" data-type="line" data-label="" points="260.6501950585176,327.2821846553967 410.663198959688,523.9011703511054" fill="none" stroke="hsl(23, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="11.1,15.5 14.84,10" data-type="line" data-label="" points="260.6501950585176,123.38101430429128 533.0039011703514,523.9011703511054" fill="none" stroke="hsl(50, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="8.9,14.7 8.600000000000001,14.7 8.600000000000001,15.1 8.9,15.1" data-type="line" data-label="" points="100.44213263979202,181.63849154746435 78.59557867360218,181.63849154746435 78.59557867360218,152.50975292587782 100.44213263979202,152.50975292587782" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="8.9,14.5 8.8,14.5 8.8,14.9 8.9,14.9" data-type="line" data-label="" points="100.44213263979202,196.2028608582575 93.15994798439544,196.2028608582575 93.15994798439544,167.07412223667097 100.44213263979202,167.07412223667097" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="11.1,12.7 12.129999999999999,12.7 12.129999999999999,10 13.16,10" data-type="line" data-label="" points="260.6501950585176,327.2821846553967 335.6566970091028,327.2821846553967 335.6566970091028,523.9011703511054 410.663198959688,523.9011703511054" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="11.1,15.5 15.04,15.5 15.04,10 14.84,10" data-type="line" data-label="" points="260.6501950585176,123.38101430429128 547.5682704811445,123.38101430429128 547.5682704811445,523.9011703511054 533.0039011703514,523.9011703511054" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="8.600000000000001,14.7 8.31,14.7 8.31,14.699" data-type="line" data-label="" points="78.59557867360218,181.63849154746435 57.477243172951944,181.63849154746435 57.477243172951944,181.71131339401813" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="11.1,13.3 12.341,13.3 12.341,13.249" data-type="line" data-label="" points="260.6501950585176,283.5890767230169 351.0221066319897,283.5890767230169 351.0221066319897,287.3029908972692" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="schematic_component_0" data-x="10" data-y="14" x="100.44213263979202" y="108.81664499349813" width="160.2080624187256" height="247.59427828348498" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.013732142857142852"/></g><g><rect data-type="rect" data-label="schematic_component_1" data-x="14" data-y="10" x="410.6631989596879" y="499.1417425227569" width="122.34070221066338" height="49.51885565669704" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.013732142857142852"/></g><g><rect data-type="rect" data-label="ATMEGA328P_AU" data-x="10.080000000000002" data-y="12.17" x="129.57087126137844" y="359.3237971391418" width="113.60208062418747" height="13.10793237971393" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.013732142857142852"/></g><g><rect data-type="rect" data-label="U_MCU" data-x="9.600000000000001" data-y="15.815" x="125.2015604681406" y="91.33940182054607" width="52.431729518855605" height="18.20546163849167" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.013732142857142852"/></g><g><rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net0" data-x="8.31" data-y="14.488999999999999" x="40" y="181.71131339401813" width="34.95448634590389" height="30.585175552665987" fill="#00000066" stroke="#000000" stroke-width="0.013732142857142852"/></g><g><rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net0" data-x="12.341" data-y="13.039" x="333.5448634590378" y="287.30299089726924" width="34.954486345903774" height="30.585175552665874" fill="#00000066" stroke="#000000" stroke-width="0.013732142857142852"/></g><g><rect data-type="rect" data-label="netId: VCC_3V3
+globalConnNetId: connectivity_net1" data-x="11.614999999999998" data-y="12.91" x="263.1989596879063" y="296.69700910273076" width="69.90897269180766" height="30.585175552665874" fill="#ef444466" stroke="#ef4444" stroke-width="0.013732142857142852"/></g><g><rect data-type="rect" data-label="netId: FAULT
+globalConnNetId: connectivity_net2" data-x="15.399999999999999" data-y="15.5" x="547.5682704811444" y="116.09882964889471" width="52.43172951885549" height="14.564369310793154" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.013732142857142852"/></g><g><circle data-type="point" data-label="U_MCU.1
+x-" data-x="8.9" data-y="15.5" cx="100.44213263979202" cy="123.38101430429128" r="3" fill="hsl(144, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.2
+x-" data-x="8.9" data-y="15.3" cx="100.44213263979202" cy="137.94538361508444" r="3" fill="hsl(145, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.3
+x-" data-x="8.9" data-y="15.1" cx="100.44213263979202" cy="152.50975292587782" r="3" fill="hsl(146, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.4
+x-" data-x="8.9" data-y="14.9" cx="100.44213263979202" cy="167.07412223667097" r="3" fill="hsl(147, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.5
+x-" data-x="8.9" data-y="14.7" cx="100.44213263979202" cy="181.63849154746435" r="3" fill="hsl(148, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.6
+x-" data-x="8.9" data-y="14.5" cx="100.44213263979202" cy="196.2028608582575" r="3" fill="hsl(149, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.7
+x-" data-x="8.9" data-y="14.3" cx="100.44213263979202" cy="210.76723016905066" r="3" fill="hsl(150, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.8
+x-" data-x="8.9" data-y="14.1" cx="100.44213263979202" cy="225.33159947984404" r="3" fill="hsl(151, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.9
+x-" data-x="8.9" data-y="13.9" cx="100.44213263979202" cy="239.8959687906372" r="3" fill="hsl(152, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.10
+x-" data-x="8.9" data-y="13.700000000000001" cx="100.44213263979202" cy="254.46033810143035" r="3" fill="hsl(192, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.11
+x-" data-x="8.9" data-y="13.5" cx="100.44213263979202" cy="269.02470741222373" r="3" fill="hsl(193, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.12
+x-" data-x="8.9" data-y="13.3" cx="100.44213263979202" cy="283.5890767230169" r="3" fill="hsl(194, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.13
+x-" data-x="8.9" data-y="13.1" cx="100.44213263979202" cy="298.15344603381016" r="3" fill="hsl(195, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.14
+x-" data-x="8.9" data-y="12.9" cx="100.44213263979202" cy="312.7178153446034" r="3" fill="hsl(196, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.15
+x-" data-x="8.9" data-y="12.7" cx="100.44213263979202" cy="327.2821846553967" r="3" fill="hsl(197, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.16
+x-" data-x="8.9" data-y="12.5" cx="100.44213263979202" cy="341.84655396618996" r="3" fill="hsl(198, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.17
+x+" data-x="11.1" data-y="12.5" cx="260.6501950585176" cy="341.84655396618996" r="3" fill="hsl(199, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.18
+x+" data-x="11.1" data-y="12.7" cx="260.6501950585176" cy="327.2821846553967" r="3" fill="hsl(200, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.19
+x+" data-x="11.1" data-y="12.9" cx="260.6501950585176" cy="312.7178153446034" r="3" fill="hsl(201, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.20
+x+" data-x="11.1" data-y="13.1" cx="260.6501950585176" cy="298.15344603381016" r="3" fill="hsl(223, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.21
+x+" data-x="11.1" data-y="13.3" cx="260.6501950585176" cy="283.5890767230169" r="3" fill="hsl(224, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.22
+x+" data-x="11.1" data-y="13.5" cx="260.6501950585176" cy="269.02470741222373" r="3" fill="hsl(225, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.23
+x+" data-x="11.1" data-y="13.7" cx="260.6501950585176" cy="254.46033810143047" r="3" fill="hsl(226, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.24
+x+" data-x="11.1" data-y="13.9" cx="260.6501950585176" cy="239.8959687906372" r="3" fill="hsl(227, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.25
+x+" data-x="11.1" data-y="14.1" cx="260.6501950585176" cy="225.33159947984404" r="3" fill="hsl(228, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.26
+x+" data-x="11.1" data-y="14.299999999999999" cx="260.6501950585176" cy="210.7672301690509" r="3" fill="hsl(229, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.27
+x+" data-x="11.1" data-y="14.5" cx="260.6501950585176" cy="196.2028608582575" r="3" fill="hsl(230, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.28
+x+" data-x="11.1" data-y="14.7" cx="260.6501950585176" cy="181.63849154746435" r="3" fill="hsl(231, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.29
+x+" data-x="11.1" data-y="14.9" cx="260.6501950585176" cy="167.07412223667097" r="3" fill="hsl(232, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.30
+x+" data-x="11.1" data-y="15.1" cx="260.6501950585176" cy="152.50975292587782" r="3" fill="hsl(254, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.31
+x+" data-x="11.1" data-y="15.3" cx="260.6501950585176" cy="137.94538361508444" r="3" fill="hsl(255, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.32
+x+" data-x="11.1" data-y="15.5" cx="260.6501950585176" cy="123.38101430429128" r="3" fill="hsl(256, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="R_FAULT_PULLUP.1
+x-" data-x="13.16" data-y="10" cx="410.663198959688" cy="523.9011703511054" r="3" fill="hsl(344, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="R_FAULT_PULLUP.2
+x+" data-x="14.84" data-y="10" cx="533.0039011703514" cy="523.9011703511054" r="3" fill="hsl(344, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="8.31" data-y="14.699" cx="57.477243172951944" cy="181.71131339401813" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="12.341" data-y="13.249" cx="351.0221066319897" cy="287.3029908972692" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="11.614999999999998" data-y="12.7" cx="298.15344603381016" cy="327.2821846553967" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="15.04" data-y="15.5" cx="547.5682704811445" cy="123.38101430429128" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":72.82184655396621,"c":0,"e":-547.6723016905073,"b":0,"d":-72.82184655396621,"f":1252.1196358907675};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/assets/small-variant-resistor-facing-direction.input.json
+++ b/tests/repros/assets/small-variant-resistor-facing-direction.input.json
@@ -1,0 +1,297 @@
+{
+  "chips": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": 10,
+        "y": 14
+      },
+      "width": 2.1999999999999993,
+      "height": 3.3999999999999986,
+      "pins": [
+        {
+          "pinId": "U_MCU.1",
+          "x": 8.9,
+          "y": 15.5,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.2",
+          "x": 8.9,
+          "y": 15.3,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.3",
+          "x": 8.9,
+          "y": 15.1,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.4",
+          "x": 8.9,
+          "y": 14.9,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.5",
+          "x": 8.9,
+          "y": 14.7,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.6",
+          "x": 8.9,
+          "y": 14.5,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.7",
+          "x": 8.9,
+          "y": 14.3,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.8",
+          "x": 8.9,
+          "y": 14.1,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.9",
+          "x": 8.9,
+          "y": 13.9,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.10",
+          "x": 8.9,
+          "y": 13.700000000000001,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.11",
+          "x": 8.9,
+          "y": 13.5,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.12",
+          "x": 8.9,
+          "y": 13.3,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.13",
+          "x": 8.9,
+          "y": 13.1,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.14",
+          "x": 8.9,
+          "y": 12.9,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.15",
+          "x": 8.9,
+          "y": 12.7,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.16",
+          "x": 8.9,
+          "y": 12.5,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U_MCU.17",
+          "x": 11.1,
+          "y": 12.5,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.18",
+          "x": 11.1,
+          "y": 12.7,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.19",
+          "x": 11.1,
+          "y": 12.9,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.20",
+          "x": 11.1,
+          "y": 13.1,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.21",
+          "x": 11.1,
+          "y": 13.3,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.22",
+          "x": 11.1,
+          "y": 13.5,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.23",
+          "x": 11.1,
+          "y": 13.7,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.24",
+          "x": 11.1,
+          "y": 13.9,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.25",
+          "x": 11.1,
+          "y": 14.1,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.26",
+          "x": 11.1,
+          "y": 14.299999999999999,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.27",
+          "x": 11.1,
+          "y": 14.5,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.28",
+          "x": 11.1,
+          "y": 14.7,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.29",
+          "x": 11.1,
+          "y": 14.9,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.30",
+          "x": 11.1,
+          "y": 15.1,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.31",
+          "x": 11.1,
+          "y": 15.3,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "U_MCU.32",
+          "x": 11.1,
+          "y": 15.5,
+          "_facingDirection": "x+"
+        }
+      ]
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": {
+        "x": 14,
+        "y": 10
+      },
+      "width": 1.6799999999999997,
+      "height": 0.6799999999999997,
+      "pins": [
+        {
+          "pinId": "R_FAULT_PULLUP.1",
+          "x": 13.7,
+          "y": 10,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "R_FAULT_PULLUP.2",
+          "x": 14.3,
+          "y": 10,
+          "_facingDirection": "x+"
+        }
+      ]
+    }
+  ],
+  "directConnections": [],
+  "netConnections": [
+    {
+      "netId": "GND",
+      "pinIds": [
+        "U_MCU.3",
+        "U_MCU.5",
+        "U_MCU.21"
+      ],
+      "netLabelWidth": 0.42,
+      "netLabelHeight": 0.48
+    },
+    {
+      "netId": "VCC_3V3",
+      "pinIds": [
+        "U_MCU.4",
+        "U_MCU.6",
+        "U_MCU.18",
+        "R_FAULT_PULLUP.1"
+      ],
+      "netLabelWidth": 0.42,
+      "netLabelHeight": 0.96
+    },
+    {
+      "netId": "FAULT",
+      "pinIds": [
+        "U_MCU.32",
+        "R_FAULT_PULLUP.2"
+      ],
+      "netLabelWidth": 0.72
+    }
+  ],
+  "textBoxes": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": 10.080000000000002,
+        "y": 12.17
+      },
+      "width": 1.5600000000000005,
+      "height": 0.17999999999999972,
+      "text": "ATMEGA328P_AU"
+    },
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": 9.600000000000001,
+        "y": 15.815
+      },
+      "width": 0.7200000000000006,
+      "height": 0.25,
+      "text": "U_MCU"
+    }
+  ],
+  "availableNetLabelOrientations": {
+    "VCC_3V3": [
+      "y+"
+    ],
+    "GND": [
+      "y-"
+    ],
+    "FAULT": [
+      "x-",
+      "x+"
+    ]
+  },
+  "maxMspPairDistance": 2.4
+}

--- a/tests/repros/small-variant-resistor-facing-direction.test.ts
+++ b/tests/repros/small-variant-resistor-facing-direction.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "./assets/small-variant-resistor-facing-direction.input.json"
+import "tests/fixtures/matcher"
+
+// Regression for a small-variant resistor (R_FAULT_PULLUP) whose wide
+// reference-designator text inflates its chip box, so its two ports sit *inside*
+// the box rather than on an edge.
+//
+// The input supplies each port's facing direction (as @tscircuit/core does from
+// the schematic symbol). The solver must snap such inside-pins to the box edge
+// ALONG that facing (correctPinsInsideChips) instead of guessing the nearest
+// edge — which, for a horizontal resistor whose ref text widened the box, is the
+// bottom edge, wrongly making both terminals face "y-" and routing downward.
+test("small-variant resistor with facing directions routes from the sides", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  const resistor = solver.inputProblem.chips.find(
+    (c) => c.chipId === "schematic_component_1",
+  )!
+  // Terminals keep their symbol-provided facing instead of being re-detected as
+  // facing down, and are snapped to the left/right edges of the inflated box.
+  expect(resistor.pins.map((p) => p._facingDirection).sort()).toEqual([
+    "x+",
+    "x-",
+  ])
+  const left = resistor.pins.find((p) => p._facingDirection === "x-")!
+  const right = resistor.pins.find((p) => p._facingDirection === "x+")!
+  expect(left.x).toBeCloseTo(resistor.center.x - resistor.width / 2)
+  expect(right.x).toBeCloseTo(resistor.center.x + resistor.width / 2)
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## What

`correctPinsInsideChips` moves any pin that sits *inside* its chip's bounding box out onto the nearest edge, so the router has a perimeter point to start from. This changes that step to honor an explicit `_facingDirection`: when a pin already declares which way it faces, snap it to the edge **along that direction** and keep the facing, instead of snapping to the geometrically nearest edge and clearing it.
Nearest-edge snapping is still the fallback for pins with no `_facingDirection`, so existing behavior is unchanged.

## Why

Consumers (e.g. `@tscircuit/core`) hand the solver a **text-inclusive** chip box — the component's box grown to enclose its reference-designator/value text. For a *small-variant* part with a *large* ref designator (a resistor labeled `R_FAULT_PULLUP`, a decoupling cap, …), that box is much wider/taller than the part, so the component's two ports end up **inside** the box rather than on an edge.

`correctPinsInsideChips` then moved each port to the *nearest* edge. For a horizontal resistor whose wide ref text pushed the left/right edges far away, the nearest edge is the **bottom** — so both terminals were snapped downward and
re-detected as facing `y-`. The result: connections/net labels dropped *below* the part instead of leaving from its left/right sides.

The port's true facing is already known from the schematic symbol, and the solver already respects `pin._facingDirection` everywhere else (`pin._facingDirection ?? getPinDirection(...)`). The one place that ignored it — and actively cleared it — was this correction step. This makes it consistent: trust the declared facing.

This is the solver half of the fix; the consumer supplies `_facingDirection` from the symbol (`@tscircuit/core` PR: https://github.com/tscircuit/core/pull/2614). Neither half works alone — sending the facing has no effect while this step overwrites it.

## Before / after

- Before: small resistor with a long ref designator → both pins face `y-`, trace/net labels route below the part.
- After: pins keep `x-`/`x+`, connections leave from the sides.

Before:
<img width="325" height="325" alt="Screenshot 2026-07-08 at 4 06 41 PM" src="https://github.com/user-attachments/assets/40519101-6988-4db3-90e6-cba552480bb7" />

After:
<img width="348" height="307" alt="Screenshot 2026-07-08 at 4 07 05 PM" src="https://github.com/user-attachments/assets/fbceae5a-ad12-4e01-8eba-92eb44287557" />
