### PR TITLE
Guard getColorFromString against NaN hue for very long strings

### DIFF
--- a/lib/utils/getColorFromString.ts
+++ b/lib/utils/getColorFromString.ts
@@ -3,5 +3,9 @@ export const getColorFromString = (string: string, alpha = 1) => {
   const hash = string.split("").reduce((acc, char) => {
     return acc * 31 + char.charCodeAt(0)
   }, 0)
-  return `hsl(${hash % 360}, 100%, 50%, ${alpha})`
+  // For very long strings the accumulator overflows to Infinity, which makes
+  // `hash % 360` NaN and produces an invalid `hsl(NaN, ...)` color. Fall back
+  // to a valid hue in that case. Every finite hash is unchanged.
+  const hue = Number.isFinite(hash) ? hash % 360 : 0
+  return `hsl(${hue}, 100%, 50%, ${alpha})`
 }

--- a/tests/functions/getColorFromString.test.ts
+++ b/tests/functions/getColorFromString.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test"
+import { getColorFromString } from "lib/utils/getColorFromString"
+
+test("getColorFromString returns a valid hue for very long strings", () => {
+  // The hash accumulator overflows to Infinity for long strings, which used to
+  // produce an invalid `hsl(NaN, 100%, 50%, 1)` color.
+  const color = getColorFromString("n".repeat(300))
+
+  expect(color).not.toContain("NaN")
+  const hue = Number(color.slice(color.indexOf("(") + 1, color.indexOf(",")))
+  expect(Number.isFinite(hue)).toBe(true)
+  expect(hue).toBeGreaterThanOrEqual(0)
+  expect(hue).toBeLessThan(360)
+})
+
+test("getColorFromString is unchanged for normal strings", () => {
+  expect(getColorFromString("U1.13-RFSET.1")).toBe("hsl(328, 100%, 50%, 1)")
+  expect(getColorFromString("net0", 0.75)).toBe("hsl(195, 100%, 50%, 0.75)")
+})


### PR DESCRIPTION
Closes #651

The hash accumulator overflows to `Infinity` for long strings, so `hash % 360` came out `NaN` and the color was `hsl(NaN, ...)`. This falls back to a valid hue when the hash isn't finite — every finite hash keeps the exact same output, so no existing colors change. Added a small test.