### PR TITLE
fix: handle empty or undefined connections arrays without crashing

### DIFF
--- a/lib/data-structures/ChipObstacleSpatialIndex.ts
+++ b/lib/data-structures/ChipObstacleSpatialIndex.ts
@@ -10,7 +10,7 @@ export interface SpatiallyIndexedChip extends InputChip {
 
 export class ChipObstacleSpatialIndex {
   chips: Array<SpatiallyIndexedChip>
-  spatialIndex: Flatbush
+  spatialIndex: Flatbush | null
   spatialIndexIdToChip: Map<number, SpatiallyIndexedChip>
 
   constructor(chips: InputChip[]) {
@@ -21,6 +21,13 @@ export class ChipObstacleSpatialIndex {
     }))
 
     this.spatialIndexIdToChip = new Map()
+
+    if (chips.length === 0) {
+      // Flatbush requires at least 1 item; skip index construction for empty input
+      this.spatialIndex = null
+      return
+    }
+
     this.spatialIndex = new Flatbush(chips.length)
 
     for (const chip of this.chips) {
@@ -37,6 +44,7 @@ export class ChipObstacleSpatialIndex {
   }
 
   getChipsInBounds(bounds: Bounds): Array<InputChip & { bounds: Bounds }> {
+    if (!this.spatialIndex) return []
     const chipSpatialIndexIds = this.spatialIndex.search(
       bounds.minX,
       bounds.minY,

--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -68,7 +68,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     this.pinMap = getPinMap(params.inputProblem)
     this.chipObstacleSpatialIndex =
       params.inputProblem._chipObstacleSpatialIndex ??
-      new ChipObstacleSpatialIndex(params.inputProblem.chips)
+      new ChipObstacleSpatialIndex(params.inputProblem.chips ?? [])
     this.maxSearchDistance = getMaxSearchDistance(params.inputProblem)
     this.queuedLabelIndices = this.getProcessableLabelIndices()
     this.setCurrentLabel(this.queuedLabelIndices[0] ?? null)
@@ -290,7 +290,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
 
   private getAvailableOrientations(label: NetLabelPlacement) {
     const effectiveNetId = label.netId ?? label.globalConnNetId
-    return this.inputProblem.availableNetLabelOrientations[effectiveNetId] ?? []
+    return (this.inputProblem.availableNetLabelOrientations ?? {})[effectiveNetId] ?? []
   }
 
   private findValidShiftedCandidate(
@@ -627,36 +627,36 @@ export class AvailableNetOrientationSolver extends BaseSolver {
 
   private getNetLabelWidth(label: NetLabelPlacement) {
     if (label.netId) {
-      const ncWidth = this.inputProblem.netConnections.find(
+      const ncWidth = (this.inputProblem.netConnections ?? []).find(
         (connection) => connection.netId === label.netId,
       )?.netLabelWidth
       if (ncWidth !== undefined) return ncWidth
 
-      const dcWidthByNetId = this.inputProblem.directConnections.find(
+      const dcWidthByNetId = (this.inputProblem.directConnections ?? []).find(
         (dc) => dc.netId === label.netId,
       )?.netLabelWidth
       if (dcWidthByNetId !== undefined) return dcWidthByNetId
     }
 
-    const dcWidthByPinId = this.inputProblem.directConnections.find((dc) =>
-      dc.pinIds.some((pid) => label.pinIds.includes(pid)),
+    const dcWidthByPinId = (this.inputProblem.directConnections ?? []).find(
+      (dc) => dc.pinIds.some((pid) => label.pinIds.includes(pid)),
     )?.netLabelWidth
     if (dcWidthByPinId !== undefined) return dcWidthByPinId
 
-    return this.inputProblem.netConnections.find((nc) =>
+    return (this.inputProblem.netConnections ?? []).find((nc) =>
       nc.pinIds.some((pid) => label.pinIds.includes(pid)),
     )?.netLabelWidth
   }
 
   private getNetLabelHeight(label: NetLabelPlacement) {
     if (label.netId) {
-      const ncHeight = this.inputProblem.netConnections.find(
+      const ncHeight = (this.inputProblem.netConnections ?? []).find(
         (connection) => connection.netId === label.netId,
       )?.netLabelHeight
       if (ncHeight !== undefined) return ncHeight
     }
 
-    return this.inputProblem.netConnections.find((nc) =>
+    return (this.inputProblem.netConnections ?? []).find((nc) =>
       nc.pinIds.some((pid) => label.pinIds.includes(pid)),
     )?.netLabelHeight
   }

--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -290,7 +290,10 @@ export class AvailableNetOrientationSolver extends BaseSolver {
 
   private getAvailableOrientations(label: NetLabelPlacement) {
     const effectiveNetId = label.netId ?? label.globalConnNetId
-    return (this.inputProblem.availableNetLabelOrientations ?? {})[effectiveNetId] ?? []
+    return (
+      (this.inputProblem.availableNetLabelOrientations ?? {})[effectiveNetId] ??
+      []
+    )
   }
 
   private findValidShiftedCandidate(

--- a/lib/solvers/AvailableNetOrientationSolver/geometry.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/geometry.ts
@@ -212,7 +212,7 @@ const sameY = (a: Point, b: Point) => Math.abs(a.y - b.y) <= EPS
 
 export const getMaxSearchDistance = (inputProblem: InputProblem) => {
   const maxChipWidth = Math.max(
-    ...inputProblem.chips.map((chip) => chip.width),
+    ...(inputProblem.chips ?? []).map((chip) => chip.width),
     1,
   )
   return maxChipWidth * 3

--- a/lib/solvers/AvailableNetOrientationSolver/traces.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/traces.ts
@@ -5,7 +5,7 @@ import type { CandidateLabel } from "./types"
 
 export const getPinMap = (inputProblem: InputProblem) => {
   const pinMap: Record<string, InputPin & { chipId: string }> = {}
-  for (const chip of inputProblem.chips) {
+  for (const chip of inputProblem.chips ?? []) {
     for (const pin of chip.pins) {
       pinMap[pin.pinId] = { ...pin, chipId: chip.chipId }
     }

--- a/lib/solvers/Example28Solver/Example28Solver.ts
+++ b/lib/solvers/Example28Solver/Example28Solver.ts
@@ -139,7 +139,7 @@ export class Example28Solver extends BaseSolver {
   private hasExplicitOrientationConstraint(label: NetLabelPlacement) {
     const effectiveNetId = label.netId ?? label.globalConnNetId
     return Object.hasOwn(
-      this.inputProblem.availableNetLabelOrientations,
+      this.inputProblem.availableNetLabelOrientations ?? {},
       effectiveNetId,
     )
   }

--- a/lib/solvers/GuidelinesSolver/GuidelinesSolver.ts
+++ b/lib/solvers/GuidelinesSolver/GuidelinesSolver.ts
@@ -60,7 +60,7 @@ export class GuidelinesSolver extends BaseSolver {
       },
     ]
     this.chipPairsGenerator = getGeneratorForAllChipPairs(
-      this.inputProblem.chips,
+      this.inputProblem.chips ?? [],
     )
 
     this.usedXGuidelines = new Set()

--- a/lib/solvers/GuidelinesSolver/getInputProblemBounds.ts
+++ b/lib/solvers/GuidelinesSolver/getInputProblemBounds.ts
@@ -8,7 +8,7 @@ export const getInputProblemBounds = (inputProblem: InputProblem) => {
     minY: Infinity,
     maxY: -Infinity,
   }
-  for (const chip of inputProblem.chips) {
+  for (const chip of inputProblem.chips ?? []) {
     const chipBounds = getInputChipBounds(chip)
     bounds.minX = Math.min(bounds.minX, chipBounds.minX)
     bounds.maxX = Math.max(bounds.maxX, chipBounds.maxX)

--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -60,7 +60,7 @@ export class LongDistancePairSolver extends BaseSolver {
     const { netConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
     this.netConnMap = netConnMap
     const pinMap = new Map<PinId, InputPin & { chipId: string }>()
-    for (const chip of inputProblem.chips) {
+    for (const chip of inputProblem.chips ?? []) {
       this.chipMap[chip.chipId] = chip
       for (const pin of chip.pins) {
         pinMap.set(pin.pinId, { ...pin, chipId: chip.chipId })

--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -63,6 +63,7 @@ export class MspConnectionPairSolver extends BaseSolver {
     // Build a mapping from PinId to user-provided netId (if any)
     this.userNetIdByPinId = {}
     for (const dc of inputProblem.directConnections ?? []) {
+      if (!dc) continue
       if (dc.netId) {
         const [a, b] = dc.pinIds
         this.userNetIdByPinId[a] = dc.netId
@@ -70,6 +71,7 @@ export class MspConnectionPairSolver extends BaseSolver {
       }
     }
     for (const nc of inputProblem.netConnections ?? []) {
+      if (!nc) continue
       for (const pid of nc.pinIds) {
         this.userNetIdByPinId[pid] = nc.netId
       }

--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -49,27 +49,27 @@ export class MspConnectionPairSolver extends BaseSolver {
     this.globalConnMap = netConnMap
 
     this.pinMap = {}
-    for (const chip of inputProblem.chips) {
+    for (const chip of inputProblem.chips ?? []) {
       for (const pin of chip.pins) {
         this.pinMap[pin.pinId] = { ...pin, chipId: chip.chipId }
       }
     }
 
     this.chipMap = {}
-    for (const chip of inputProblem.chips) {
+    for (const chip of inputProblem.chips ?? []) {
       this.chipMap[chip.chipId] = chip
     }
 
     // Build a mapping from PinId to user-provided netId (if any)
     this.userNetIdByPinId = {}
-    for (const dc of inputProblem.directConnections) {
+    for (const dc of inputProblem.directConnections ?? []) {
       if (dc.netId) {
         const [a, b] = dc.pinIds
         this.userNetIdByPinId[a] = dc.netId
         this.userNetIdByPinId[b] = dc.netId
       }
     }
-    for (const nc of inputProblem.netConnections) {
+    for (const nc of inputProblem.netConnections ?? []) {
       for (const pid of nc.pinIds) {
         this.userNetIdByPinId[pid] = nc.netId
       }

--- a/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
+++ b/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
@@ -6,7 +6,7 @@ export const getConnectivityMapsFromInputProblem = (
 ): { directConnMap: ConnectivityMap; netConnMap: ConnectivityMap } => {
   const directConnMap = new ConnectivityMap({})
 
-  for (const directConn of inputProblem.directConnections) {
+  for (const directConn of inputProblem.directConnections ?? []) {
     directConnMap.addConnections([
       directConn.netId
         ? [directConn.netId, ...directConn.pinIds]
@@ -16,7 +16,7 @@ export const getConnectivityMapsFromInputProblem = (
 
   const netConnMap = new ConnectivityMap(directConnMap.netMap)
 
-  for (const netConn of inputProblem.netConnections) {
+  for (const netConn of inputProblem.netConnections ?? []) {
     netConnMap.addConnections([[netConn.netId, ...netConn.pinIds]])
   }
 

--- a/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
+++ b/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
@@ -7,6 +7,7 @@ export const getConnectivityMapsFromInputProblem = (
   const directConnMap = new ConnectivityMap({})
 
   for (const directConn of inputProblem.directConnections ?? []) {
+    if (!directConn) continue
     directConnMap.addConnections([
       directConn.netId
         ? [directConn.netId, ...directConn.pinIds]
@@ -17,6 +18,7 @@ export const getConnectivityMapsFromInputProblem = (
   const netConnMap = new ConnectivityMap(directConnMap.netMap)
 
   for (const netConn of inputProblem.netConnections ?? []) {
+    if (!netConn) continue
     netConnMap.addConnections([[netConn.netId, ...netConn.pinIds]])
   }
 

--- a/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
+++ b/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
@@ -123,7 +123,7 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
     this.outputNetLabelPlacements = [...params.netLabelPlacements]
     this.chipIndex =
       params.inputProblem._chipObstacleSpatialIndex ??
-      new ChipObstacleSpatialIndex(params.inputProblem.chips)
+      new ChipObstacleSpatialIndex(params.inputProblem.chips ?? [])
     this.traceMap = Object.fromEntries(
       params.traces.map((t) => [t.mspPairId, t]),
     ) as Record<MspConnectionPairId, SolvedTracePath>

--- a/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
@@ -109,7 +109,7 @@ export class NetLabelPlacementSolver extends BaseSolver {
     )
 
     const pinIdToPinMap = new Map<string, unknown>()
-    for (const chip of this.inputProblem.chips) {
+    for (const chip of this.inputProblem.chips ?? []) {
       for (const pin of chip.pins) {
         pinIdToPinMap.set(pin.pinId, pin)
       }
@@ -117,14 +117,14 @@ export class NetLabelPlacementSolver extends BaseSolver {
 
     // Map pins to user-provided netIds (if any)
     const userNetIdByPinId: Record<string, string | undefined> = {}
-    for (const dc of this.inputProblem.directConnections) {
+    for (const dc of this.inputProblem.directConnections ?? []) {
       if (dc.netId) {
         const [a, b] = dc.pinIds
         userNetIdByPinId[a] = dc.netId
         userNetIdByPinId[b] = dc.netId
       }
     }
-    for (const nc of this.inputProblem.netConnections) {
+    for (const nc of this.inputProblem.netConnections ?? []) {
       for (const pid of nc.pinIds) {
         userNetIdByPinId[pid] = nc.netId
       }
@@ -132,7 +132,7 @@ export class NetLabelPlacementSolver extends BaseSolver {
 
     const groups: Array<OverlappingSameNetTraceGroup> = []
 
-    const allPinIds = this.inputProblem.chips.flatMap((c) =>
+    const allPinIds = (this.inputProblem.chips ?? []).flatMap((c) =>
       c.pins.map((p) => p.pinId),
     )
 
@@ -255,12 +255,12 @@ export class NetLabelPlacementSolver extends BaseSolver {
     group: OverlappingSameNetTraceGroup,
   ): number | undefined {
     if (group.netId) {
-      const ncWidth = this.inputProblem.netConnections.find(
+      const ncWidth = (this.inputProblem.netConnections ?? []).find(
         (nc) => nc.netId === group.netId,
       )?.netLabelWidth
       if (ncWidth !== undefined) return ncWidth
 
-      const dcWidthByNetId = this.inputProblem.directConnections.find(
+      const dcWidthByNetId = (this.inputProblem.directConnections ?? []).find(
         (dc) => dc.netId === group.netId,
       )?.netLabelWidth
       if (dcWidthByNetId !== undefined) return dcWidthByNetId
@@ -271,12 +271,12 @@ export class NetLabelPlacementSolver extends BaseSolver {
       pinIds.push(group.portOnlyPinId)
     }
 
-    const dcWidthByPinId = this.inputProblem.directConnections.find((dc) =>
-      dc.pinIds.some((pid) => pinIds.includes(pid)),
+    const dcWidthByPinId = (this.inputProblem.directConnections ?? []).find(
+      (dc) => dc.pinIds.some((pid) => pinIds.includes(pid)),
     )?.netLabelWidth
     if (dcWidthByPinId !== undefined) return dcWidthByPinId
 
-    return this.inputProblem.netConnections.find((nc) =>
+    return (this.inputProblem.netConnections ?? []).find((nc) =>
       nc.pinIds.some((pid) => pinIds.includes(pid)),
     )?.netLabelWidth
   }
@@ -285,7 +285,7 @@ export class NetLabelPlacementSolver extends BaseSolver {
     group: OverlappingSameNetTraceGroup,
   ): number | undefined {
     if (group.netId) {
-      const ncHeight = this.inputProblem.netConnections.find(
+      const ncHeight = (this.inputProblem.netConnections ?? []).find(
         (nc) => nc.netId === group.netId,
       )?.netLabelHeight
       if (ncHeight !== undefined) return ncHeight
@@ -296,7 +296,7 @@ export class NetLabelPlacementSolver extends BaseSolver {
       pinIds.push(group.portOnlyPinId)
     }
 
-    return this.inputProblem.netConnections.find((nc) =>
+    return (this.inputProblem.netConnections ?? []).find((nc) =>
       nc.pinIds.some((pid) => pinIds.includes(pid)),
     )?.netLabelHeight
   }
@@ -374,7 +374,7 @@ export class NetLabelPlacementSolver extends BaseSolver {
       inputProblem: this.inputProblem,
       inputTraceMap: this.inputTraceMap,
       overlappingSameNetTraceGroup: nextOverlappingSameNetTraceGroup,
-      availableOrientations: this.inputProblem.availableNetLabelOrientations[
+      availableOrientations: (this.inputProblem.availableNetLabelOrientations ?? {})[
         netId
       ] ?? ["x+", "x-", "y+", "y-"],
       netLabelWidth,

--- a/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
@@ -374,9 +374,8 @@ export class NetLabelPlacementSolver extends BaseSolver {
       inputProblem: this.inputProblem,
       inputTraceMap: this.inputTraceMap,
       overlappingSameNetTraceGroup: nextOverlappingSameNetTraceGroup,
-      availableOrientations: (this.inputProblem.availableNetLabelOrientations ?? {})[
-        netId
-      ] ?? ["x+", "x-", "y+", "y-"],
+      availableOrientations: (this.inputProblem.availableNetLabelOrientations ??
+        {})[netId] ?? ["x+", "x-", "y+", "y-"],
       netLabelWidth,
       netLabelHeight,
     })

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver.ts
@@ -98,7 +98,7 @@ export class SingleNetLabelPlacementSolver extends BaseSolver {
 
     this.chipObstacleSpatialIndex =
       params.inputProblem._chipObstacleSpatialIndex ??
-      new ChipObstacleSpatialIndex(params.inputProblem.chips)
+      new ChipObstacleSpatialIndex(params.inputProblem.chips ?? [])
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/host.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/host.ts
@@ -27,7 +27,7 @@ export function chooseHostTraceForGroup(params: {
     mspConnectionPairIds,
   } = params
   const chipsById: Record<string, InputChip> = Object.fromEntries(
-    inputProblem.chips.map((c) => [c.chipId, c]),
+    (inputProblem.chips ?? []).map((c) => [c.chipId, c]),
   )
 
   let groupTraces = Object.values(inputTraceMap).filter(

--- a/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/solvePortOnlyPin.ts
+++ b/lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/solvePortOnlyPin.ts
@@ -65,7 +65,7 @@ export function solveNetLabelPlacementForPortOnlyPin(params: {
   // Find pin coordinates and facing direction
   let pin: { x: number; y: number } | null = null
   let pinFacingDirection: FacingDirection | null = null
-  for (const chip of inputProblem.chips) {
+  for (const chip of inputProblem.chips ?? []) {
     const p = chip.pins.find((pp) => pp.pinId === pinId)
     if (p) {
       pin = { x: p.x, y: p.y }

--- a/lib/solvers/RailNetLabelCornerPlacementSolver/RailNetLabelCornerPlacementSolver.ts
+++ b/lib/solvers/RailNetLabelCornerPlacementSolver/RailNetLabelCornerPlacementSolver.ts
@@ -209,7 +209,7 @@ export class RailNetLabelCornerPlacementSolver extends BaseSolver {
   }
 
   private intersectsAnyChip(bounds: Bounds) {
-    return this.inputProblem.chips.some((chip) =>
+    return (this.inputProblem.chips ?? []).some((chip) =>
       rectsOverlap(bounds, getRectBounds(chip.center, chip.width, chip.height)),
     )
   }

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/SchematicTraceSingleLineSolver.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/SchematicTraceSingleLineSolver.ts
@@ -56,7 +56,7 @@ export class SchematicTraceSingleLineSolver extends BaseSolver {
     this.chipMap = params.chipMap
     this.chipObstacleSpatialIndex =
       this.inputProblem._chipObstacleSpatialIndex ||
-      new ChipObstacleSpatialIndex(this.inputProblem.chips)
+      new ChipObstacleSpatialIndex(this.inputProblem.chips ?? [])
 
     if (!this.inputProblem._chipObstacleSpatialIndex) {
       this.inputProblem._chipObstacleSpatialIndex =
@@ -64,7 +64,7 @@ export class SchematicTraceSingleLineSolver extends BaseSolver {
     }
 
     // Build a lookup of all pins by id and attach chipId to each pin entry
-    for (const chip of this.inputProblem.chips) {
+    for (const chip of this.inputProblem.chips ?? []) {
       for (const pin of chip.pins) {
         this.pinIdMap.set(pin.pinId, { ...pin, chipId: chip.chipId })
       }

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
@@ -131,7 +131,7 @@ export class SchematicTraceSingleLineSolver2 extends BaseSolver {
     if (!netId) return {}
 
     const orientations =
-      this.inputProblem.availableNetLabelOrientations[netId] ??
+      (this.inputProblem.availableNetLabelOrientations ?? {})[netId] ??
       (["x+", "x-", "y+", "y-"] as FacingDirection[])
     const netLabelWidth = this.getNetLabelWidthForConnectionPair(netId)
     const netLabelHeight = this.getNetLabelHeightForConnectionPair(netId)
@@ -172,35 +172,35 @@ export class SchematicTraceSingleLineSolver2 extends BaseSolver {
   }
 
   private getNetLabelWidthForConnectionPair(netId: string) {
-    const ncWidth = this.inputProblem.netConnections.find(
+    const ncWidth = (this.inputProblem.netConnections ?? []).find(
       (nc) => nc.netId === netId,
     )?.netLabelWidth
     if (ncWidth !== undefined) return ncWidth
 
-    const dcWidthByNetId = this.inputProblem.directConnections.find(
+    const dcWidthByNetId = (this.inputProblem.directConnections ?? []).find(
       (dc) => dc.netId === netId,
     )?.netLabelWidth
     if (dcWidthByNetId !== undefined) return dcWidthByNetId
 
     const pinIds = this.pins.map((p) => p.pinId)
-    const dcWidthByPinId = this.inputProblem.directConnections.find((dc) =>
-      dc.pinIds.some((pid) => pinIds.includes(pid)),
+    const dcWidthByPinId = (this.inputProblem.directConnections ?? []).find(
+      (dc) => dc.pinIds.some((pid) => pinIds.includes(pid)),
     )?.netLabelWidth
     if (dcWidthByPinId !== undefined) return dcWidthByPinId
 
-    return this.inputProblem.netConnections.find((nc) =>
+    return (this.inputProblem.netConnections ?? []).find((nc) =>
       nc.pinIds.some((pid) => pinIds.includes(pid)),
     )?.netLabelWidth
   }
 
   private getNetLabelHeightForConnectionPair(netId: string) {
-    const ncHeight = this.inputProblem.netConnections.find(
+    const ncHeight = (this.inputProblem.netConnections ?? []).find(
       (nc) => nc.netId === netId,
     )?.netLabelHeight
     if (ncHeight !== undefined) return ncHeight
 
     const pinIds = this.pins.map((p) => p.pinId)
-    return this.inputProblem.netConnections.find((nc) =>
+    return (this.inputProblem.netConnections ?? []).find((nc) =>
       nc.pinIds.some((pid) => pinIds.includes(pid)),
     )?.netLabelHeight
   }

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect.ts
@@ -30,7 +30,7 @@ export const getObstacleRects = (
   problem: InputProblem,
   opts: { textBoxPadding?: RectPadding } = {},
 ): ObstacleRect[] => {
-  const chipRects = problem.chips.map(chipToRect)
+  const chipRects = (problem.chips ?? []).map(chipToRect)
   const textBoxRects = (problem.textBoxes ?? []).map((textBox) => {
     const b = getTextBoxBounds(textBox, opts.textBoxPadding)
     return {

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -344,6 +344,11 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       _hideRatsNet: this.hideRatsNet,
     })
 
+    // Ensure required array fields are present even when caller omits them
+    cloned.chips ??= []
+    cloned.directConnections ??= []
+    cloned.netConnections ??= []
+
     // First, expand chips so existing pin coordinates sit on or within their edges without shrinking.
     expandChipsToFitPins(cloned)
     // Then, for any remaining pins that are still inside due to mixed extremes, snap them to the nearest edge.

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -344,11 +344,23 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       _hideRatsNet: this.hideRatsNet,
     })
 
-    // Ensure required array/object fields are present even when caller omits them
-    cloned.chips ??= []
-    cloned.directConnections ??= []
-    cloned.netConnections ??= []
-    cloned.availableNetLabelOrientations ??= {}
+    // Ensure required array/object fields are present even when caller passes
+    // a non-array (e.g. null, a number) instead of an array/object.
+    // Also filter out any null/undefined elements within the arrays so
+    // downstream solvers never encounter sparse/corrupted entries.
+    cloned.chips = Array.isArray(cloned.chips) ? cloned.chips.filter(Boolean) : []
+    cloned.directConnections = Array.isArray(cloned.directConnections)
+      ? cloned.directConnections.filter(Boolean)
+      : []
+    cloned.netConnections = Array.isArray(cloned.netConnections)
+      ? cloned.netConnections.filter(Boolean)
+      : []
+    cloned.availableNetLabelOrientations =
+      cloned.availableNetLabelOrientations != null &&
+      typeof cloned.availableNetLabelOrientations === "object" &&
+      !Array.isArray(cloned.availableNetLabelOrientations)
+        ? cloned.availableNetLabelOrientations
+        : {}
 
     // First, expand chips so existing pin coordinates sit on or within their edges without shrinking.
     expandChipsToFitPins(cloned)

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -348,7 +348,9 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     // a non-array (e.g. null, a number) instead of an array/object.
     // Also filter out any null/undefined elements within the arrays so
     // downstream solvers never encounter sparse/corrupted entries.
-    cloned.chips = Array.isArray(cloned.chips) ? cloned.chips.filter(Boolean) : []
+    cloned.chips = Array.isArray(cloned.chips)
+      ? cloned.chips.filter(Boolean)
+      : []
     cloned.directConnections = Array.isArray(cloned.directConnections)
       ? cloned.directConnections.filter(Boolean)
       : []

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -344,10 +344,11 @@ export class SchematicTracePipelineSolver extends BaseSolver {
       _hideRatsNet: this.hideRatsNet,
     })
 
-    // Ensure required array fields are present even when caller omits them
+    // Ensure required array/object fields are present even when caller omits them
     cloned.chips ??= []
     cloned.directConnections ??= []
     cloned.netConnections ??= []
+    cloned.availableNetLabelOrientations ??= {}
 
     // First, expand chips so existing pin coordinates sit on or within their edges without shrinking.
     expandChipsToFitPins(cloned)

--- a/lib/solvers/SchematicTracePipelineSolver/colorAvailableNetOrientationLabels.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/colorAvailableNetOrientationLabels.ts
@@ -35,6 +35,7 @@ const getAvailableOrientationsForRect = (
   label: string | undefined,
   availableOrientations: InputProblem["availableNetLabelOrientations"],
 ) => {
+  if (!availableOrientations) return undefined
   for (const netId of getNetIdsFromRectLabel(label)) {
     if (Object.hasOwn(availableOrientations, netId)) {
       return availableOrientations[netId]

--- a/lib/solvers/SchematicTracePipelineSolver/correctPinsInsideChip.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/correctPinsInsideChip.ts
@@ -2,7 +2,7 @@ import type { InputProblem } from "lib/types/InputProblem"
 import { getInputChipBounds } from "../GuidelinesSolver/getInputChipBounds"
 
 export const correctPinsInsideChips = (problem: InputProblem) => {
-  for (const chip of problem.chips) {
+  for (const chip of problem.chips ?? []) {
     const bounds = getInputChipBounds(chip)
     for (const pin of chip.pins) {
       const isInside =

--- a/lib/solvers/SchematicTracePipelineSolver/expandChipsToFitPins.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/expandChipsToFitPins.ts
@@ -11,7 +11,7 @@ import type { InputProblem } from "lib/types/InputProblem"
  * - Clears cached _facingDirection on pins since geometry changed.
  */
 export const expandChipsToFitPins = (problem: InputProblem) => {
-  for (const chip of problem.chips) {
+  for (const chip of problem.chips ?? []) {
     const halfWidth = chip.width / 2
     const halfHeight = chip.height / 2
 

--- a/lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem.ts
@@ -27,13 +27,13 @@ export const visualizeInputProblem = (
   }
 
   const pinIdMap = new Map<PinId, InputPin>()
-  for (const chip of inputProblem.chips) {
+  for (const chip of inputProblem.chips ?? []) {
     for (const pin of chip.pins) {
       pinIdMap.set(pin.pinId, pin)
     }
   }
 
-  for (const chip of inputProblem.chips) {
+  for (const chip of inputProblem.chips ?? []) {
     graphics.rects.push({
       label: chip.chipId,
       center: chip.center,
@@ -64,7 +64,7 @@ export const visualizeInputProblem = (
   }
 
   if (!hideRatsNet) {
-    for (const directConn of inputProblem.directConnections) {
+    for (const directConn of inputProblem.directConnections ?? []) {
       const [pinId1, pinId2] = directConn.pinIds
       const pin1 = pinIdMap.get(pinId1)!
       const pin2 = pinIdMap.get(pinId2)!
@@ -89,7 +89,7 @@ export const visualizeInputProblem = (
       })
     }
 
-    for (const netConn of inputProblem.netConnections) {
+    for (const netConn of inputProblem.netConnections ?? []) {
       const pins = netConn.pinIds.map((pinId) => pinIdMap.get(pinId)!)
       for (let i = 0; i < pins.length - 1; i++) {
         for (let j = i + 1; j < pins.length; j++) {

--- a/lib/solvers/TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver.ts
+++ b/lib/solvers/TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver.ts
@@ -255,7 +255,7 @@ export class TraceAnchoredNetLabelOverlapSolver extends BaseSolver {
   }
 
   private intersectsAnyChip(bounds: Bounds) {
-    return this.inputProblem.chips.some((chip) =>
+    return (this.inputProblem.chips ?? []).some((chip) =>
       rectsTouchOrOverlap(
         bounds,
         getRectBounds(chip.center, chip.width, chip.height),

--- a/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
+++ b/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
@@ -273,7 +273,7 @@ type ChipBounds = Bounds & {
 }
 
 const getChipBounds = (inputProblem: InputProblem): ChipBounds => {
-  if (inputProblem.chips.length === 0) {
+  if ((inputProblem.chips ?? []).length === 0) {
     return {
       minX: 0,
       minY: 0,
@@ -284,7 +284,7 @@ const getChipBounds = (inputProblem: InputProblem): ChipBounds => {
     }
   }
 
-  const bounds = inputProblem.chips.reduce<Bounds>(
+  const bounds = (inputProblem.chips ?? []).reduce<Bounds>(
     (acc, chip) => ({
       minX: Math.min(acc.minX, chip.center.x - chip.width / 2),
       minY: Math.min(acc.minY, chip.center.y - chip.height / 2),
@@ -310,17 +310,17 @@ const getNetLabelWidth = (
   inputProblem: InputProblem,
   label: NetLabelPlacement,
 ) => {
-  const ncWidthByNetId = inputProblem.netConnections.find(
+  const ncWidthByNetId = (inputProblem.netConnections ?? []).find(
     (connection) => connection.netId === label.netId,
   )?.netLabelWidth
   if (ncWidthByNetId !== undefined) return ncWidthByNetId
 
-  const dcWidth = inputProblem.directConnections.find((dc) =>
+  const dcWidth = (inputProblem.directConnections ?? []).find((dc) =>
     dc.pinIds.some((pid) => label.pinIds.includes(pid)),
   )?.netLabelWidth
   if (dcWidth !== undefined) return dcWidth
 
-  const ncWidthByPinId = inputProblem.netConnections.find((nc) =>
+  const ncWidthByPinId = (inputProblem.netConnections ?? []).find((nc) =>
     nc.pinIds.some((pid) => label.pinIds.includes(pid)),
   )?.netLabelWidth
   if (ncWidthByPinId !== undefined) return ncWidthByPinId
@@ -336,12 +336,12 @@ const getNetLabelHeight = (
   inputProblem: InputProblem,
   label: NetLabelPlacement,
 ): number | undefined => {
-  const ncHeightByNetId = inputProblem.netConnections.find(
+  const ncHeightByNetId = (inputProblem.netConnections ?? []).find(
     (connection) => connection.netId === label.netId,
   )?.netLabelHeight
   if (ncHeightByNetId !== undefined) return ncHeightByNetId
 
-  return inputProblem.netConnections.find((nc) =>
+  return (inputProblem.netConnections ?? []).find((nc) =>
     nc.pinIds.some((pid) => label.pinIds.includes(pid)),
   )?.netLabelHeight
 }

--- a/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
+++ b/lib/solvers/TraceCleanupSolver/sub-solver/UntangleTraceSubsolver.ts
@@ -90,7 +90,7 @@ export class UntangleTraceSubsolver extends BaseSolver {
 
     this.chipObstacleSpatialIndex =
       this.input.inputProblem._chipObstacleSpatialIndex ??
-      new ChipObstacleSpatialIndex(this.input.inputProblem.chips)
+      new ChipObstacleSpatialIndex(this.input.inputProblem.chips ?? [])
     if (!this.input.inputProblem._chipObstacleSpatialIndex) {
       this.input.inputProblem._chipObstacleSpatialIndex =
         this.chipObstacleSpatialIndex

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/LabelMergingSolver.ts
@@ -71,7 +71,7 @@ export class MergedNetLabelObstacleSolver extends BaseSolver {
       case "grouping_labels":
         this.labelGroups = groupLabelsByChipAndOrientation({
           labels: this.filteredLabels,
-          chips: this.inputProblem.chips,
+          chips: this.inputProblem.chips ?? [],
         })
         this.groupKeysToProcess = Object.keys(this.labelGroups)
         this.pipelineStep = "merging_groups"

--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -44,12 +44,12 @@ export interface InputNetConnection {
 }
 
 export interface InputProblem {
-  chips: Array<InputChip>
-  directConnections: Array<InputDirectConnection>
-  netConnections: Array<InputNetConnection>
+  chips?: Array<InputChip>
+  directConnections?: Array<InputDirectConnection>
+  netConnections?: Array<InputNetConnection>
   textBoxes?: Array<TextBoxes>
 
-  availableNetLabelOrientations: Record<NetId, FacingDirection[]>
+  availableNetLabelOrientations?: Record<NetId, FacingDirection[]>
   maxMspPairDistance?: number
 
   _chipObstacleSpatialIndex?: ChipObstacleSpatialIndex

--- a/lib/utils/arePinsInDifferentSchematicSections.ts
+++ b/lib/utils/arePinsInDifferentSchematicSections.ts
@@ -21,7 +21,7 @@ export const arePinsInDifferentSchematicSections = (
   const sectionByChipId = new Map<string, string>()
   const sectionByPinId = new Map<string, string>()
 
-  for (const chip of inputProblem.chips) {
+  for (const chip of inputProblem.chips ?? []) {
     if (!chip.sectionId) continue
 
     sectionByChipId.set(chip.chipId, chip.sectionId)

--- a/lib/utils/getOrientationConstraintKeys.ts
+++ b/lib/utils/getOrientationConstraintKeys.ts
@@ -9,7 +9,7 @@ export const getOrientationConstraintKeys = (
   dedupeStrings([
     label.netId,
     label.globalConnNetId,
-    ...inputProblem.netConnections
+    ...(inputProblem.netConnections ?? [])
       .filter((connection) =>
         label.pinIds.some((pinId) => connection.pinIds.includes(pinId)),
       )

--- a/tests/repros/repro-empty-connections.test.ts
+++ b/tests/repros/repro-empty-connections.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+
+/**
+ * Regression test for issue #657:
+ * Solver crashed with "TypeError: inputProblem.directConnections is not iterable"
+ * when connections arrays were empty or undefined.
+ */
+
+test("solver handles empty connections without crashing", () => {
+  const solver = new SchematicTracePipelineSolver({
+    chips: [],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})
+
+test("solver handles undefined connections without crashing", () => {
+  const solver = new SchematicTracePipelineSolver({
+    chips: [],
+    directConnections: undefined as any,
+    netConnections: undefined as any,
+    availableNetLabelOrientations: {},
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})
+
+test("solver handles all fields undefined without crashing", () => {
+  const solver = new SchematicTracePipelineSolver({
+    chips: undefined as any,
+    directConnections: undefined as any,
+    netConnections: undefined as any,
+    availableNetLabelOrientations: {},
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})

--- a/tests/repros/repro-empty-connections.test.ts
+++ b/tests/repros/repro-empty-connections.test.ts
@@ -18,7 +18,9 @@ test("solver handles empty connections without crashing", () => {
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
-  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
+  expect(
+    Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths),
+  ).toBe(true)
 })
 
 test("solver handles undefined connections without crashing", () => {
@@ -31,7 +33,9 @@ test("solver handles undefined connections without crashing", () => {
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
-  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
+  expect(
+    Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths),
+  ).toBe(true)
 })
 
 test("solver handles all fields undefined without crashing", () => {
@@ -44,7 +48,9 @@ test("solver handles all fields undefined without crashing", () => {
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
-  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
+  expect(
+    Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths),
+  ).toBe(true)
 })
 
 test("solver handles missing availableNetLabelOrientations without crashing", () => {
@@ -57,7 +63,9 @@ test("solver handles missing availableNetLabelOrientations without crashing", ()
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
-  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
+  expect(
+    Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths),
+  ).toBe(true)
 })
 
 test("MspConnectionPairSolver handles undefined connections directly without crashing", () => {
@@ -87,5 +95,7 @@ test("solver handles directConnections array with undefined elements without cra
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
-  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
+  expect(
+    Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths),
+  ).toBe(true)
 })

--- a/tests/repros/repro-empty-connections.test.ts
+++ b/tests/repros/repro-empty-connections.test.ts
@@ -18,30 +18,33 @@ test("solver handles empty connections without crashing", () => {
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
+  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
 })
 
 test("solver handles undefined connections without crashing", () => {
   const solver = new SchematicTracePipelineSolver({
     chips: [],
-    directConnections: undefined as any,
-    netConnections: undefined as any,
+    directConnections: undefined,
+    netConnections: undefined,
     availableNetLabelOrientations: {},
   })
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
+  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
 })
 
 test("solver handles all fields undefined without crashing", () => {
   const solver = new SchematicTracePipelineSolver({
-    chips: undefined as any,
-    directConnections: undefined as any,
-    netConnections: undefined as any,
+    chips: undefined,
+    directConnections: undefined,
+    netConnections: undefined,
     availableNetLabelOrientations: {},
   })
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
+  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
 })
 
 test("solver handles missing availableNetLabelOrientations without crashing", () => {
@@ -49,23 +52,40 @@ test("solver handles missing availableNetLabelOrientations without crashing", ()
     chips: [],
     directConnections: [],
     netConnections: [],
-    availableNetLabelOrientations: undefined as any,
+    availableNetLabelOrientations: undefined,
   })
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
+  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
 })
 
 test("MspConnectionPairSolver handles undefined connections directly without crashing", () => {
   const solver = new MspConnectionPairSolver({
     inputProblem: {
-      chips: undefined as any,
-      directConnections: undefined as any,
-      netConnections: undefined as any,
+      chips: undefined,
+      directConnections: undefined,
+      netConnections: undefined,
       availableNetLabelOrientations: {},
     },
   })
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
+  expect(Array.isArray(solver.mspConnectionPairs)).toBe(true)
+})
+
+test("solver handles directConnections array with undefined elements without crashing", () => {
+  // Intentional as any: we deliberately pass a sparse/corrupted array to prove
+  // the element-level null guards (Fix E) protect against individual null entries.
+  const solver = new SchematicTracePipelineSolver({
+    chips: [],
+    directConnections: [undefined] as any,
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
 })

--- a/tests/repros/repro-empty-connections.test.ts
+++ b/tests/repros/repro-empty-connections.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { MspConnectionPairSolver } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
 import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 
 /**
@@ -37,6 +38,32 @@ test("solver handles all fields undefined without crashing", () => {
     directConnections: undefined as any,
     netConnections: undefined as any,
     availableNetLabelOrientations: {},
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})
+
+test("solver handles missing availableNetLabelOrientations without crashing", () => {
+  const solver = new SchematicTracePipelineSolver({
+    chips: [],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: undefined as any,
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})
+
+test("MspConnectionPairSolver handles undefined connections directly without crashing", () => {
+  const solver = new MspConnectionPairSolver({
+    inputProblem: {
+      chips: undefined as any,
+      directConnections: undefined as any,
+      netConnections: undefined as any,
+      availableNetLabelOrientations: {},
+    },
   })
   solver.solve()
   expect(solver.solved).toBe(true)

--- a/tests/repros/small-variant-resistor-facing-direction.test.ts
+++ b/tests/repros/small-variant-resistor-facing-direction.test.ts
@@ -17,7 +17,7 @@ test("small-variant resistor with facing directions routes from the sides", () =
 
   solver.solve()
 
-  const resistor = solver.inputProblem.chips.find(
+  const resistor = (solver.inputProblem.chips ?? []).find(
     (c) => c.chipId === "schematic_component_1",
   )!
   // Terminals keep their symbol-provided facing instead of being re-detected as

--- a/tests/solvers/SchematicTracePipelineSolver/empty-connections.test.ts
+++ b/tests/solvers/SchematicTracePipelineSolver/empty-connections.test.ts
@@ -17,7 +17,9 @@ test("pipeline solver handles empty directConnections and netConnections", () =>
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
-  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
+  expect(
+    Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths),
+  ).toBe(true)
 })
 
 test("pipeline solver handles undefined directConnections and netConnections", () => {
@@ -30,5 +32,7 @@ test("pipeline solver handles undefined directConnections and netConnections", (
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
-  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
+  expect(
+    Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths),
+  ).toBe(true)
 })

--- a/tests/solvers/SchematicTracePipelineSolver/empty-connections.test.ts
+++ b/tests/solvers/SchematicTracePipelineSolver/empty-connections.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+
+/**
+ * Regression tests for issue #657:
+ * Solver crashed with "TypeError: inputProblem.directConnections is not iterable"
+ * when directConnections or netConnections were undefined or empty.
+ */
+
+test("pipeline solver handles empty directConnections and netConnections", () => {
+  const solver = new SchematicTracePipelineSolver({
+    chips: [],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})
+
+test("pipeline solver handles undefined directConnections and netConnections", () => {
+  const solver = new SchematicTracePipelineSolver({
+    chips: [],
+    directConnections: undefined as any,
+    netConnections: undefined as any,
+    availableNetLabelOrientations: {},
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})

--- a/tests/solvers/SchematicTracePipelineSolver/empty-connections.test.ts
+++ b/tests/solvers/SchematicTracePipelineSolver/empty-connections.test.ts
@@ -17,16 +17,18 @@ test("pipeline solver handles empty directConnections and netConnections", () =>
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
+  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
 })
 
 test("pipeline solver handles undefined directConnections and netConnections", () => {
   const solver = new SchematicTracePipelineSolver({
     chips: [],
-    directConnections: undefined as any,
-    netConnections: undefined as any,
+    directConnections: undefined,
+    netConnections: undefined,
     availableNetLabelOrientations: {},
   })
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
+  expect(Array.isArray(solver.schematicTraceLinesSolver?.solvedTracePaths)).toBe(true)
 })


### PR DESCRIPTION
## Summary

Fixes #657. Solvers threw `TypeError: ... is not iterable` or `Error: Unexpected numItems value: 0` when `chips`, `directConnections`, or `netConnections` were empty or `undefined`.

- Normalize `chips`, `directConnections`, and `netConnections` to `[]` in `cloneAndCorrectInputProblem` â€” the single pipeline entry point, so all downstream solvers receive valid arrays
- Add `?? []` fallbacks in `getConnectivityMapsFromInputProblem` as defense-in-depth (this function can also be called independently)
- Guard `ChipObstacleSpatialIndex` against `chips.length === 0` â€” Flatbush throws when constructed with 0 items; skip index construction and return early
- Type `spatialIndex` as `Flatbush | null` (was `Flatbush`) and guard `getChipsInBounds` against `null`

## Test plan

- [ ] `bun test tests/repros/repro-empty-connections.test.ts` â€” 3 new regression tests (empty arrays, undefined connections, all fields undefined)
- [ ] `bun test tests/examples/` â€” 50 existing example tests still pass
- [ ] `bun test tests/repros/` â€” all existing repro tests still pass
- [ ] `bunx tsc --noEmit` â€” no type errors
