### PR TITLE
Add empty-connections early-return guards to all pipeline solvers

### DIFF
--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -52,8 +52,8 @@ export class AvailableNetOrientationSolver extends BaseSolver {
   currentCandidateResults: EvaluatedCandidate[] = []
 
   private traceMap: Record<string, SolvedTracePath>
-  private chipObstacleSpatialIndex: ChipObstacleSpatialIndex
-  private maxSearchDistance: number
+  private chipObstacleSpatialIndex!: ChipObstacleSpatialIndex
+  private maxSearchDistance!: number
   private pinMap: Record<string, InputPin & { chipId: string }>
 
   constructor(params: AvailableNetOrientationSolverParams) {
@@ -66,6 +66,15 @@ export class AvailableNetOrientationSolver extends BaseSolver {
       this.traces.map((trace) => [trace.mspPairId, trace]),
     )
     this.pinMap = getPinMap(params.inputProblem)
+
+    if (this.outputNetLabelPlacements.length === 0) {
+      // No labels to reorient; solve immediately with an empty result.
+      // This also avoids building a chip obstacle spatial index for an
+      // empty chip set (Flatbush cannot be constructed with zero items).
+      this.solved = true
+      return
+    }
+
     this.chipObstacleSpatialIndex =
       params.inputProblem._chipObstacleSpatialIndex ??
       new ChipObstacleSpatialIndex(params.inputProblem.chips)

--- a/lib/solvers/Example28Solver/Example28Solver.ts
+++ b/lib/solvers/Example28Solver/Example28Solver.ts
@@ -67,6 +67,11 @@ export class Example28Solver extends BaseSolver {
     this.pinMap = getPinMap(params.inputProblem)
     this.initializeQueuedOverlaps()
     this.currentOverlap = this.queuedOverlaps[0] ?? null
+
+    if (this.traces.length === 0) {
+      // No traces to reroute; solve immediately with an empty result.
+      this.solved = true
+    }
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
+++ b/lib/solvers/LongDistancePairSolver/LongDistancePairSolver.ts
@@ -123,6 +123,11 @@ export class LongDistancePairSolver extends BaseSolver {
       }
     }
     this.queuedCandidatePairs = candidatePairs
+
+    if (this.queuedCandidatePairs.length === 0) {
+      // No candidate pairs to route; solve immediately with an empty result.
+      this.solved = true
+    }
   }
 
   override getConstructorParams() {

--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -76,6 +76,14 @@ export class MspConnectionPairSolver extends BaseSolver {
     }
 
     this.queuedDcNetIds = Object.keys(netConnMap.netMap)
+
+    if (
+      inputProblem.directConnections.length === 0 &&
+      inputProblem.netConnections.length === 0
+    ) {
+      // No connections to route; solve immediately with an empty result.
+      this.solved = true
+    }
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
+++ b/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
@@ -107,7 +107,7 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
   currentLabelToMove: NetLabelPlacement | null = null
   candidateResults: Candidate[] = []
 
-  private chipIndex: ChipObstacleSpatialIndex
+  private chipIndex!: ChipObstacleSpatialIndex
   private traceMap: Record<MspConnectionPairId, SolvedTracePath>
   private skippedCollisionKeys = new Set<string>()
 
@@ -121,12 +121,21 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
     this.traces = params.traces
     this.netLabelPlacements = params.netLabelPlacements
     this.outputNetLabelPlacements = [...params.netLabelPlacements]
-    this.chipIndex =
-      params.inputProblem._chipObstacleSpatialIndex ??
-      new ChipObstacleSpatialIndex(params.inputProblem.chips)
     this.traceMap = Object.fromEntries(
       params.traces.map((t) => [t.mspPairId, t]),
     ) as Record<MspConnectionPairId, SolvedTracePath>
+
+    if (this.outputNetLabelPlacements.length === 0) {
+      // No labels to collide; solve immediately with an empty result.
+      // This also avoids building a chip obstacle spatial index for an
+      // empty chip set (Flatbush cannot be constructed with zero items).
+      this.solved = true
+      return
+    }
+
+    this.chipIndex =
+      params.inputProblem._chipObstacleSpatialIndex ??
+      new ChipObstacleSpatialIndex(params.inputProblem.chips)
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
@@ -92,6 +92,11 @@ export class NetLabelPlacementSolver extends BaseSolver {
     this.queuedOverlappingSameNetTraceGroups = [
       ...this.overlappingSameNetTraceGroups,
     ]
+
+    if (this.queuedOverlappingSameNetTraceGroups.length === 0) {
+      // No connection nets to label; solve immediately with an empty result.
+      this.solved = true
+    }
   }
 
   computeOverlappingSameNetTraceGroups(): Array<OverlappingSameNetTraceGroup> {

--- a/lib/solvers/NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver.ts
+++ b/lib/solvers/NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver.ts
@@ -189,6 +189,15 @@ export class NetLabelTraceCollisionSolver extends BaseSolver {
     this.netLabelPlacements = params.netLabelPlacements
     this.outputTraces = [...params.traces]
     this.outputNetLabelPlacements = [...params.netLabelPlacements]
+
+    if (
+      this.outputTraces.length === 0 ||
+      this.outputNetLabelPlacements.length === 0
+    ) {
+      // Trace/label collisions require both traces and labels; solve
+      // immediately with an empty result.
+      this.solved = true
+    }
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/lib/solvers/RailNetLabelCornerPlacementSolver/RailNetLabelCornerPlacementSolver.ts
+++ b/lib/solvers/RailNetLabelCornerPlacementSolver/RailNetLabelCornerPlacementSolver.ts
@@ -51,6 +51,14 @@ export class RailNetLabelCornerPlacementSolver extends BaseSolver {
       params.traces.map((trace) => [trace.mspPairId, trace]),
     )
     this.queuedLabelIndices = this.getProcessableLabelIndices()
+
+    if (this.queuedLabelIndices.length === 0) {
+      // No labels need corner placement; solve immediately, leaving the
+      // input labels unchanged.
+      this.solved = true
+      return
+    }
+
     this.prepareNextLabel()
   }
 

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver.ts
@@ -50,6 +50,11 @@ export class SchematicTraceLinesSolver extends BaseSolver {
     this.chipMap = params.chipMap
 
     this.queuedConnectionPairs = [...this.mspConnectionPairs]
+
+    if (this.queuedConnectionPairs.length === 0) {
+      // No connection pairs to route; solve immediately with an empty result.
+      this.solved = true
+    }
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/lib/solvers/TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver.ts
+++ b/lib/solvers/TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver.ts
@@ -50,6 +50,12 @@ export class TraceAnchoredNetLabelOverlapSolver extends BaseSolver {
     this.traces = params.traces
     this.netLabelPlacements = params.netLabelPlacements
     this.outputNetLabelPlacements = [...params.netLabelPlacements]
+
+    if (this.outputNetLabelPlacements.length === 0) {
+      // No labels to resolve overlaps for; solve immediately with an
+      // empty result.
+      this.solved = true
+    }
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
+++ b/lib/solvers/TraceCleanupSolver/TraceCleanupSolver.ts
@@ -54,6 +54,13 @@ export class TraceCleanupSolver extends BaseSolver {
     this.traceIdQueue = Array.from(
       solverInput.allTraces.map((e) => e.mspPairId),
     )
+
+    if (this.outputTraces.length === 0) {
+      // No traces to clean up; solve immediately with an empty result.
+      // This also avoids building a chip obstacle spatial index for an
+      // empty chip set inside the untangle sub-solver.
+      this.solved = true
+    }
   }
 
   override _step() {

--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver.ts
@@ -52,6 +52,18 @@ export class TraceLabelOverlapAvoidanceSolver extends BaseSolver {
     this.netLabelPlacements = solverInput.netLabelPlacements
     this.cleanTraces = []
     this.subSolvers = []
+
+    if (this.unprocessedTraces.length === 0) {
+      // No traces to check for overlaps; run the final label merge
+      // immediately so downstream pipeline stages can read its output.
+      this.labelMergingSolver = new MergedNetLabelObstacleSolver({
+        netLabelPlacements: this.netLabelPlacements,
+        inputProblem: this.inputProblem,
+        traces: [],
+      })
+      this.labelMergingSolver.solve()
+      this.solved = true
+    }
   }
 
   override _step() {

--- a/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
+++ b/lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver.ts
@@ -60,6 +60,11 @@ export class TraceOverlapShiftSolver extends BaseSolver {
     }
 
     this.traceNetIslands = this.computeTraceNetIslands()
+
+    if (this.inputTracePaths.length === 0) {
+      // No traces to shift; solve immediately with an empty result.
+      this.solved = true
+    }
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/tests/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver_emptyConnections.test.ts
+++ b/tests/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver_emptyConnections.test.ts
@@ -1,0 +1,213 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "connectivity-map"
+import inputData from "../../assets/example01.json"
+import type { InputProblem } from "lib/types/InputProblem"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import { MspConnectionPairSolver } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import { SchematicTraceLinesSolver } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { LongDistancePairSolver } from "lib/solvers/LongDistancePairSolver/LongDistancePairSolver"
+import { TraceOverlapShiftSolver } from "lib/solvers/TraceOverlapShiftSolver/TraceOverlapShiftSolver"
+import { NetLabelPlacementSolver } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { TraceLabelOverlapAvoidanceSolver } from "lib/solvers/TraceLabelOverlapAvoidanceSolver/TraceLabelOverlapAvoidanceSolver"
+import { TraceCleanupSolver } from "lib/solvers/TraceCleanupSolver/TraceCleanupSolver"
+import { Example28Solver } from "lib/solvers/Example28Solver/Example28Solver"
+import { AvailableNetOrientationSolver } from "lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver"
+import { RailNetLabelCornerPlacementSolver } from "lib/solvers/RailNetLabelCornerPlacementSolver/RailNetLabelCornerPlacementSolver"
+import { TraceAnchoredNetLabelOverlapSolver } from "lib/solvers/TraceAnchoredNetLabelOverlapSolver/TraceAnchoredNetLabelOverlapSolver"
+import { NetLabelTraceCollisionSolver } from "lib/solvers/NetLabelTraceCollisionSolver/NetLabelTraceCollisionSolver"
+import { NetLabelNetLabelCollisionSolver } from "lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver"
+
+const emptyConnectionsProblem: InputProblem = {
+  ...(inputData as unknown as InputProblem),
+  directConnections: [],
+  netConnections: [],
+}
+
+test("SchematicTracePipelineSolver solves with empty connections", () => {
+  const solver = new SchematicTracePipelineSolver(emptyConnectionsProblem)
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.mspConnectionPairSolver!.mspConnectionPairs).toHaveLength(0)
+  expect(solver.schematicTraceLinesSolver!.solvedTracePaths).toHaveLength(0)
+  expect(solver.traceCleanupSolver!.getOutput().traces).toHaveLength(0)
+  expect(solver.netLabelPlacementSolver!.netLabelPlacements).toHaveLength(0)
+  expect(
+    solver.netLabelNetLabelCollisionSolver!.getOutput().netLabelPlacements,
+  ).toHaveLength(0)
+})
+
+test("SchematicTracePipelineSolver solves with no chips and empty connections", () => {
+  const solver = new SchematicTracePipelineSolver({
+    ...emptyConnectionsProblem,
+    chips: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})
+
+test("MspConnectionPairSolver solves with empty connections", () => {
+  const solver = new MspConnectionPairSolver({
+    inputProblem: emptyConnectionsProblem,
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.mspConnectionPairs).toHaveLength(0)
+})
+
+test("SchematicTraceLinesSolver solves with no connection pairs", () => {
+  const solver = new SchematicTraceLinesSolver({
+    mspConnectionPairs: [],
+    chipMap: {},
+    dcConnMap: new ConnectivityMap({}),
+    globalConnMap: new ConnectivityMap({}),
+    inputProblem: emptyConnectionsProblem,
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.solvedTracePaths).toHaveLength(0)
+})
+
+test("LongDistancePairSolver solves with no connection pairs", () => {
+  const solver = new LongDistancePairSolver({
+    inputProblem: emptyConnectionsProblem,
+    primaryMspConnectionPairs: [],
+    alreadySolvedTraces: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.getOutput().allTracesMerged).toHaveLength(0)
+})
+
+test("TraceOverlapShiftSolver solves with no traces", () => {
+  const solver = new TraceOverlapShiftSolver({
+    inputProblem: emptyConnectionsProblem,
+    inputTracePaths: [],
+    globalConnMap: new ConnectivityMap({}),
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(Object.keys(solver.correctedTraceMap)).toHaveLength(0)
+})
+
+test("NetLabelPlacementSolver solves with empty connections", () => {
+  const solver = new NetLabelPlacementSolver({
+    inputProblem: emptyConnectionsProblem,
+    inputTraceMap: {},
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.netLabelPlacements).toHaveLength(0)
+})
+
+test("TraceLabelOverlapAvoidanceSolver solves with no traces or labels", () => {
+  const solver = new TraceLabelOverlapAvoidanceSolver({
+    inputProblem: emptyConnectionsProblem,
+    traces: [],
+    netLabelPlacements: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.getOutput().traces).toHaveLength(0)
+  // Downstream pipeline stages read labelMergingSolver unconditionally
+  expect(solver.labelMergingSolver).toBeDefined()
+  expect(
+    solver.labelMergingSolver!.getOutput().netLabelPlacements,
+  ).toHaveLength(0)
+})
+
+test("TraceCleanupSolver solves with no traces", () => {
+  const solver = new TraceCleanupSolver({
+    inputProblem: emptyConnectionsProblem,
+    allTraces: [],
+    allLabelPlacements: [],
+    mergedLabelNetIdMap: {},
+    paddingBuffer: 0.1,
+  } as any)
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.getOutput().traces).toHaveLength(0)
+})
+
+test("Example28Solver solves with no traces or labels", () => {
+  const solver = new Example28Solver({
+    inputProblem: emptyConnectionsProblem,
+    traces: [],
+    netLabelPlacements: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.outputTraces).toHaveLength(0)
+  expect(solver.outputNetLabelPlacements).toHaveLength(0)
+})
+
+test("AvailableNetOrientationSolver solves with no traces or labels", () => {
+  const solver = new AvailableNetOrientationSolver({
+    inputProblem: emptyConnectionsProblem,
+    traces: [],
+    netLabelPlacements: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.getOutput().traces).toHaveLength(0)
+  expect(solver.getOutput().netLabelPlacements).toHaveLength(0)
+})
+
+test("RailNetLabelCornerPlacementSolver solves with no traces or labels", () => {
+  const solver = new RailNetLabelCornerPlacementSolver({
+    inputProblem: emptyConnectionsProblem,
+    traces: [],
+    netLabelPlacements: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.outputNetLabelPlacements).toHaveLength(0)
+})
+
+test("TraceAnchoredNetLabelOverlapSolver solves with no traces or labels", () => {
+  const solver = new TraceAnchoredNetLabelOverlapSolver({
+    inputProblem: emptyConnectionsProblem,
+    traces: [],
+    netLabelPlacements: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.getOutput().netLabelPlacements).toHaveLength(0)
+})
+
+test("NetLabelTraceCollisionSolver solves with no traces or labels", () => {
+  const solver = new NetLabelTraceCollisionSolver({
+    inputProblem: emptyConnectionsProblem,
+    traces: [],
+    netLabelPlacements: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.getOutput().traces).toHaveLength(0)
+  expect(solver.getOutput().netLabelPlacements).toHaveLength(0)
+})
+
+test("NetLabelNetLabelCollisionSolver solves with no traces or labels", () => {
+  const solver = new NetLabelNetLabelCollisionSolver({
+    inputProblem: emptyConnectionsProblem,
+    traces: [],
+    netLabelPlacements: [],
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.getOutput().netLabelPlacements).toHaveLength(0)
+})


### PR DESCRIPTION
## Problem

Passing an input problem with no connections (`directConnections: []` / `netConnections: []`, which yields no MSP pairs and no traces) caused solvers to run their step loops over empty work queues, and a fully empty input (`chips: []`) crashed outright: `TraceCleanupSolver`, `AvailableNetOrientationSolver`, and `NetLabelNetLabelCollisionSolver` build a Flatbush-backed `ChipObstacleSpatialIndex`, and Flatbush throws `Unexpected numItems value: 0` when constructed with zero chips.

Note: the issue mentions `CapacityMeshSolver.ts` / `DirectLineSolver.ts`; those files don't exist in this repo, so I applied the guard to every solver in the actual pipeline (`SchematicTracePipelineSolver`'s stages).

## Fix

Add an early-return guard to each pipeline solver: when there are no connections / connection pairs / traces / labels to process, the solver marks itself `solved` in the constructor and returns an empty result (empty traces / labels maps) instead of stepping:

- `MspConnectionPairSolver` — no `directConnections` and no `netConnections`
- `SchematicTraceLinesSolver` — no MSP connection pairs
- `LongDistancePairSolver` — no candidate pairs
- `TraceOverlapShiftSolver` — no input traces
- `NetLabelPlacementSolver` — no connection-net groups to label
- `TraceLabelOverlapAvoidanceSolver` — no traces (still runs the final `MergedNetLabelObstacleSolver` so downstream stages can read `labelMergingSolver.getOutput()`)
- `TraceCleanupSolver` — no traces (also avoids building the spatial index that crashed on `chips: []`)
- `Example28Solver` — no traces
- `AvailableNetOrientationSolver` — no labels (skips the spatial index construction)
- `RailNetLabelCornerPlacementSolver` — no labels needing corner placement
- `TraceAnchoredNetLabelOverlapSolver` — no labels
- `NetLabelTraceCollisionSolver` — no traces or no labels
- `NetLabelNetLabelCollisionSolver` — no labels (skips the spatial index construction)

## Tests

Added `tests/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver_emptyConnections.test.ts` covering the pipeline and each solver with empty connections (and the pipeline with `chips: []`), asserting the solver solves without failing and returns empty traces/labels.

- Full suite: `bun test` — 117 pass, 4 skip, 0 fail
- `tsc --noEmit` and `biome format` clean
- Verified stage-by-stage that solver outputs for a normal input (example19) are byte-identical before/after this change

This PR was prepared with assistance from an AI coding agent.

Closes #657