### PR TITLE
Prevent non-finite hues for long color identifiers

### DIFF
--- a/lib/utils/getColorFromString.ts
+++ b/lib/utils/getColorFromString.ts
@@ -1,7 +1,14 @@
 export const getColorFromString = (string: string, alpha = 1) => {
   // pseudo random number from string
-  const hash = string.split("").reduce((acc, char) => {
-    return acc * 31 + char.charCodeAt(0)
-  }, 0)
+  let hash = 0
+  let useModuloHash = false
+  for (let i = 0; i < string.length; i++) {
+    // Preserve the existing hash until the next multiplication could overflow.
+    // From that point onward, reducing modulo 360 keeps the eventual hue
+    // equivalent while allowing every remaining character to contribute.
+    if (hash >= Number.MAX_VALUE / 31) useModuloHash = true
+    if (useModuloHash) hash %= 360
+    hash = hash * 31 + string.charCodeAt(i)
+  }
   return `hsl(${hash % 360}, 100%, 50%, ${alpha})`
 }

--- a/tests/functions/get-color-from-string.test.ts
+++ b/tests/functions/get-color-from-string.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { getColorFromString } from "lib/utils/getColorFromString"
+
+const getHue = (color: string) => {
+  const match = color.match(/^hsl\((\d+), 100%, 50%, [^)]+\)$/)
+  expect(match).not.toBeNull()
+  return Number(match?.[1])
+}
+
+test("preserves existing colors for ordinary identifiers", () => {
+  expect(getColorFromString("U1.13-RFSET.1")).toBe("hsl(328, 100%, 50%, 1)")
+  expect(getColorFromString("net0", 0.75)).toBe("hsl(195, 100%, 50%, 0.75)")
+  expect(getColorFromString("")).toBe("hsl(0, 100%, 50%, 1)")
+})
+
+test("returns a valid hue for the reported long string", () => {
+  const hue = getHue(getColorFromString("n".repeat(300)))
+
+  expect(hue).toBeGreaterThanOrEqual(0)
+  expect(hue).toBeLessThan(360)
+})
+
+test("keeps long-string colors deterministic and distinguishable", () => {
+  const prefix = "global-connection-".repeat(1_000)
+  const firstColor = getColorFromString(`${prefix}a`, 0.35)
+  const secondColor = getColorFromString(`${prefix}b`, 0.35)
+
+  expect(getColorFromString(`${prefix}a`, 0.35)).toBe(firstColor)
+  expect(getHue(firstColor)).toBeLessThan(360)
+  expect(getHue(secondColor)).toBeLessThan(360)
+  expect(firstColor).not.toBe(secondColor)
+})


### PR DESCRIPTION
## Summary

- preserve existing `getColorFromString` results for ordinary identifiers
- switch to modulo-360 accumulation before the hash can overflow, keeping arbitrary-length identifiers finite and deterministic
- verify the reported long-string case and ensure long suffixes still affect the generated color

## Testing

- `bun test`
- `bun run build`
- `bun run format:check`
- `bunx tsc --noEmit`

Closes #651

/claim #651
