### PR TITLE
Add Core repro154 for missing ground trace

### DIFF
--- a/tests/repros/__snapshots__/repro-core-subcircuit-missing-ground.snap.svg
+++ b/tests/repros/__snapshots__/repro-core-subcircuit-missing-ground.snap.svg
@@ -1,0 +1,56 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-2.65,0 2.75,-0.2" data-type="line" data-label="" points="182.64150943396226,325.811320754717 467.92452830188677,336.37735849056605" fill="none" stroke="hsl(288, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="-2.65,-0.2 2.75,0" data-type="line" data-label="" points="182.64150943396226,336.37735849056605 467.92452830188677,325.811320754717" fill="none" stroke="hsl(344, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="-2.65,0 0.050000000000000044,0 0.050000000000000044,-0.2 2.75,-0.2" data-type="line" data-label="" points="182.64150943396226,325.811320754717 325.2830188679245,325.811320754717 325.2830188679245,336.37735849056605 467.92452830188677,336.37735849056605" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="schematic_component_0" data-x="-4" data-y="0" x="40" y="304.6792452830189" width="142.64150943396226" height="42.2641509433962" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01892857142857143"/></g><g><rect data-type="rect" data-label="schematic_component_1" data-x="4" data-y="0" x="467.92452830188677" y="304.6792452830189" width="132.07547169811323" height="42.2641509433962" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.01892857142857143"/></g><g><rect data-type="rect" data-label="power" data-x="-4.65" data-y="0.53" x="61.13207547169809" y="293.0566037735849" width="31.698113207547152" height="9.509433962264097" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.01892857142857143"/></g><g><rect data-type="rect" data-label="load" data-x="3.3899999999999997" data-y="0.53" x="489.0566037735849" y="293.0566037735849" width="25.358490566037688" height="9.509433962264097" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.01892857142857143"/></g><g><rect data-type="rect" data-label="netId: .power &gt; .VOUT_3V3 to .load &gt; .3V3
+globalConnNetId: connectivity_net0" data-x="-1.2999999999999998" data-y="0.225" x="248.67924528301884" y="302.0377358490566" width="10.56603773584908" height="23.773584905660357" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01892857142857143"/></g><g><rect data-type="rect" data-label="netId: .power &gt; .SEC_GND to .load &gt; .GND
+globalConnNetId: connectivity_net1" data-x="-2.424" data-y="-0.2" x="182.6943396226415" y="331.09433962264154" width="23.773584905660385" height="10.56603773584908" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01892857142857143"/></g><g><rect data-type="rect" data-label="netId: .power &gt; .SEC_GND to .load &gt; .GND
+globalConnNetId: connectivity_net1" data-x="2.524" data-y="0" x="444.0981132075471" y="320.52830188679246" width="23.773584905660414" height="10.566037735849022" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.01892857142857143"/></g><g><circle data-type="point" data-label="schematic_component_0.1
+x+" data-x="-2.65" data-y="0.2" cx="182.64150943396226" cy="315.2452830188679" r="3" fill="hsl(96, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_component_0.2
+x+" data-x="-2.65" data-y="0" cx="182.64150943396226" cy="325.811320754717" r="3" fill="hsl(96, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_component_0.3
+x+" data-x="-2.65" data-y="-0.2" cx="182.64150943396226" cy="336.37735849056605" r="3" fill="hsl(96, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_component_1.1
+x-" data-x="2.75" data-y="0.2" cx="467.92452830188677" cy="315.2452830188679" r="3" fill="hsl(96, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_component_1.2
+x-" data-x="2.75" data-y="0" cx="467.92452830188677" cy="325.811320754717" r="3" fill="hsl(96, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_component_1.3
+x-" data-x="2.75" data-y="-0.2" cx="467.92452830188677" cy="336.37735849056605" r="3" fill="hsl(96, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-1.2999999999999998" data-y="0" cx="253.96226415094338" cy="325.811320754717" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="-2.65" data-y="-0.2" cx="182.64150943396226" cy="336.37735849056605" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="2.75" data-y="0" cx="467.92452830188677" cy="325.811320754717" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":52.83018867924528,"c":0,"e":322.64150943396226,"b":0,"d":-52.83018867924528,"f":325.811320754717};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/assets/repro-core-subcircuit-missing-ground.input.json
+++ b/tests/repros/assets/repro-core-subcircuit-missing-ground.input.json
@@ -1,0 +1,103 @@
+{
+  "chips": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": -4,
+        "y": 0
+      },
+      "width": 1.9000000000000004,
+      "height": 0.8,
+      "pins": [
+        {
+          "pinId": "schematic_component_0.1",
+          "x": -2.65,
+          "y": 0.2,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "schematic_component_0.2",
+          "x": -2.65,
+          "y": 0,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "schematic_component_0.3",
+          "x": -2.65,
+          "y": -0.2,
+          "_facingDirection": "x+"
+        }
+      ]
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": {
+        "x": 4,
+        "y": 0
+      },
+      "width": 1.6999999999999997,
+      "height": 0.8,
+      "pins": [
+        {
+          "pinId": "schematic_component_1.1",
+          "x": 2.75,
+          "y": 0.2,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_component_1.2",
+          "x": 2.75,
+          "y": 0,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_component_1.3",
+          "x": 2.75,
+          "y": -0.2,
+          "_facingDirection": "x-"
+        }
+      ]
+    }
+  ],
+  "directConnections": [
+    {
+      "pinIds": [
+        "schematic_component_0.2",
+        "schematic_component_1.3"
+      ],
+      "netId": ".power > .VOUT_3V3 to .load > .3V3"
+    },
+    {
+      "pinIds": [
+        "schematic_component_0.3",
+        "schematic_component_1.2"
+      ],
+      "netId": ".power > .SEC_GND to .load > .GND"
+    }
+  ],
+  "netConnections": [],
+  "textBoxes": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": -4.65,
+        "y": 0.53
+      },
+      "width": 0.5999999999999996,
+      "height": 0.17999999999999994,
+      "text": "power"
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": {
+        "x": 3.3899999999999997,
+        "y": 0.53
+      },
+      "width": 0.48,
+      "height": 0.17999999999999994,
+      "text": "load"
+    }
+  ],
+  "availableNetLabelOrientations": {},
+  "maxMspPairDistance": 2.4
+}

--- a/tests/repros/repro-core-subcircuit-missing-ground.test.ts
+++ b/tests/repros/repro-core-subcircuit-missing-ground.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import "tests/fixtures/matcher"
+import inputProblem from "./assets/repro-core-subcircuit-missing-ground.input.json"
+
+// Captured from @tscircuit/core main repro154: two crossed connections enter
+// the solver, but only the VOUT_3V3-to-3V3 connection is routed.
+test("core repro154 omits one of two crossed subcircuit connections", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- add the exact `InputProblem` captured from `@tscircuit/core` main repro154 at commit `9247fb37`
- add a focused solver-level visual snapshot test
- reproduce the pipeline routing only the `VOUT_3V3 -> 3V3` connection while the crossed `SEC_GND -> GND` connection is left as two fallback label placements

## Why

The Core repro proves both cross-subcircuit traces reach the schematic trace solver. Moving the unchanged input into this repository isolates the remaining missing-GND behavior from Core's subcircuit and rendering logic.

## Validation

- `bun test tests/repros/repro-core-subcircuit-missing-ground.test.ts`
- `bunx tsc --noEmit`
- Biome check on the new test and input asset
- headless pipeline stages generated and visually inspected through `bun run debug:pipeline`
