### PR TITLE
fix: prevent hash overflow to NaN in getColorFromString (#651)

### DIFF
--- a/lib/utils/getColorFromString.ts
+++ b/lib/utils/getColorFromString.ts
@@ -6,4 +6,3 @@ export const getColorFromString = (string: string, alpha = 1) => {
   const hue = Math.abs(hash) % 360
   return `hsl(${hue}, 100%, 50%, ${alpha})`
 }
-

--- a/lib/utils/getColorFromString.ts
+++ b/lib/utils/getColorFromString.ts
@@ -1,7 +1,9 @@
 export const getColorFromString = (string: string, alpha = 1) => {
   // pseudo random number from string
   const hash = string.split("").reduce((acc, char) => {
-    return acc * 31 + char.charCodeAt(0)
+    return (acc * 31 + char.charCodeAt(0)) | 0
   }, 0)
-  return `hsl(${hash % 360}, 100%, 50%, ${alpha})`
+  const hue = Math.abs(hash) % 360
+  return `hsl(${hue}, 100%, 50%, ${alpha})`
 }
+

--- a/tests/get-color-from-string.test.ts
+++ b/tests/get-color-from-string.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { getColorFromString } from "../lib/utils/getColorFromString"
+import { getColorFromString } from "lib/utils/getColorFromString"
 
 describe("getColorFromString", () => {
   test("returns valid HSL for standard strings", () => {

--- a/tests/getColorFromString.test.ts
+++ b/tests/getColorFromString.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { getColorFromString } from "../lib/utils/getColorFromString"
+
+describe("getColorFromString", () => {
+  test("returns valid HSL for standard strings", () => {
+    const color = getColorFromString("net1")
+    expect(color).toMatch(/^hsl\(\d+, 100%, 50%, 1\)$/)
+  })
+
+  test("returns valid HSL for custom alpha", () => {
+    const color = getColorFromString("net1", 0.5)
+    expect(color).toMatch(/^hsl\(\d+, 100%, 50%, 0\.5\)$/)
+  })
+
+  test("does not overflow to NaN for very long strings", () => {
+    const longString = "n".repeat(300)
+    const color = getColorFromString(longString)
+    expect(color.includes("NaN")).toBe(false)
+    expect(color).toMatch(/^hsl\(\d+, 100%, 50%, 1\)$/)
+  })
+})


### PR DESCRIPTION
Fixes #651

### Cause
When passing long strings (e.g. `"n".repeat(300)`), accumulating `acc * 31 + charCodeAt(0)` overflows JavaScript's `Number.MAX_VALUE` to `Infinity`. Subsequently, `Infinity % 360` evaluates to `NaN`, returning an invalid color string `hsl(NaN, 100%, 50%, 1)`.

### Solution
- Use 32-bit integer bitwise OR (`| 0`) on each hash accumulation step to keep the hash bounded within signed 32-bit integer range.
- Use `Math.abs(hash) % 360` to guarantee a valid non-negative hue integer between 0 and 359.

### Verification
Added `tests/getColorFromString.test.ts` verifying valid HSL format, alpha parameter handling, and long string handling (`"n".repeat(300)`). All tests pass cleanly.