### PR TITLE
test: repro #687 — V1V1 net label left stacked on QD3/QCLK port labels

### DIFF
--- a/tests/repros/__snapshots__/repro-netlabel-collision-687.snap.svg
+++ b/tests/repros/__snapshots__/repro-netlabel-collision-687.snap.svg
@@ -1,0 +1,81 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0.5,0.4 5.5,0.4" data-type="line" data-label="" points="120,288 520,288" fill="none" stroke="hsl(77, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="0.5,0.2 5.5,0.2" data-type="line" data-label="" points="120,304 520,304" fill="none" stroke="hsl(78, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="0.5,0 5.5,0" data-type="line" data-label="" points="120,320 520,320" fill="none" stroke="hsl(79, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="0.5,-0.2 5.5,-0.2" data-type="line" data-label="" points="120,336 520,336" fill="none" stroke="hsl(80, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="0.5,-0.4 5.5,-0.4" data-type="line" data-label="" points="120,352 520,352" fill="none" stroke="hsl(209, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="0.5,0.6 0.5,-0.6" data-type="line" data-label="" points="120,272 120,368" fill="none" stroke="hsl(30, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="0.5,0.6 1.201,0.6 1.201,-0.6 0.5,-0.6" data-type="line" data-label="" points="120,272 176.08,272 176.08,368 120,368" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="U1" data-x="0" data-y="0" x="40" y="240" width="80" height="160" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="U2" data-x="6" data-y="0" x="520" y="240" width="80" height="160" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="U3" data-x="1.8" data-y="0" x="204" y="200" width="40" height="240" fill="hsl(166, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="C1" data-x="0.8" data-y="1.2" x="88" y="188" width="112" height="72" fill="hsl(326, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="C2" data-x="0.8" data-y="-1.2" x="88" y="380" width="112" height="72" fill="hsl(327, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: V1V1
+globalConnNetId: connectivity_net5" data-x="0.8505" data-y="-0.39" x="124.04" y="334.4" width="48.00000000000003" height="33.60000000000002" fill="#ef444466" stroke="#ef4444" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QD0
+globalConnNetId: connectivity_net0" data-x="0.741" data-y="0.4" x="120.07999999999998" y="280" width="38.40000000000002" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QD0
+globalConnNetId: connectivity_net0" data-x="5.2589999999999995" data-y="0.4" x="481.52" y="280" width="38.400000000000034" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QD1
+globalConnNetId: connectivity_net1" data-x="0.741" data-y="0.2" x="120.07999999999998" y="296" width="38.40000000000002" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QD1
+globalConnNetId: connectivity_net1" data-x="5.2589999999999995" data-y="0.2" x="481.52" y="296" width="38.400000000000034" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QD2
+globalConnNetId: connectivity_net2" data-x="0.741" data-y="0" x="120.07999999999998" y="312" width="38.40000000000002" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QD2
+globalConnNetId: connectivity_net2" data-x="5.2589999999999995" data-y="0" x="481.52" y="312" width="38.400000000000034" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QD3
+globalConnNetId: connectivity_net3" data-x="0.741" data-y="-0.2" x="120.07999999999998" y="328" width="38.40000000000002" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QD3
+globalConnNetId: connectivity_net3" data-x="5.2589999999999995" data-y="-0.2" x="481.52" y="328" width="38.400000000000034" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QCLK
+globalConnNetId: connectivity_net4" data-x="0.801" data-y="-0.4" x="120.08" y="344" width="47.99999999999997" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><rect data-type="rect" data-label="netId: QCLK
+globalConnNetId: connectivity_net4" data-x="5.199" data-y="-0.4" x="471.91999999999996" y="344" width="47.99999999999994" height="16" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0125"/></g><g><circle data-type="point" data-label="U1.1
+x+" data-x="0.5" data-y="0.6" cx="120" cy="272" r="3" fill="hsl(319, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.2
+x+" data-x="0.5" data-y="0.4" cx="120" cy="288" r="3" fill="hsl(320, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.3
+x+" data-x="0.5" data-y="0.2" cx="120" cy="304" r="3" fill="hsl(321, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.4
+x+" data-x="0.5" data-y="0" cx="120" cy="320" r="3" fill="hsl(322, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.5
+x+" data-x="0.5" data-y="-0.2" cx="120" cy="336" r="3" fill="hsl(323, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.6
+x+" data-x="0.5" data-y="-0.4" cx="120" cy="352" r="3" fill="hsl(324, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.7
+x+" data-x="0.5" data-y="-0.6" cx="120" cy="368" r="3" fill="hsl(325, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U2.1
+x-" data-x="5.5" data-y="0.4" cx="520" cy="288" r="3" fill="hsl(200, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U2.2
+x-" data-x="5.5" data-y="0.2" cx="520" cy="304" r="3" fill="hsl(201, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U2.3
+x-" data-x="5.5" data-y="0" cx="520" cy="320" r="3" fill="hsl(202, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U2.4
+x-" data-x="5.5" data-y="-0.2" cx="520" cy="336" r="3" fill="hsl(203, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U2.5
+x-" data-x="5.5" data-y="-0.4" cx="520" cy="352" r="3" fill="hsl(204, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U3.1
+y+" data-x="1.8" data-y="1.5" cx="224" cy="200" r="3" fill="hsl(81, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C1.1
+y-" data-x="0.8" data-y="0.75" cx="144" cy="260" r="3" fill="hsl(121, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C2.1
+y+" data-x="0.8" data-y="-0.75" cx="144" cy="380" r="3" fill="hsl(2, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="0.8505" data-y="-0.6" cx="148.04000000000002" cy="368" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="0.5" data-y="0.4" cx="120" cy="288" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="5.5" data-y="0.4" cx="520" cy="288" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="0.5" data-y="0.2" cx="120" cy="304" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="5.5" data-y="0.2" cx="520" cy="304" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="0.5" data-y="0" cx="120" cy="320" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="5.5" data-y="0" cx="520" cy="320" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="0.5" data-y="-0.2" cx="120" cy="336" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="5.5" data-y="-0.2" cx="520" cy="336" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="0.5" data-y="-0.4" cx="120" cy="352" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="5.5" data-y="-0.4" cx="520" cy="352" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":80,"c":0,"e":80,"b":0,"d":-80,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/assets/repro-netlabel-collision-687.input.json
+++ b/tests/repros/assets/repro-netlabel-collision-687.input.json
@@ -1,0 +1,212 @@
+{
+  "chips": [
+    {
+      "chipId": "U1",
+      "center": {
+        "x": 0,
+        "y": 0
+      },
+      "width": 1,
+      "height": 2,
+      "pins": [
+        {
+          "pinId": "U1.1",
+          "x": 0.5,
+          "y": 0.6
+        },
+        {
+          "pinId": "U1.2",
+          "x": 0.5,
+          "y": 0.4
+        },
+        {
+          "pinId": "U1.3",
+          "x": 0.5,
+          "y": 0.2
+        },
+        {
+          "pinId": "U1.4",
+          "x": 0.5,
+          "y": 0
+        },
+        {
+          "pinId": "U1.5",
+          "x": 0.5,
+          "y": -0.2
+        },
+        {
+          "pinId": "U1.6",
+          "x": 0.5,
+          "y": -0.4
+        },
+        {
+          "pinId": "U1.7",
+          "x": 0.5,
+          "y": -0.6
+        }
+      ]
+    },
+    {
+      "chipId": "U2",
+      "center": {
+        "x": 6,
+        "y": 0
+      },
+      "width": 1,
+      "height": 2,
+      "pins": [
+        {
+          "pinId": "U2.1",
+          "x": 5.5,
+          "y": 0.4
+        },
+        {
+          "pinId": "U2.2",
+          "x": 5.5,
+          "y": 0.2
+        },
+        {
+          "pinId": "U2.3",
+          "x": 5.5,
+          "y": 0
+        },
+        {
+          "pinId": "U2.4",
+          "x": 5.5,
+          "y": -0.2
+        },
+        {
+          "pinId": "U2.5",
+          "x": 5.5,
+          "y": -0.4
+        }
+      ]
+    },
+    {
+      "chipId": "U3",
+      "center": {
+        "x": 1.8,
+        "y": 0
+      },
+      "width": 0.5,
+      "height": 3,
+      "pins": [
+        {
+          "pinId": "U3.1",
+          "x": 1.8,
+          "y": 1.5
+        }
+      ]
+    },
+    {
+      "chipId": "C1",
+      "center": {
+        "x": 0.8,
+        "y": 1.2
+      },
+      "width": 1.4,
+      "height": 0.9,
+      "pins": [
+        {
+          "pinId": "C1.1",
+          "x": 0.8,
+          "y": 0.75
+        }
+      ]
+    },
+    {
+      "chipId": "C2",
+      "center": {
+        "x": 0.8,
+        "y": -1.2
+      },
+      "width": 1.4,
+      "height": 0.9,
+      "pins": [
+        {
+          "pinId": "C2.1",
+          "x": 0.8,
+          "y": -0.75
+        }
+      ]
+    }
+  ],
+  "directConnections": [],
+  "netConnections": [
+    {
+      "netId": "QD0",
+      "pinIds": [
+        "U1.2",
+        "U2.1"
+      ],
+      "netLabelWidth": 0.48
+    },
+    {
+      "netId": "QD1",
+      "pinIds": [
+        "U1.3",
+        "U2.2"
+      ],
+      "netLabelWidth": 0.48
+    },
+    {
+      "netId": "QD2",
+      "pinIds": [
+        "U1.4",
+        "U2.3"
+      ],
+      "netLabelWidth": 0.48
+    },
+    {
+      "netId": "QD3",
+      "pinIds": [
+        "U1.5",
+        "U2.4"
+      ],
+      "netLabelWidth": 0.48
+    },
+    {
+      "netId": "QCLK",
+      "pinIds": [
+        "U1.6",
+        "U2.5"
+      ],
+      "netLabelWidth": 0.6
+    },
+    {
+      "netId": "V1V1",
+      "pinIds": [
+        "U1.1",
+        "U1.7"
+      ],
+      "netLabelWidth": 0.42,
+      "netLabelHeight": 0.6
+    }
+  ],
+  "availableNetLabelOrientations": {
+    "QD0": [
+      "x-",
+      "x+"
+    ],
+    "QD1": [
+      "x-",
+      "x+"
+    ],
+    "QD2": [
+      "x-",
+      "x+"
+    ],
+    "QD3": [
+      "x-",
+      "x+"
+    ],
+    "QCLK": [
+      "x-",
+      "x+"
+    ],
+    "V1V1": [
+      "y+"
+    ]
+  },
+  "maxMspPairDistance": 2.4
+}

--- a/tests/repros/repro-netlabel-collision-687.test.ts
+++ b/tests/repros/repro-netlabel-collision-687.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "./assets/repro-netlabel-collision-687.input.json"
+import "tests/fixtures/matcher"
+
+const boundsOf = (label: {
+  center: { x: number; y: number }
+  width: number
+  height: number
+}) => ({
+  minX: label.center.x - label.width / 2,
+  maxX: label.center.x + label.width / 2,
+  minY: label.center.y - label.height / 2,
+  maxY: label.center.y + label.height / 2,
+})
+
+const overlapArea = (
+  a: ReturnType<typeof boundsOf>,
+  b: ReturnType<typeof boundsOf>,
+) => {
+  const w = Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX)
+  const h = Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY)
+  return w > 0 && h > 0 ? w * h : 0
+}
+
+// Reproduction for #687, minimized from bug-report-20260721T221026Z.
+//
+// U1's right-edge pin column is fully walled in: a solid column of port
+// labels (QD0..QD3, QCLK) to the east, chips C1/C2 above and below, and
+// chip U3 closing off the corridor. The V1V1 trace (U1.1 -> U1.7) wraps
+// around the label column, and its net label has NO strictly collision-free
+// candidate anywhere along the trace. NetLabelNetLabelCollisionSolver gives
+// up and leaves the V1V1 label stacked directly on top of the QD3 and QCLK
+// port labels — the same pile-up as the original board.
+//
+// This test asserts the CURRENT (buggy) behavior so the bug is pinned by CI.
+// A fix should flip the two non-zero overlap assertions to .toBe(0).
+test("repro #687: V1V1 net label left stacked on QD3/QCLK port labels", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+  solver.solve()
+
+  const labels =
+    solver.netLabelNetLabelCollisionSolver!.outputNetLabelPlacements
+
+  const v1v1 = labels.find((l) => l.netId === "V1V1")!
+  const qd3 = labels.find((l) => l.netId === "QD3" && l.center.x < 3)!
+  const qclk = labels.find((l) => l.netId === "QCLK" && l.center.x < 3)!
+  expect(v1v1).toBeDefined()
+  expect(qd3).toBeDefined()
+  expect(qclk).toBeDefined()
+
+  // BUG: the V1V1 label still overlaps both port labels after the collision
+  // solver has run (total stacked overlap ≈ 0.16)
+  expect(overlapArea(boundsOf(v1v1), boundsOf(qd3))).toBeGreaterThan(0)
+  expect(overlapArea(boundsOf(v1v1), boundsOf(qclk))).toBeGreaterThan(0)
+
+  // visual snapshot: the V1V1 label sits on the QD3/QCLK pile-up
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
Reproduction-only PR for #687, as requested in the review on #690.

Input is a minimal 5-chip scene (`tests/repros/assets/repro-netlabel-collision-687.input.json`) minimized from the user-submitted board `bug-report-20260721T221026Z` (#688), preserving its exact failure mechanism and net names.

**What it shows:** the `V1V1` trace label has no strictly collision-free candidate anywhere along its trace — the pin column is walled in by the QD0–QD3/QCLK port-label column, chips above/below, and a chip closing the corridor — so `NetLabelNetLabelCollisionSolver` gives up and leaves it stacked on the `QD3` and `QCLK` port labels (total stacked overlap ≈ 0.16; the original board shows ≈ 0.168 in the same shape).

| Current behavior (pinned by this PR) |
|---|
| ![V1V1 stacked on QD3/QCLK](https://raw.githubusercontent.com/Hero988/schematic-trace-solver/acdb867417c44f49c74876ee250be1e3b90f9e6f/tests/repros/__snapshots__/repro-netlabel-collision-687.snap.svg) |

- `tests/repros/repro-netlabel-collision-687.test.ts` asserts the CURRENT buggy behavior (overlaps > 0) so CI pins the bug; a fix should flip those two assertions to `.toBe(0)`.
- #690 is rebased on this branch and flips exactly this snapshot, so its diff shows the before/after.