### PR TITLE
fix: fix: remove duplicate trace segments in same-net routing (is

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #254
+
+fix: remove duplicate trace segments in same-net routing (issue #78)


### PR DESCRIPTION
Closes #254

fix: remove duplicate trace segments in same-net routing (issue #78)

/claim #254