### PR TITLE
Support schematic port IDs in net label grouping

### DIFF
--- a/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/groupLabelsByChipAndOrientation.ts
+++ b/lib/solvers/TraceLabelOverlapAvoidanceSolver/sub-solvers/LabelMergingSolver/groupLabelsByChipAndOrientation.ts
@@ -7,7 +7,8 @@ import type { InputProblem } from "lib/types/InputProblem"
  * with the same orientation relative to that chip.
  *
  * @param labels An array of NetLabelPlacement objects to be grouped.
- * @param chips An array of Chip objects from the InputProblem. (Currently not directly used for grouping logic, but part of the signature).
+ * @param chips Chips from the input problem, used to resolve opaque pin IDs to
+ * their owning component.
  * @returns A record where keys are in the format "chipId-orientation" (e.g., "U1-left")
  *          and values are arrays of NetLabelPlacement objects belonging to that group.
  */
@@ -19,6 +20,11 @@ export const groupLabelsByChipAndOrientation = ({
   chips: InputProblem["chips"]
 }): Record<string, NetLabelPlacement[]> => {
   const groupedLabels: Record<string, NetLabelPlacement[]> = {}
+  const chipIdByPinId = new Map(
+    chips.flatMap((chip) =>
+      chip.pins.map((pin) => [pin.pinId, chip.chipId] as const),
+    ),
+  )
 
   for (const label of labels) {
     if (label.pinIds.length === 0) {
@@ -26,10 +32,12 @@ export const groupLabelsByChipAndOrientation = ({
       continue
     }
 
-    // Extract chipId from the first pinId (e.g., "U1.1" -> "U1")
-    const chipId = label.pinIds[0].split(".")[0]
+    const pinId = label.pinIds[0]!
+    // Preserve historical group IDs for component-qualified pins while using
+    // the input's pin ownership for opaque IDs such as schematic_port_123.
+    const legacyChipId = pinId.includes(".") ? pinId.split(".")[0] : undefined
+    const chipId = legacyChipId ?? chipIdByPinId.get(pinId)
     if (!chipId) {
-      // Should not happen if pinIds are well-formed, but good to guard
       continue
     }
 


### PR DESCRIPTION
## Summary

- resolve opaque pin IDs such as `schematic_port_29` to their owning chip through `InputProblem.chips`
- retain historical merged-group IDs for legacy component-qualified pins such as `J2.13`
- add a focused unit test for schematic-port grouping
- add the exact current `@tscircuit/core` RP2040 gamepad solver input and a visual regression proving uniform GND rails

## Root cause

`groupLabelsByChipAndOrientation` inferred component ownership with `pinId.split(".")[0]`. That worked for legacy IDs such as `J2.13`, but Core now passes schematic port IDs such as `schematic_port_29`, which contain no component prefix. Every port was therefore treated as a separate component during netlabel merging.

Because adjacent labels were not merged into component-side obstacles, the trace/label overlap stage rerouted individual GND branches around separate labels. Those detours produced the staggered rails seen in Core even with schematic-trace-solver 0.0.109.

The fix uses the chip/pin relationship already present in the solver input as the source of truth for opaque IDs. The prior cleanup-stage workaround has been removed from the final diff.

## Impact

Current Core output with schematic-port IDs now follows the same component-side label grouping behavior as legacy component-qualified pin IDs. The RP2040 repro produces one uniform GND rail on each side of the chip without weakening rail-alignment readability checks.

## Validation

- `bun test` — 146 passed, 4 skipped, 0 failed
- `bunx tsc --noEmit`
- focused trace-label overlap and RP2040 tests — 10 passed, 0 failed