### PR TITLE
test: pin net-label placement defects per bug report

### DIFF
--- a/tests/fixtures/labelPlacementDefects.ts
+++ b/tests/fixtures/labelPlacementDefects.ts
@@ -1,0 +1,108 @@
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const EPS = 1e-9
+
+type Bounds = { minX: number; maxX: number; minY: number; maxY: number }
+
+const boundsOf = (
+  center: { x: number; y: number },
+  width: number,
+  height: number,
+): Bounds => ({
+  minX: center.x - width / 2,
+  maxX: center.x + width / 2,
+  minY: center.y - height / 2,
+  maxY: center.y + height / 2,
+})
+
+/** Interior overlap: touching edges are not an overlap. */
+const overlaps = (a: Bounds, b: Bounds) =>
+  a.minX < b.maxX - EPS &&
+  a.maxX > b.minX + EPS &&
+  a.minY < b.maxY - EPS &&
+  a.maxY > b.minY + EPS
+
+/**
+ * Fraction of `inner`'s area covered by `outer`.
+ */
+const coverageFraction = (inner: Bounds, outer: Bounds) => {
+  const overlapWidth = Math.max(
+    0,
+    Math.min(inner.maxX, outer.maxX) - Math.max(inner.minX, outer.minX),
+  )
+  const overlapHeight = Math.max(
+    0,
+    Math.min(inner.maxY, outer.maxY) - Math.max(inner.minY, outer.minY),
+  )
+  const area = (inner.maxX - inner.minX) * (inner.maxY - inner.minY)
+
+  return area > 0 ? (overlapWidth * overlapHeight) / area : 0
+}
+
+/**
+ * Mirrors `CHIP_COLLISION_MIN_OVERLAP_FRACTION` in
+ * `NetLabelNetLabelCollisionSolver`: a label counts as "inside" a chip only
+ * once the chip covers at least half of it. Smaller incidental overlaps are
+ * tolerated there deliberately, so counting them would report defects the
+ * solver is intentionally leaving alone.
+ */
+const INSIDE_CHIP_MIN_COVERAGE = 0.5
+
+/**
+ * Net labels substantially covered by a chip body. These render behind the
+ * component and are illegible — see #655.
+ */
+export const getLabelsInsideChips = (
+  labels: NetLabelPlacement[],
+  inputProblem: InputProblem,
+) => {
+  const offenders: Array<{ netId: string; chipId: string }> = []
+
+  for (const label of labels) {
+    const labelBounds = boundsOf(label.center, label.width, label.height)
+
+    for (const chip of inputProblem.chips) {
+      const chipBounds = boundsOf(chip.center, chip.width, chip.height)
+      if (
+        !overlaps(labelBounds, chipBounds) ||
+        coverageFraction(labelBounds, chipBounds) < INSIDE_CHIP_MIN_COVERAGE
+      ) {
+        continue
+      }
+      offenders.push({
+        netId: label.netId ?? label.globalConnNetId,
+        chipId: chip.chipId,
+      })
+      break
+    }
+  }
+
+  return offenders
+}
+
+/** Pairs of net labels whose boxes overlap each other. */
+export const getOverlappingLabelPairs = (labels: NetLabelPlacement[]) => {
+  const pairs: Array<{ a: string; b: string }> = []
+
+  for (let i = 0; i < labels.length; i++) {
+    for (let k = i + 1; k < labels.length; k++) {
+      const a = labels[i]!
+      const b = labels[k]!
+      if (
+        !overlaps(
+          boundsOf(a.center, a.width, a.height),
+          boundsOf(b.center, b.width, b.height),
+        )
+      ) {
+        continue
+      }
+      pairs.push({
+        a: a.netId ?? a.globalConnNetId,
+        b: b.netId ?? b.globalConnNetId,
+      })
+    }
+  }
+
+  return pairs
+}

--- a/tests/net-label-placement-defects.test.ts
+++ b/tests/net-label-placement-defects.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import {
+  getLabelsInsideChips,
+  getOverlappingLabelPairs,
+} from "tests/fixtures/labelPlacementDefects"
+
+/**
+ * Net-label placement defects per board: labels rendered inside a chip body
+ * (illegible — see #655) and labels overlapping each other.
+ *
+ * These are current values, not targets. Several are open bugs. Pinning them
+ * means a placement change that makes a board worse fails a named assertion
+ * instead of disappearing into a regenerated SVG snapshot.
+ *
+ * If a change legitimately improves a board, lower the number in the same PR.
+ */
+const EXPECTED: Record<
+  string,
+  { insideChips: number; overlappingPairs: number }
+> = {
+  "bug-report-20260706T213649Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260706T220324Z": { insideChips: 0, overlappingPairs: 1 },
+  "bug-report-20260707T020342Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260707T092615Z": { insideChips: 1, overlappingPairs: 1 },
+  "bug-report-20260707T134549Z": { insideChips: 0, overlappingPairs: 1 },
+  "bug-report-20260707T134722Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260707T140410Z": { insideChips: 0, overlappingPairs: 1 },
+  "bug-report-20260707T141025Z": { insideChips: 1, overlappingPairs: 0 },
+  "bug-report-20260707T141421Z": { insideChips: 1, overlappingPairs: 1 },
+  "bug-report-20260707T230831Z": { insideChips: 4, overlappingPairs: 0 },
+  "bug-report-20260708T053736Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260708T055430Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260708T095725Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260716T144856Z": { insideChips: 1, overlappingPairs: 0 },
+  "bug-report-20260717T022934Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260717T031704Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260717T042845Z": { insideChips: 0, overlappingPairs: 0 },
+  "bug-report-20260721T221026Z": { insideChips: 0, overlappingPairs: 2 },
+  "bug-report-20260724T175257Z": { insideChips: 0, overlappingPairs: 0 },
+}
+
+const BUG_REPORTS_DIR = path.join(import.meta.dir, "bug-reports")
+
+const measure = (board: string) => {
+  const inputPath = path.join(BUG_REPORTS_DIR, board, `${board}.json`)
+  const inputProblem = JSON.parse(fs.readFileSync(inputPath, "utf8"))
+
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+  solver.solve()
+
+  // The *output* copy — `netLabelPlacements` on the solver is its input.
+  const labels =
+    solver.netLabelNetLabelCollisionSolver?.getOutput().netLabelPlacements ?? []
+
+  return {
+    insideChips: getLabelsInsideChips(labels, solver.inputProblem).length,
+    overlappingPairs: getOverlappingLabelPairs(labels).length,
+  }
+}
+
+test("every pinned board still exists", () => {
+  const onDisk = fs
+    .readdirSync(BUG_REPORTS_DIR)
+    .filter((d) => fs.existsSync(path.join(BUG_REPORTS_DIR, d, `${d}.json`)))
+    .sort()
+
+  expect(onDisk).toEqual(Object.keys(EXPECTED).sort())
+})
+
+for (const [board, expected] of Object.entries(EXPECTED)) {
+  test(`${board} label placement defects`, () => {
+    expect(measure(board)).toEqual(expected)
+  })
+}


### PR DESCRIPTION
Same pattern as #718, applied to net-label placement instead of trace crossings.

## What it measures

Two defects, per imported bug report:

- **labels inside chip bodies** — they render behind the component and are illegible (#655)
- **label-label overlaps**

Corpus state on `main`: **8 labels inside chips, 7 overlapping pairs.**

## The threshold matters, and I got it wrong first

My initial version counted *any* interior overlap. That reported 17 in-chip labels — but when I looked at what it was flagging, most were incidental grazes:

```
TH_20    coverage=3%
TH_80    coverage=3%
SDA      coverage=6%
SCL      coverage=6%
HIDRV    coverage=1%
```

`NetLabelNetLabelCollisionSolver` has `CHIP_COLLISION_MIN_OVERLAP_FRACTION = 0.5` and tolerates smaller overlaps **deliberately** — its comment says relocating them can violate orientation preferences. So a metric counting every graze would report defects the solver is intentionally leaving alone, and would fight the implementation rather than guard it.

The helper now mirrors that constant. With it, the count is 8 rather than 17, and every remaining one is a genuine ≥50% cover.

## Why pin it

These boards are verified by SVG snapshots today. A label sliding under a chip is a few pixels in a large regenerated SVG and easy to approve by accident. Pinning means a placement regression fails an assertion that names the board.

**The numbers are current state, not targets.** Several are open bugs and should come down — #699 already takes `bug-report-20260707T230831Z` from 4 to 0.

There's also a guard asserting the pinned set matches what's on disk, so a newly imported bug report can't go unmeasured.

## Verification

- **The guard bites:** changing the expected `insideChips` for `bug-report-20260707T230831Z` from 4 to 3 fails with a visible diff. A pinning test that can't fail is worse than none.
- Full suite **168 pass / 0 fail / 4 skip**, `tsc --noEmit` clean, biome clean.
- Reads `netLabelNetLabelCollisionSolver.getOutput().netLabelPlacements` — the *output* copy. The solver also exposes `netLabelPlacements`, which is its input; reading that makes any fix look like a no-op.

**Diff: 2 new files, no existing file touched.** Independent of #718 — either can merge first.
