### PR TITLE
fix: key skipped label collisions by label pair, not net pair

### DIFF
--- a/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
+++ b/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
@@ -1,18 +1,18 @@
 import type { GraphicsObject } from "graphics-debug"
+import { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
-import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
-import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import type { MspConnectionPairId } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
-import type { InputProblem } from "lib/types/InputProblem"
-import type { FacingDirection } from "lib/utils/dir"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { rectIntersectsAnyTrace } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/collisions"
 import {
-  getDimsForOrientation,
   getCenterFromAnchor,
+  getDimsForOrientation,
   getRectBounds,
 } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
-import { rectIntersectsAnyTrace } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/collisions"
-import { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { FacingDirection } from "lib/utils/dir"
 import { getColorFromString } from "lib/utils/getColorFromString"
 import { rectIntersectsAnyTextBox } from "lib/utils/textBoxBounds"
 
@@ -147,8 +147,24 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
     return getRectBounds(label.center, label.width, label.height)
   }
 
+  /**
+   * Identifies a specific *pair of labels*, not merely the pair of nets they
+   * belong to.
+   *
+   * Keying on `globalConnNetId` alone collapses every label pair drawn from
+   * the same two nets into one key — on the larger boards a single net pair
+   * can account for over a hundred label pairs. Giving up on one of them then
+   * suppressed all the others, so overlaps that were never examined looked
+   * like overlaps the search had rejected.
+   *
+   * `pinIds` identifies the individual label, so this stays stable across
+   * relocations of the same label while still separating distinct pairs.
+   */
   private collisionKey(a: NetLabelPlacement, b: NetLabelPlacement) {
-    return [a.globalConnNetId, b.globalConnNetId].sort().join("::")
+    const labelKey = (label: NetLabelPlacement) =>
+      `${label.globalConnNetId}#${[...label.pinIds].sort().join(",")}`
+
+    return [labelKey(a), labelKey(b)].sort().join("::")
   }
 
   private findNextCollidingPair():

--- a/tests/solvers/NetLabelNetLabelCollisionSolver/collision-key-identifies-label-pair.test.ts
+++ b/tests/solvers/NetLabelNetLabelCollisionSolver/collision-key-identifies-label-pair.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { NetLabelNetLabelCollisionSolver } from "lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+
+const label = (globalConnNetId: string, pinIds: string[]) =>
+  ({
+    globalConnNetId,
+    pinIds,
+    mspConnectionPairIds: [],
+    orientation: "x+",
+    center: { x: 0, y: 0 },
+    width: 1,
+    height: 1,
+  }) as unknown as NetLabelPlacement
+
+const collisionKey = (a: NetLabelPlacement, b: NetLabelPlacement) =>
+  (
+    NetLabelNetLabelCollisionSolver.prototype as unknown as {
+      collisionKey: (a: NetLabelPlacement, b: NetLabelPlacement) => string
+    }
+  ).collisionKey(a, b)
+
+test("distinct label pairs on the same nets get distinct collision keys", () => {
+  // Two separate pairs of labels, both drawn from netA and netB. Keying on the
+  // net ids alone would collapse them into one key, so abandoning the search
+  // for the first pair would silently suppress the second — on the larger
+  // boards a single net pair covers over a hundred label pairs.
+  const first = collisionKey(label("netA", ["p1"]), label("netB", ["p2"]))
+  const second = collisionKey(label("netA", ["p3"]), label("netB", ["p4"]))
+
+  expect(first).not.toBe(second)
+})
+
+test("collision key is stable regardless of argument order", () => {
+  const a = label("netA", ["p1"])
+  const b = label("netB", ["p2"])
+
+  expect(collisionKey(a, b)).toBe(collisionKey(b, a))
+})
+
+test("collision key is stable regardless of pin id order", () => {
+  const a = label("netA", ["p1", "p2"])
+  const b = label("netA", ["p2", "p1"])
+  const other = label("netB", ["p3"])
+
+  expect(collisionKey(a, other)).toBe(collisionKey(b, other))
+})


### PR DESCRIPTION
Latent bug found while investigating the 7 remaining label-label overlaps from #720. **It changes no board today** — I'll be upfront about that — but it's a real aliasing defect with a direct test.

## The bug

`NetLabelNetLabelCollisionSolver` gives up on a collision when it exhausts its candidate positions, recording the pair in `skippedCollisionKeys` so `findNextCollidingPair` won't retry it. The key was:

```ts
private collisionKey(a: NetLabelPlacement, b: NetLabelPlacement) {
  return [a.globalConnNetId, b.globalConnNetId].sort().join("::")
}
```

That identifies a pair of **nets**, not a pair of **labels**. Any two labels from netA and netB share one key, so abandoning the search for one pair silently suppresses every other pair on those same nets — including ones that were never examined and might well have been resolvable.

Scale of the aliasing across the corpus:

```
bug-report-20260706T220324Z:  459 net-pairs have >1 label pair (max 136)
bug-report-20260707T092615Z:  163 net-pairs have >1 label pair (max  70)
bug-report-20260707T140410Z:   73 net-pairs have >1 label pair (max  21)
bug-report-20260716T144856Z:   49 net-pairs have >1 label pair (max  30)
```

So one skip could mask up to 135 unexamined pairs.

## The fix

Include `pinIds` in the key. It identifies the individual label and is stable across relocations of that label, so distinct pairs stay distinct while a label being moved keeps its identity.

## Honest scope: no board changes

I measured before and after across every imported bug report:

```
before:  insideChips=8  overlappingPairs=7
after:   insideChips=8  overlappingPairs=7
```

Identical. I checked why, rather than shipping and claiming an improvement: **among label pairs that actually overlap today, no two share a net-pair key.** The 5 skipped keys are each the only overlap for their nets, so the aliasing never fires on this corpus. It's latent.

I considered dropping the change for that reason. I kept it because the defect is provable independently of whether a fixture happens to trigger it, and because a board that does trigger it would fail in a confusing way — overlaps that were never examined would look like overlaps the search had rejected.

## Verification

Three tests pin the key's contract directly:

- distinct label pairs on the same nets get distinct keys
- the key is stable regardless of argument order
- the key is stable regardless of `pinIds` order

**Confirmed they bite:** reverting `collisionKey` to the old net-only version fails the first test (2 pass / 1 fail).

Full suite **151 pass / 0 fail / 4 skip**, `tsc --noEmit` clean, biome clean.

**Diff: 1 source file (+17/-1) plus one test file.** Independent of #699/#720.
