### PR TITLE
Prefer adaptive elbows for short backtracking routes

### DIFF
--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
@@ -58,6 +58,25 @@ const calculateElbowForPins = ({
     { overshoot },
   )
 
+const pinsFaceEachOther = ({
+  pin1,
+  pin2,
+}: {
+  pin1: MspConnectionPair["pins"][number]
+  pin2: MspConnectionPair["pins"][number]
+}) => {
+  const xDistance = pin2.x - pin1.x
+  const yDistance = pin2.y - pin1.y
+  if (Math.abs(xDistance) >= Math.abs(yDistance)) {
+    return xDistance > 0
+      ? pin1._facingDirection === "x+" && pin2._facingDirection === "x-"
+      : pin1._facingDirection === "x-" && pin2._facingDirection === "x+"
+  }
+  return yDistance > 0
+    ? pin1._facingDirection === "y+" && pin2._facingDirection === "y-"
+    : pin1._facingDirection === "y-" && pin2._facingDirection === "y+"
+}
+
 export class SchematicTraceSingleLineSolver2 extends BaseSolver {
   pins: MspConnectionPair["pins"]
   connectionPair?: MspConnectionPair
@@ -130,9 +149,16 @@ export class SchematicTraceSingleLineSolver2 extends BaseSolver {
       pin2,
       overshoot: Math.min(0.2, Math.max(0.02, routingDistance / 4)),
     })
+    const adaptiveElbowIsShorter =
+      this.pathLength(adaptiveElbow) < this.pathLength(defaultElbow)
+    const defaultElbowBacktracks =
+      this.pathLength(defaultElbow) > routingDistance + 1e-9
     const shouldUseAdaptiveElbow =
-      findFirstCollision(defaultElbow, this.obstacles) !== null &&
-      findFirstCollision(adaptiveElbow, this.obstacles) === null
+      findFirstCollision(adaptiveElbow, this.obstacles) === null &&
+      ((pinsFaceEachOther({ pin1, pin2 }) &&
+        defaultElbowBacktracks &&
+        adaptiveElbowIsShorter) ||
+        findFirstCollision(defaultElbow, this.obstacles) !== null)
 
     // Build initial elbow path
     this.baseElbow = defaultElbow

--- a/tests/solvers/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2_repro47-short-opposing-pins.test.ts
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2_repro47-short-opposing-pins.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { SchematicTraceSingleLineSolver2 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+import type { InputChip, InputProblem } from "lib/types/InputProblem"
+
+const getOrthogonalPathLength = (points: Array<{ x: number; y: number }>) =>
+  points.slice(0, -1).reduce((length, point, pointIndex) => {
+    const nextPoint = points[pointIndex + 1]!
+    return (
+      length + Math.abs(nextPoint.x - point.x) + Math.abs(nextPoint.y - point.y)
+    )
+  }, 0)
+
+test("repro47 uses a minimal route between nearby opposing pins", async () => {
+  const diode: InputChip = {
+    chipId: "D2",
+    center: { x: 3.2, y: 0.095 },
+    width: 0.4,
+    height: 0.2,
+    pins: [{ pinId: "D2.cathode", x: 3.4, y: 0.095 }],
+  }
+  const pushButton: InputChip = {
+    chipId: "SW2",
+    center: { x: 3.81, y: 0.045 },
+    width: 0.4,
+    height: 0.2,
+    pins: [{ pinId: "SW2.pin1", x: 3.61, y: 0.045 }],
+  }
+  const pins: ConstructorParameters<
+    typeof SchematicTraceSingleLineSolver2
+  >[0]["pins"] = [
+    {
+      pinId: "D2.cathode",
+      chipId: diode.chipId,
+      x: 3.4,
+      y: 0.095,
+      _facingDirection: "x+" as const,
+    },
+    {
+      pinId: "SW2.pin1",
+      chipId: pushButton.chipId,
+      x: 3.61,
+      y: 0.045,
+      _facingDirection: "x-" as const,
+    },
+  ]
+  const inputProblem: InputProblem = {
+    chips: [diode, pushButton],
+    directConnections: [{ pinIds: [pins[0].pinId, pins[1].pinId] }],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+  const solver = new SchematicTraceSingleLineSolver2({
+    pins,
+    chipMap: { [diode.chipId]: diode, [pushButton.chipId]: pushButton },
+    inputProblem,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(getOrthogonalPathLength(solver.solvedTracePath!)).toBeCloseTo(0.26)
+  await expect(solver).toMatchSolverSnapshot(import.meta.path)
+})

--- a/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/SchematicTraceSingleLineSolver2_repro47-short-opposing-pins.snap.svg
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/__snapshots__/SchematicTraceSingleLineSolver2_repro47-short-opposing-pins.snap.svg
@@ -1,0 +1,46 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="3.4,0.095 3.61,0.045" data-type="line" data-label="" points="261.78217821782187,306.13861386138615 378.21782178217813,333.86138613861385" fill="none" stroke="hsl(112, 100%, 50%, 0.1)" stroke-width="1px"/></g><g><polyline data-points="3.4,0.095 3.465,0.095 3.505,0.095 3.505,0.045 3.545,0.045 3.61,0.045" data-type="line" data-label="" points="261.78217821782187,306.13861386138615 297.82178217821775,306.13861386138615 320,306.13861386138615 320,333.86138613861385 342.17821782178225,333.86138613861385 378.21782178217813,333.86138613861385" fill="none" stroke="red" stroke-width="1px" stroke-dasharray="4 4"/></g><g><polyline data-points="3.4,0.095 3.61,0.045" data-type="line" data-label="" points="261.78217821782187,306.13861386138615 378.21782178217813,333.86138613861385" fill="none" stroke="blue" stroke-width="1px" stroke-dasharray="5 5"/></g><g><polyline data-points="3.4,0.095 3.465,0.095 3.505,0.095 3.505,0.045 3.545,0.045 3.61,0.045" data-type="line" data-label="" points="261.78217821782187,306.13861386138615 297.82178217821775,306.13861386138615 320,306.13861386138615 320,333.86138613861385 342.17821782178225,333.86138613861385 378.21782178217813,333.86138613861385" fill="none" stroke="green" stroke-width="1px"/></g><g><rect data-type="rect" data-label="D2" data-x="3.2" data-y="0.095" x="40" y="250.69306930693068" width="221.7821782178221" height="110.89108910891093" fill="hsl(358, 100%, 50%, 0.1)" stroke="black" stroke-width="0.0018035714285714283"/></g><g><rect data-type="rect" data-label="SW2" data-x="3.81" data-y="0.045" x="378.21782178217825" y="278.41584158415844" width="221.78217821782187" height="110.89108910891088" fill="hsl(70, 100%, 50%, 0.1)" stroke="black" stroke-width="0.0018035714285714283"/></g><g><circle data-type="point" data-label="D2.cathode
+x+" data-x="3.4" data-y="0.095" cx="261.78217821782187" cy="306.13861386138615" r="3" fill="hsl(22, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="SW2.pin1
+x-" data-x="3.61" data-y="0.045" cx="378.21782178217813" cy="333.86138613861385" r="3" fill="hsl(12, 100%, 50%, 0.8)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":554.4554455445545,"c":0,"e":-1623.3663366336636,"b":0,"d":-554.4554455445545,"f":358.81188118811883};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>


### PR DESCRIPTION
## Summary

- prefer the adaptive elbow when a fixed-overshoot route between inward-facing pins backtracks
- retain the default elbow for non-backtracking routes and preserve the existing adaptive-on-collision behavior
- add a pin-level regression using the core repro47 D2/SW2 geometry, plus a solver SVG snapshot

## Root cause

Core's `repro47-switch-matrix-diodes` circuit places several diode cathodes about 0.26 schematic units from their switch pins. The default elbow uses a fixed 0.2-unit overshoot from both endpoints, so its legs pass one another and produce a 0.64-unit serpentine. Because that route is collision-free, the existing collision fallback never selects the shorter adaptive elbow.

The new predicate selects the adaptive path only when the pins face each other, the default route backtracks, the adaptive path is shorter, and the adaptive path is collision-free.

## Core repro47 before/after

These are the full schematic snapshots from `tests/repros/repro47-switch-matrix-diodes.test.tsx`. The before image is core `main`; the after image is byte-for-byte identical to the snapshot rendered from clean core `main` with this locally built solver branch.

### Before

![Core repro47 before — serpentine diode-to-switch traces](https://raw.githubusercontent.com/tscircuit/core/46d5ae90cc4071045ffdc0a76a3db48fdc1d5be3/tests/repros/__snapshots__/repro47-switch-matrix-diodes-schematic.snap.svg)

### After

![Core repro47 after — compact diode-to-switch traces](https://raw.githubusercontent.com/tscircuit/core/9f61480de5f60dae5da2ff5df5e0c160ab99d1b4/tests/repros/__snapshots__/repro47-switch-matrix-diodes-schematic.snap.svg)

## Validation

- solver `bun test` — 145 pass, 4 skip, 0 fail
- solver `bunx tsc --noEmit`
- solver `bun run build`
- core `bun test --timeout 15000` with the local solver — 1259 pass, 31 skip, 0 fail
- core `./node_modules/.bin/tsc --noEmit`