### PR TITLE
Add pushbutton-diode short trace shape repro

### DIFF
--- a/tests/repros/__snapshots__/repro-pushbutton-diode-short-opposing-pins.snap.svg
+++ b/tests/repros/__snapshots__/repro-pushbutton-diode-short-opposing-pins.snap.svg
@@ -1,0 +1,50 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0.73,-0.05 0.52,0" data-type="line" data-label="" points="359.63470319634706,321.27853881278537 305.93607305936075,308.4931506849315" fill="none" stroke="hsl(16, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="0.73,-0.05 0.625,-0.05 0.625,0 0.52,0" data-type="line" data-label="" points="359.63470319634706,321.27853881278537 332.78538812785393,321.27853881278537 332.78538812785393,308.4931506849315 305.93607305936075,308.4931506849315" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="schematic_component_0" data-x="1.2" data-y="0" x="359.6347031963471" y="216.57762739726036" width="240.36529680365294" height="183.83104657534224" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.003910714285714286"/></g><g><rect data-type="rect" data-label="schematic_component_1" data-x="0" data-y="0.07" x="40" y="203.65296803652967" width="265.93607305936075" height="173.8812785388128" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.003910714285714286"/></g><g><rect data-type="rect" data-label="netId: .SW1 &gt; .pin1 to D1.pin2
+globalConnNetId: connectivity_net0" data-x="0.625" data-y="-0.275" x="307.2146118721462" y="321.27853881278537" width="51.14155251141551" height="115.06849315068496" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.003910714285714286"/></g><g><circle data-type="point" data-label="schematic_port_0
+x-" data-x="0.73" data-y="-0.05" cx="359.63470319634706" cy="321.27853881278537" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_1
+x+" data-x="1.67" data-y="-0.05" cx="600" cy="321.27853881278537" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_2
+x-" data-x="-0.52" data-y="0" cx="40" cy="308.4931506849315" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_3
+x+" data-x="0.52" data-y="0" cx="305.93607305936075" cy="308.4931506849315" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="0.625" data-y="-0.05" cx="332.78538812785393" cy="321.27853881278537" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":255.70776255707764,"c":0,"e":172.96803652968038,"b":0,"d":-255.70776255707764,"f":308.4931506849315};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/assets/repro-pushbutton-diode-short-opposing-pins.input.json
+++ b/tests/repros/assets/repro-pushbutton-diode-short-opposing-pins.input.json
@@ -1,0 +1,63 @@
+{
+  "chips": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": 1.2,
+        "y": 0
+      },
+      "width": 0.94,
+      "height": 0.718910699999999,
+      "pins": [
+        {
+          "pinId": "schematic_port_0",
+          "x": 0.73,
+          "y": -0.05,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_1",
+          "x": 1.67,
+          "y": -0.05,
+          "_facingDirection": "x+"
+        }
+      ]
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": {
+        "x": 0,
+        "y": 0.07
+      },
+      "width": 1.04,
+      "height": 0.68,
+      "pins": [
+        {
+          "pinId": "schematic_port_2",
+          "x": -0.52,
+          "y": 0,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_3",
+          "x": 0.52,
+          "y": 0,
+          "_facingDirection": "x+"
+        }
+      ]
+    }
+  ],
+  "directConnections": [
+    {
+      "netId": ".SW1 > .pin1 to D1.pin2",
+      "pinIds": [
+        "schematic_port_0",
+        "schematic_port_3"
+      ]
+    }
+  ],
+  "netConnections": [],
+  "textBoxes": [],
+  "availableNetLabelOrientations": {},
+  "maxMspPairDistance": 2.4
+}

--- a/tests/repros/repro-pushbutton-diode-short-opposing-pins.test.ts
+++ b/tests/repros/repro-pushbutton-diode-short-opposing-pins.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "./assets/repro-pushbutton-diode-short-opposing-pins.input.json"
+import "tests/fixtures/matcher"
+
+// Captured from @tscircuit/core: a pushbutton and diode with nearby opposing
+// pins produce a hooked multi-segment trace in the full schematic pipeline.
+test("pushbutton-to-diode short opposing pins produce a hooked trace", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- add a full-pipeline repro using the exact `@tscircuit/core` input for a pushbutton connected to a nearby diode
- capture the hooked three-segment route between the two opposing pins in an SVG snapshot

## Context

The Core circuit places `D1.pin2` at `(0.52, 0)` and `SW1.pin1` at `(0.73, -0.05)`, only `0.26` schematic units apart by Manhattan distance. Despite that short distance, the pipeline creates a centered dogleg instead of a cleaner short connection.

There is already line-solver coverage for similar nearby opposing pins; this repro preserves the exact Core geometry and exercises the complete schematic trace pipeline.

## Validation

- `bun test` — 150 passed, 4 skipped
- `bun test tests/repros/repro-pushbutton-diode-short-opposing-pins.test.ts`
- `bun run format:check`
- `bun run build`
- visually checked the final headless pipeline-stage render against the reported shape