### PR TITLE
Add TYPE_C same-chip connection repro

### DIFF
--- a/tests/repros/__snapshots__/repro-type-c-16pin-self-connection.snap.svg
+++ b/tests/repros/__snapshots__/repro-type-c-16pin-self-connection.snap.svg
@@ -1,0 +1,54 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-1.3,-0.30000000000000004 1.3,-0.30000000000000004" data-type="line" data-label="" points="94.19354838709677,376 563.8709677419354,376" fill="none" stroke="hsl(8, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="-1.3,-0.30000000000000004 -1.5,-0.30000000000000004 -1.5,-0.52 1.5000000000000007,-0.52 1.5000000000000007,-0.30000000000000004 1.3000000000000005,-0.30000000000000004" data-type="line" data-label="" points="94.19354838709677,376 58.064516129032256,376 58.064516129032256,415.741935483871 600,415.741935483871 600,376 563.8709677419355,376" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="94.1935483870968" y="231.48387096774195" width="469.6774193548386" height="180.64516129032256" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.005535714285714286"/></g><g><rect data-type="rect" data-label="TYPE_C_16PIN_2MD" data-x="0.06" data-y="-0.63" x="166.4516129032258" y="419.35483870967744" width="346.8387096774193" height="32.51612903225805" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.005535714285714286"/></g><g><rect data-type="rect" data-label="U1" data-x="-0.78" data-y="0.615" x="155.6129032258064" y="188.12903225806457" width="65.03225806451613" height="45.16129032258064" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.005535714285714286"/></g><g><rect data-type="rect" data-label="netId: .U1 &gt; .pin4 to U1.pin5
+globalConnNetId: connectivity_net0" data-x="-1.5" data-y="0.17999999999999994" x="39.999999999999986" y="202.58064516129036" width="36.12903225806454" height="173.41935483870964" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.005535714285714286"/></g><g><circle data-type="point" data-label="schematic_port_0
+x-" data-x="-1.3" data-y="0.30000000000000004" cx="94.19354838709677" cy="267.61290322580646" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_1
+x-" data-x="-1.3" data-y="0.10000000000000003" cx="94.19354838709677" cy="303.741935483871" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_2
+x-" data-x="-1.3" data-y="-0.09999999999999998" cx="94.19354838709677" cy="339.8709677419355" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_3
+x-" data-x="-1.3" data-y="-0.30000000000000004" cx="94.19354838709677" cy="376" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_4
+x+" data-x="1.3" data-y="-0.30000000000000004" cx="563.8709677419354" cy="376" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_5
+x+" data-x="1.3" data-y="-0.10000000000000003" cx="563.8709677419354" cy="339.8709677419355" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_6
+x+" data-x="1.3" data-y="0.09999999999999998" cx="563.8709677419354" cy="303.741935483871" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_7
+x+" data-x="1.3" data-y="0.30000000000000004" cx="563.8709677419354" cy="267.61290322580646" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-1.5" data-y="-0.30000000000000004" cx="58.064516129032256" cy="376" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":180.64516129032256,"c":0,"e":329.0322580645161,"b":0,"d":-180.64516129032256,"f":321.80645161290323};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/repro-type-c-16pin-self-connection.test.ts
+++ b/tests/repros/repro-type-c-16pin-self-connection.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import "tests/fixtures/matcher"
+
+// Captured from @tscircuit/core for a TYPE_C_16PIN_2MD chip whose pin 4 is
+// connected directly to pin 5 on the same schematic component.
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "schematic_component_0",
+      center: { x: 0, y: 0 },
+      width: 2.6,
+      height: 1,
+      pins: [
+        {
+          pinId: "schematic_port_0",
+          x: -1.3,
+          y: 0.30000000000000004,
+        },
+        {
+          pinId: "schematic_port_1",
+          x: -1.3,
+          y: 0.10000000000000003,
+        },
+        {
+          pinId: "schematic_port_2",
+          x: -1.3,
+          y: -0.09999999999999998,
+        },
+        {
+          pinId: "schematic_port_3",
+          x: -1.3,
+          y: -0.30000000000000004,
+        },
+        {
+          pinId: "schematic_port_4",
+          x: 1.3,
+          y: -0.30000000000000004,
+        },
+        {
+          pinId: "schematic_port_5",
+          x: 1.3,
+          y: -0.10000000000000003,
+        },
+        {
+          pinId: "schematic_port_6",
+          x: 1.3,
+          y: 0.09999999999999998,
+        },
+        {
+          pinId: "schematic_port_7",
+          x: 1.3,
+          y: 0.30000000000000004,
+        },
+      ],
+    },
+  ],
+  directConnections: [
+    {
+      netId: ".U1 > .pin4 to U1.pin5",
+      netLabelWidth: 0.96,
+      pinIds: ["schematic_port_3", "schematic_port_4"],
+    },
+  ],
+  netConnections: [],
+  textBoxes: [
+    {
+      chipId: "schematic_component_0",
+      center: { x: 0.06, y: -0.63 },
+      width: 1.92,
+      height: 0.17999999999999994,
+      text: "TYPE_C_16PIN_2MD",
+    },
+    {
+      chipId: "schematic_component_0",
+      center: { x: -0.78, y: 0.615 },
+      width: 0.3599999999999999,
+      height: 0.25,
+      text: "U1",
+    },
+  ],
+  availableNetLabelOrientations: {},
+  maxMspPairDistance: 2.4,
+  _hideRatsNet: false,
+}
+
+test("TYPE_C_16PIN_2MD routes pin 4 to pin 5 on the same chip", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+
+  solver.solve()
+
+  expect(solver.netLabelTraceCollisionSolver!.getOutput().traces).toHaveLength(
+    1,
+  )
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- add a schematic trace solver repro captured from `@tscircuit/core`
- reproduce a `TYPE_C_16PIN_2MD` chip with `U1.pin4` connected to `U1.pin5`
- preserve the manufacturer-part-number and reference-designator text boxes in the captured solver input
- add the generated solver snapshot for the same-chip route

## Why

This provides a minimal trace-solver fixture for the supplied core circuit, including the route's interaction with the manufacturer-part-number text box.

## Validation

- `bun test tests/repros/repro-type-c-16pin-self-connection.test.ts`
- `bun test` — 151 passed, 4 skipped, 0 failed
- `bun run format:check`
- `bun run build`