### PR TITLE
add RP2040 net label placement repro

### DIFF
--- a/tests/repros/__snapshots__/repro-rp2040-v3v3-label-placement.snap.svg
+++ b/tests/repros/__snapshots__/repro-rp2040-v3v3-label-placement.snap.svg
@@ -1,0 +1,70 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-1.35,0.9999999999999998 -1.35,2.8" data-type="line" data-label="" points="236.98717948717947,241.02564102564105 236.98717948717947,79.48717948717953" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="-1.35,0.9999999999999998 -1.35,-1.4000000000000004" data-type="line" data-label="" points="236.98717948717947,241.02564102564105 236.98717948717947,456.41025641025647" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="-1.35,2.8 -1.35,-1.4000000000000004" data-type="line" data-label="" points="236.98717948717947,79.48717948717953 236.98717948717947,456.41025641025647" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="-1.35,0.9999999999999998 -1.55,0.9999999999999998 -1.55,2.8 -1.35,2.8" data-type="line" data-label="" points="236.98717948717947,241.02564102564105 219.03846153846155,241.02564102564105 219.03846153846155,79.48717948717953 236.98717948717947,79.48717948717953" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="-1.55,0.9999999999999998 -1.9000000000000001,0.9999999999999998 -1.9000000000000001,1.0009999999999997" data-type="line" data-label="" points="219.03846153846155,241.02564102564105 187.6282051282051,241.02564102564105 187.6282051282051,240.93589743589746" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="-1.35,-1.4000000000000004 -1.701,-1.4000000000000004 -1.701,-1.3490000000000004" data-type="line" data-label="" points="236.98717948717947,456.41025641025647 205.48717948717947,456.41025641025647 205.48717948717947,451.83333333333337" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="U1" data-x="0" data-y="0" x="236.98717948717945" y="61.53846153846155" width="242.30769230769235" height="538.4615384615385" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.011142857142857144"/></g><g><rect data-type="rect" data-label="U1" data-x="-0.83" data-y="3.115" x="267.5" y="40" width="32.30769230769232" height="22.43589743589746" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.011142857142857144"/></g><g><rect data-type="rect" data-label="netId: V3V3
+globalConnNetId: connectivity_net0" data-x="-1.9000000000000001" data-y="1.2109999999999996" x="160.70512820512818" y="203.2435897435898" width="53.84615384615384" height="37.69230769230768" fill="#ef444466" stroke="#ef4444" stroke-width="0.011142857142857144"/></g><g><rect data-type="rect" data-label="netId: V3V3
+globalConnNetId: connectivity_net0" data-x="-1.701" data-y="-1.1390000000000005" x="178.56410256410254" y="414.14102564102575" width="53.84615384615384" height="37.69230769230768" fill="#ef444466" stroke="#ef4444" stroke-width="0.011142857142857144"/></g><g><circle data-type="point" data-label="U1.1
+x-" data-x="-1.35" data-y="2.8" cx="236.98717948717947" cy="79.48717948717953" r="3" fill="hsl(319, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.2
+x-" data-x="-1.35" data-y="2.5999999999999996" cx="236.98717948717947" cy="97.43589743589749" r="3" fill="hsl(320, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.3
+x-" data-x="-1.35" data-y="2.4" cx="236.98717948717947" cy="115.38461538461542" r="3" fill="hsl(321, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.4
+x-" data-x="-1.35" data-y="2.1999999999999997" cx="236.98717948717947" cy="133.33333333333337" r="3" fill="hsl(322, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.5
+x-" data-x="-1.35" data-y="1.9999999999999998" cx="236.98717948717947" cy="151.28205128205133" r="3" fill="hsl(323, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.6
+x-" data-x="-1.35" data-y="1.7999999999999998" cx="236.98717948717947" cy="169.23076923076925" r="3" fill="hsl(324, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.7
+x-" data-x="-1.35" data-y="1.5999999999999996" cx="236.98717948717947" cy="187.17948717948724" r="3" fill="hsl(325, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.8
+x-" data-x="-1.35" data-y="1.3999999999999997" cx="236.98717948717947" cy="205.12820512820517" r="3" fill="hsl(326, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.9
+x-" data-x="-1.35" data-y="1.1999999999999997" cx="236.98717948717947" cy="223.0769230769231" r="3" fill="hsl(327, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.10
+x-" data-x="-1.35" data-y="0.9999999999999998" cx="236.98717948717947" cy="241.02564102564105" r="3" fill="hsl(217, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.11
+x-" data-x="-1.35" data-y="0.7999999999999998" cx="236.98717948717947" cy="258.974358974359" r="3" fill="hsl(218, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.12
+x-" data-x="-1.35" data-y="0.5999999999999996" cx="236.98717948717947" cy="276.92307692307696" r="3" fill="hsl(219, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.13
+x-" data-x="-1.35" data-y="0.39999999999999947" cx="236.98717948717947" cy="294.8717948717949" r="3" fill="hsl(220, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.14
+x-" data-x="-1.35" data-y="0.19999999999999973" cx="236.98717948717947" cy="312.8205128205129" r="3" fill="hsl(221, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.15
+x-" data-x="-1.35" data-y="-4.440892098500626e-16" cx="236.98717948717947" cy="330.76923076923083" r="3" fill="hsl(222, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.16
+x-" data-x="-1.35" data-y="-0.20000000000000018" cx="236.98717948717947" cy="348.71794871794873" r="3" fill="hsl(223, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.17
+x-" data-x="-1.35" data-y="-0.40000000000000036" cx="236.98717948717947" cy="366.6666666666667" r="3" fill="hsl(224, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.18
+x-" data-x="-1.35" data-y="-0.6000000000000005" cx="236.98717948717947" cy="384.61538461538464" r="3" fill="hsl(225, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.19
+x-" data-x="-1.35" data-y="-0.8000000000000003" cx="236.98717948717947" cy="402.5641025641026" r="3" fill="hsl(226, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.20
+x-" data-x="-1.35" data-y="-1.0000000000000004" cx="236.98717948717947" cy="420.51282051282055" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.21
+x-" data-x="-1.35" data-y="-1.2000000000000002" cx="236.98717948717947" cy="438.46153846153845" r="3" fill="hsl(249, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.22
+x-" data-x="-1.35" data-y="-1.4000000000000004" cx="236.98717948717947" cy="456.41025641025647" r="3" fill="hsl(250, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-1.9000000000000001" data-y="1.0009999999999997" cx="187.6282051282051" cy="240.93589743589746" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-1.701" data-y="-1.3490000000000004" cx="205.48717948717947" cy="451.83333333333337" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":89.74358974358974,"c":0,"e":358.14102564102564,"b":0,"d":-89.74358974358974,"f":330.7692307692308};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/repro-rp2040-v3v3-label-placement.test.ts
+++ b/tests/repros/repro-rp2040-v3v3-label-placement.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import "tests/fixtures/matcher"
+
+// Reduced from the current @tscircuit/core input for an RP2040. The important
+// details are the 0.2-unit pin pitch, V3V3's 0.6-unit rail-label height, and a
+// third distance-split net member. The reversed first pair preserves the MSP
+// pair direction produced by the original multi-pin input (pin 10 to pin 1).
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "U1",
+      center: { x: 0, y: 0 },
+      width: 1.9,
+      height: 6,
+      pins: Array.from({ length: 22 }, (_, index) => ({
+        pinId: `U1.${index + 1}`,
+        x: -1.35,
+        y: 2.8 - index * 0.2,
+        _facingDirection: "x-" as const,
+      })),
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    {
+      netId: "V3V3",
+      pinIds: ["U1.10", "U1.1", "U1.22"],
+      netLabelWidth: 0.42,
+      netLabelHeight: 0.6,
+    },
+  ],
+  textBoxes: [
+    {
+      chipId: "U1",
+      center: { x: -0.83, y: 3.115 },
+      width: 0.36,
+      height: 0.25,
+      text: "U1",
+    },
+  ],
+  availableNetLabelOrientations: { V3V3: ["y+"] },
+  maxMspPairDistance: 2.4,
+}
+
+test("reproduces RP2040 V3V3 label placed by pin 10 instead of pin 1", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+
+  solver.solve()
+
+  const v3v3Label = solver
+    .netLabelNetLabelCollisionSolver!.getOutput()
+    .netLabelPlacements.find(
+      (label) => label.netId === "V3V3" && label.pinIds.includes("U1.1"),
+    )
+
+  expect(v3v3Label?.orientation).toBe("y+")
+  // This reproduces the bug: the label is by pin 10 (y=1), not pin 1 (y=2.8).
+  expect(v3v3Label?.anchorPoint.y).toBeCloseTo(1)
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## What changed

- adds a reduced RP2040-shaped input that reproduces the V3V3 label anchoring beside pin 10 instead of the top pin 1
- captures the incorrect final layout in an SVG solver snapshot
- documents the multi-pin MSP ordering and distance-split conditions needed to trigger the issue

## Impact

This gives the solver a focused regression fixture for the downward-displaced vertical rail label before changing placement behavior.

## Validation

- `bun test tests/repros/repro-rp2040-v3v3-label-placement.test.ts`
- full suite previously verified locally: 157 passed, 4 skipped
- `bunx tsc --noEmit`
- `bun run format:check`