### PR TITLE
test: add STM32C071 VSS / PA0 overlap repro

### DIFF
--- a/tests/repros/__snapshots__/repro-stm32c071-vss-through-pa0.snap.svg
+++ b/tests/repros/__snapshots__/repro-stm32c071-vss-through-pa0.snap.svg
@@ -1,0 +1,67 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-0.5,0.21000000000000002 0,0.08" data-type="line" data-label="" points="192.72727272727272,275.8787878787879 362.42424242424244,320" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="-0.46,-0.06 0,-0.06" data-type="line" data-label="" points="206.30303030303028,367.51515151515156 362.42424242424244,367.51515151515156" fill="none" stroke="hsl(342, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="0,-0.06 0,0.04" data-type="line" data-label="" points="362.42424242424244,367.51515151515156 362.42424242424244,333.5757575757576" fill="none" stroke="hsl(342, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="-0.5,0.21000000000000002 -0.5,0.41000000000000003 -0.25,0.41000000000000003 -0.25,0.08000000000000002 0,0.08000000000000002" data-type="line" data-label="" points="192.72727272727272,275.8787878787879 192.72727272727272,208 277.57575757575756,208 277.57575757575756,320 362.42424242424244,320" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="0,0.04000000000000001 -0.025,0.04000000000000001 -0.025,-0.009999999999999995 0,-0.009999999999999995 0,-0.06" data-type="line" data-label="" points="362.42424242424244,333.5757575757576 353.93939393939394,333.5757575757576 353.93939393939394,350.54545454545456 362.42424242424244,350.54545454545456 362.42424242424244,367.51515151515156" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="-0.46,-0.06 0,-0.06" data-type="line" data-label="" points="206.30303030303028,367.51515151515156 362.42424242424244,367.51515151515156" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="U_MCU" data-x="0.35" data-y="0" x="362.4242424242425" y="262.3030303030303" width="237.57575757575756" height="169.69696969696975" fill="hsl(229, 100%, 50%, 0.8)" stroke="black" stroke-width="0.002946428571428571"/></g><g><rect data-type="rect" data-label="C_MCU" data-x="-0.5" data-y="0.07" x="179.15151515151513" y="275.8787878787879" width="27.151515151515156" height="95.03030303030306" fill="hsl(211, 100%, 50%, 0.8)" stroke="black" stroke-width="0.002946428571428571"/></g><g><rect data-type="rect" data-label="GND_RAIL" data-x="-0.03" data-y="-0.06" x="342.06060606060606" y="357.33333333333337" width="20.363636363636374" height="20.363636363636374" fill="hsl(188, 100%, 50%, 0.8)" stroke="black" stroke-width="0.002946428571428571"/></g><g><rect data-type="rect" data-label="netId: V3V3
+globalConnNetId: connectivity_net0" data-x="-0.725" data-y="0.31000000000000005" x="39.999999999999986" y="208" width="152.72727272727272" height="67.87878787878788" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.002946428571428571"/></g><g><rect data-type="rect" data-label="netId: SWD_NRST
+globalConnNetId: connectivity_net2" data-x="-0.276" data-y="0" x="175.41818181818178" y="313.21212121212125" width="186.66666666666674" height="67.87878787878788" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.002946428571428571"/></g><g><circle data-type="point" data-label="U_MCU.PB7
+x-" data-x="0" data-y="0.2" cx="362.42424242424244" cy="279.2727272727273" r="3" fill="hsl(356, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PC14
+x-" data-x="0" data-y="0.16" cx="362.42424242424244" cy="292.8484848484849" r="3" fill="hsl(343, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PC15
+x-" data-x="0" data-y="0.12" cx="362.42424242424244" cy="306.42424242424244" r="3" fill="hsl(344, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.VDD
+x-" data-x="0" data-y="0.08" cx="362.42424242424244" cy="320" r="3" fill="hsl(77, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.VSS
+x-" data-x="0" data-y="0.04" cx="362.42424242424244" cy="333.5757575757576" r="3" fill="hsl(197, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PF2
+x-" data-x="0" data-y="0" cx="362.42424242424244" cy="347.1515151515152" r="3" fill="hsl(115, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA0
+x-" data-x="0" data-y="-0.04" cx="362.42424242424244" cy="360.72727272727275" r="3" fill="hsl(318, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA1
+x-" data-x="0" data-y="-0.08" cx="362.42424242424244" cy="374.30303030303037" r="3" fill="hsl(319, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PB3
+x+" data-x="0.7" data-y="0.2" cx="600" cy="279.2727272727273" r="3" fill="hsl(352, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA14
+x+" data-x="0.7" data-y="0.16" cx="600" cy="292.8484848484849" r="3" fill="hsl(221, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA13
+x+" data-x="0.7" data-y="0.12" cx="600" cy="306.42424242424244" r="3" fill="hsl(220, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA12
+x+" data-x="0.7" data-y="0.08" cx="600" cy="320" r="3" fill="hsl(219, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA11
+x+" data-x="0.7" data-y="0.04" cx="600" cy="333.5757575757576" r="3" fill="hsl(218, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA8
+x+" data-x="0.7" data-y="0" cx="600" cy="347.1515151515152" r="3" fill="hsl(326, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA7
+x+" data-x="0.7" data-y="-0.04" cx="600" cy="360.72727272727275" r="3" fill="hsl(325, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.PA6
+x+" data-x="0.7" data-y="-0.08" cx="600" cy="374.30303030303037" r="3" fill="hsl(324, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C_MCU.1
+y+" data-x="-0.5" data-y="0.21000000000000002" cx="192.72727272727272" cy="275.8787878787879" r="3" fill="hsl(126, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C_MCU.2
+x+" data-x="-0.46" data-y="-0.06" cx="206.30303030303028" cy="367.51515151515156" r="3" fill="hsl(127, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="GND_RAIL.1
+y+" data-x="0" data-y="-0.06" cx="362.42424242424244" cy="367.51515151515156" r="3" fill="hsl(343, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-0.5" data-y="0.31000000000000005" cx="192.72727272727272" cy="241.93939393939394" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="0" data-y="0" cx="362.42424242424244" cy="347.1515151515152" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":339.39393939393943,"c":0,"e":362.42424242424244,"b":0,"d":-339.39393939393943,"f":347.1515151515152};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/assets/repro-stm32c071-vss-through-pa0.input.json
+++ b/tests/repros/assets/repro-stm32c071-vss-through-pa0.input.json
@@ -1,0 +1,73 @@
+{
+  "chips": [
+    {
+      "chipId": "U_MCU",
+      "center": { "x": 0.35, "y": 0 },
+      "width": 0.5,
+      "height": 0.5,
+      "pins": [
+        { "pinId": "U_MCU.PB7", "x": 0, "y": 0.2, "_facingDirection": "x-" },
+        { "pinId": "U_MCU.PC14", "x": 0, "y": 0.16, "_facingDirection": "x-" },
+        { "pinId": "U_MCU.PC15", "x": 0, "y": 0.12, "_facingDirection": "x-" },
+        { "pinId": "U_MCU.VDD", "x": 0, "y": 0.08, "_facingDirection": "x-" },
+        { "pinId": "U_MCU.VSS", "x": 0, "y": 0.04, "_facingDirection": "y-" },
+        { "pinId": "U_MCU.PF2", "x": 0, "y": 0, "_facingDirection": "x-" },
+        { "pinId": "U_MCU.PA0", "x": 0, "y": -0.04, "_facingDirection": "x-" },
+        { "pinId": "U_MCU.PA1", "x": 0, "y": -0.08, "_facingDirection": "x-" },
+        { "pinId": "U_MCU.PB3", "x": 0.7, "y": 0.2, "_facingDirection": "x+" },
+        { "pinId": "U_MCU.PA14", "x": 0.7, "y": 0.16, "_facingDirection": "x+" },
+        { "pinId": "U_MCU.PA13", "x": 0.7, "y": 0.12, "_facingDirection": "x+" },
+        { "pinId": "U_MCU.PA12", "x": 0.7, "y": 0.08, "_facingDirection": "x+" },
+        { "pinId": "U_MCU.PA11", "x": 0.7, "y": 0.04, "_facingDirection": "x+" },
+        { "pinId": "U_MCU.PA8", "x": 0.7, "y": 0, "_facingDirection": "x+" },
+        { "pinId": "U_MCU.PA7", "x": 0.7, "y": -0.04, "_facingDirection": "x+" },
+        { "pinId": "U_MCU.PA6", "x": 0.7, "y": -0.08, "_facingDirection": "x+" }
+      ]
+    },
+    {
+      "chipId": "C_MCU",
+      "center": { "x": -0.5, "y": 0.07 },
+      "width": 0.08,
+      "height": 0.28,
+      "pins": [
+        { "pinId": "C_MCU.1", "x": -0.5, "y": 0.2, "_facingDirection": "y+" },
+        { "pinId": "C_MCU.2", "x": -0.5, "y": -0.06, "_facingDirection": "x+" }
+      ]
+    },
+    {
+      "chipId": "GND_RAIL",
+      "center": { "x": -0.03, "y": -0.06 },
+      "width": 0.06,
+      "height": 0.06,
+      "pins": [
+        { "pinId": "GND_RAIL.1", "x": 0, "y": -0.06, "_facingDirection": "y+" }
+      ]
+    }
+  ],
+  "directConnections": [
+    {
+      "pinIds": ["C_MCU.1", "U_MCU.VDD"],
+      "netId": "V3V3"
+    },
+    {
+      "pinIds": ["C_MCU.2", "GND_RAIL.1"],
+      "netId": "VSS"
+    },
+    {
+      "pinIds": ["GND_RAIL.1", "U_MCU.VSS"],
+      "netId": "VSS"
+    }
+  ],
+  "netConnections": [
+    {
+      "netId": "SWD_NRST",
+      "pinIds": ["U_MCU.PF2"],
+      "netLabelWidth": 0.55,
+      "netLabelHeight": 0.08
+    }
+  ],
+  "availableNetLabelOrientations": {
+    "SWD_NRST": ["x-"]
+  },
+  "maxMspPairDistance": 8
+}

--- a/tests/repros/repro-stm32c071-vss-through-pa0.test.ts
+++ b/tests/repros/repro-stm32c071-vss-through-pa0.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "./assets/repro-stm32c071-vss-through-pa0.input.json"
+import "tests/fixtures/matcher"
+
+// Regression repro: the VSS trace leaves the decoupling capacitor on the
+// lower rail, then turns upward on the MCU pin rail. That vertical segment
+// passes through PA0 and the SWD_NRST label anchored at PF2.
+test("repro STM32C071 VSS trace through PA0 and SWD_NRST", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- add a focused snapshot repro for the VSS rail crossing PA0 and the SWD_NRST label boundary
- include a compact STM32C071 input fixture and expected SVG snapshot

## Testing
- bun test tests/repros/repro-stm32c071-vss-through-pa0.test.ts
- bunx tsc --noEmit