### PR TITLE
Repro: VSS trace runs through the SWD_NRST net label (STM32C071)

### DIFF
--- a/tests/repros/__snapshots__/repro-stm32c071-vss-trace-through-pa0.snap.svg
+++ b/tests/repros/__snapshots__/repro-stm32c071-vss-trace-through-pa0.snap.svg
@@ -1,0 +1,78 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-2.6,0.74 -0.8,0.3" data-type="line" data-label="" points="109.50525771418717,265.9403551111877 283.26840199965517,308.41579038096876" fill="none" stroke="hsl(352, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="-2.6,-0.36000000000000004 -0.8,0.1" data-type="line" data-label="" points="109.50525771418717,372.1289432856404 283.26840199965517,327.7228064126874" fill="none" stroke="hsl(8, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="-2.6,0.74 -0.8,0.3" data-type="line" data-label="" points="109.50525771418717,265.9403551111877 283.26840199965517,308.41579038096876" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="-2.6,-0.36000000000000004 -0.8,0.1" data-type="line" data-label="" points="109.50525771418717,372.1289432856404 283.26840199965517,327.7228064126874" fill="none" stroke="hsl(157, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="-2.6,0.74 -2.6,0.9400000000000002 -1.7000000000000002,0.9400000000000002 -1.7000000000000002,0.30000000000000004 -0.8,0.30000000000000004" data-type="line" data-label="" points="109.50525771418717,265.9403551111877 109.50525771418717,246.633339079469 196.38682985692117,246.633339079469 196.38682985692117,308.41579038096876 283.26840199965517,308.41579038096876" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="-2.6,-0.36000000000000004 -2.6,-0.5600000000000003 -1.7000000000000002,-0.5600000000000003 -1.7000000000000002,0.09999999999999998 -0.8,0.09999999999999998" data-type="line" data-label="" points="109.50525771418717,372.1289432856404 109.50525771418717,391.4359593173591 196.38682985692117,391.4359593173591 196.38682985692117,327.7228064126874 283.26840199965517,327.7228064126874" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="U_MCU" data-x="0" data-y="0" x="283.26840199965517" y="231.18772625409406" width="154.4561282537494" height="212.3771763489054" fill="hsl(229, 100%, 50%, 0.8)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="C_MCU" data-x="-2.6" data-y="0.19" x="83.9234614721599" y="265.9403551111877" width="51.16359248405453" height="106.18858817445266" fill="hsl(211, 100%, 50%, 0.8)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="U_MCU" data-x="-0.2" data-y="1.18" x="314.64230305119804" y="216.22478882951214" width="53.09429408722633" height="14.48026202378901" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="STM32C071FBP6" data-x="-0.02" data-y="-1.22" x="292.9219100155145" y="447.4263058093432" width="131.28770901568697" height="15.445612825374951" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="C_MCU" data-x="-3.05" data-y="0.36" x="40" y="295.86622996035163" width="52.12894328564039" height="13.514911222203068" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="100n" data-x="-2.28" data-y="-0.11" x="116.26271332528873" y="340.7550422340976" width="48.26754007929668" height="14.480262023788953" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="netId: V3V3
+globalConnNetId: connectivity_net0" data-x="-2.6" data-y="1.3000000000000003" x="99.85174969832782" y="177.1280813652818" width="19.30701603171869" height="69.5052577141872" fill="#ef444466" stroke="#ef4444" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="netId: GND
+globalConnNetId: connectivity_net1" data-x="-2.6" data-y="-0.8600000000000003" x="99.85174969832782" y="391.4359593173591" width="19.30701603171869" height="57.92104809515598" fill="#00000066" stroke="#000000" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="netId: SWD_NRST
+globalConnNetId: connectivity_net2" data-x="-1.4009999999999998" data-y="-0.1" x="167.3297707291846" y="337.37631442854683" width="115.84209619031202" height="19.30701603171866" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="netId: USER_LED_PA8
+globalConnNetId: connectivity_net5" data-x="1.641" data-y="-0.1" x="437.8210653335632" y="337.37631442854683" width="162.17893466643687" height="19.30701603171866" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="netId: SWDIO
+globalConnNetId: connectivity_net3" data-x="1.2209999999999999" data-y="0.5" x="437.82106533356307" y="279.4552663333908" width="81.08946733321847" height="19.30701603171866" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.010358928571428571"/></g><g><rect data-type="rect" data-label="netId: SWCLK
+globalConnNetId: connectivity_net4" data-x="1.2209999999999999" data-y="0.7" x="437.82106533356307" y="260.1482503016721" width="81.08946733321847" height="19.307016031718717" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.010358928571428571"/></g><g><circle data-type="point" data-label="U_MCU.1
+x-" data-x="-0.8" data-y="0.9" cx="283.26840199965517" cy="250.49474228581278" r="3" fill="hsl(144, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.2
+x-" data-x="-0.8" data-y="0.7" cx="283.26840199965517" cy="269.80175831753144" r="3" fill="hsl(145, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.3
+x-" data-x="-0.8" data-y="0.5" cx="283.26840199965517" cy="289.1087743492501" r="3" fill="hsl(146, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.4
+x-" data-x="-0.8" data-y="0.3" cx="283.26840199965517" cy="308.41579038096876" r="3" fill="hsl(147, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.5
+x-" data-x="-0.8" data-y="0.1" cx="283.26840199965517" cy="327.7228064126874" r="3" fill="hsl(148, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.6
+x-" data-x="-0.8" data-y="-0.1" cx="283.26840199965517" cy="347.02982244440614" r="3" fill="hsl(149, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.7
+x-" data-x="-0.8" data-y="-0.3" cx="283.26840199965517" cy="366.3368384761248" r="3" fill="hsl(150, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.8
+x-" data-x="-0.8" data-y="-0.5" cx="283.26840199965517" cy="385.64385450784346" r="3" fill="hsl(151, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.9
+x-" data-x="-0.8" data-y="-0.7" cx="283.26840199965517" cy="404.9508705395621" r="3" fill="hsl(152, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.10
+x-" data-x="-0.8" data-y="-0.9" cx="283.26840199965517" cy="424.2578865712808" r="3" fill="hsl(192, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.11
+x+" data-x="0.8" data-y="-0.9" cx="437.72453025340457" cy="424.2578865712808" r="3" fill="hsl(193, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.12
+x+" data-x="0.8" data-y="-0.7" cx="437.72453025340457" cy="404.9508705395621" r="3" fill="hsl(194, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.13
+x+" data-x="0.8" data-y="-0.5" cx="437.72453025340457" cy="385.64385450784346" r="3" fill="hsl(195, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.14
+x+" data-x="0.8" data-y="-0.3" cx="437.72453025340457" cy="366.3368384761248" r="3" fill="hsl(196, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.15
+x+" data-x="0.8" data-y="-0.1" cx="437.72453025340457" cy="347.02982244440614" r="3" fill="hsl(197, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.16
+x+" data-x="0.8" data-y="0.1" cx="437.72453025340457" cy="327.7228064126874" r="3" fill="hsl(198, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.17
+x+" data-x="0.8" data-y="0.3" cx="437.72453025340457" cy="308.41579038096876" r="3" fill="hsl(199, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.18
+x+" data-x="0.8" data-y="0.5" cx="437.72453025340457" cy="289.1087743492501" r="3" fill="hsl(200, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.19
+x+" data-x="0.8" data-y="0.7" cx="437.72453025340457" cy="269.80175831753144" r="3" fill="hsl(201, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U_MCU.20
+x+" data-x="0.8" data-y="0.9" cx="437.72453025340457" cy="250.49474228581278" r="3" fill="hsl(223, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C_MCU.1
+y+" data-x="-2.6" data-y="0.74" cx="109.50525771418717" cy="265.9403551111877" r="3" fill="hsl(126, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C_MCU.2
+y-" data-x="-2.6" data-y="-0.36000000000000004" cx="109.50525771418717" cy="372.1289432856404" r="3" fill="hsl(127, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-2.6" data-y="0.9400000000000002" cx="109.50525771418717" cy="246.633339079469" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y-" data-x="-2.6" data-y="-0.5600000000000003" cx="109.50525771418717" cy="391.4359593173591" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-0.8" data-y="-0.1" cx="283.26840199965517" cy="347.02982244440614" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="0.8" data-y="-0.1" cx="437.72453025340457" cy="347.02982244440614" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="0.8" data-y="0.5" cx="437.72453025340457" cy="289.1087743492501" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x+" data-x="0.8" data-y="0.7" cx="437.72453025340457" cy="269.80175831753144" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":96.53508015859335,"c":0,"e":360.49646612652987,"b":0,"d":-96.53508015859335,"f":337.3763144285468};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/assets/repro-stm32c071-vss-trace-through-pa0.input.json
+++ b/tests/repros/assets/repro-stm32c071-vss-trace-through-pa0.input.json
@@ -1,0 +1,264 @@
+{
+  "chips": [
+    {
+      "chipId": "U_MCU",
+      "center": {
+        "x": 0,
+        "y": 0
+      },
+      "width": 1.6,
+      "height": 2.2,
+      "pins": [
+        {
+          "pinId": "U_MCU.1",
+          "x": -0.8,
+          "y": 0.9
+        },
+        {
+          "pinId": "U_MCU.2",
+          "x": -0.8,
+          "y": 0.7
+        },
+        {
+          "pinId": "U_MCU.3",
+          "x": -0.8,
+          "y": 0.5
+        },
+        {
+          "pinId": "U_MCU.4",
+          "x": -0.8,
+          "y": 0.3
+        },
+        {
+          "pinId": "U_MCU.5",
+          "x": -0.8,
+          "y": 0.1
+        },
+        {
+          "pinId": "U_MCU.6",
+          "x": -0.8,
+          "y": -0.1
+        },
+        {
+          "pinId": "U_MCU.7",
+          "x": -0.8,
+          "y": -0.3
+        },
+        {
+          "pinId": "U_MCU.8",
+          "x": -0.8,
+          "y": -0.5
+        },
+        {
+          "pinId": "U_MCU.9",
+          "x": -0.8,
+          "y": -0.7
+        },
+        {
+          "pinId": "U_MCU.10",
+          "x": -0.8,
+          "y": -0.9
+        },
+        {
+          "pinId": "U_MCU.11",
+          "x": 0.8,
+          "y": -0.9
+        },
+        {
+          "pinId": "U_MCU.12",
+          "x": 0.8,
+          "y": -0.7
+        },
+        {
+          "pinId": "U_MCU.13",
+          "x": 0.8,
+          "y": -0.5
+        },
+        {
+          "pinId": "U_MCU.14",
+          "x": 0.8,
+          "y": -0.3
+        },
+        {
+          "pinId": "U_MCU.15",
+          "x": 0.8,
+          "y": -0.1
+        },
+        {
+          "pinId": "U_MCU.16",
+          "x": 0.8,
+          "y": 0.1
+        },
+        {
+          "pinId": "U_MCU.17",
+          "x": 0.8,
+          "y": 0.3
+        },
+        {
+          "pinId": "U_MCU.18",
+          "x": 0.8,
+          "y": 0.5
+        },
+        {
+          "pinId": "U_MCU.19",
+          "x": 0.8,
+          "y": 0.7
+        },
+        {
+          "pinId": "U_MCU.20",
+          "x": 0.8,
+          "y": 0.9
+        }
+      ]
+    },
+    {
+      "chipId": "C_MCU",
+      "center": {
+        "x": -2.6,
+        "y": 0.19
+      },
+      "width": 0.53,
+      "height": 1.1,
+      "pins": [
+        {
+          "pinId": "C_MCU.1",
+          "x": -2.6,
+          "y": 0.74
+        },
+        {
+          "pinId": "C_MCU.2",
+          "x": -2.6,
+          "y": -0.36
+        }
+      ]
+    }
+  ],
+  "directConnections": [
+    {
+      "pinIds": [
+        "C_MCU.1",
+        "U_MCU.4"
+      ],
+      "netId": "C_MCU.pin1 to U_MCU.VDD"
+    },
+    {
+      "pinIds": [
+        "C_MCU.2",
+        "U_MCU.5"
+      ],
+      "netId": "C_MCU.pin2 to U_MCU.VSS"
+    }
+  ],
+  "netConnections": [
+    {
+      "netId": "V3V3",
+      "pinIds": [
+        "C_MCU.1",
+        "U_MCU.4"
+      ],
+      "netLabelWidth": 0.72
+    },
+    {
+      "netId": "GND",
+      "pinIds": [
+        "C_MCU.2",
+        "U_MCU.5"
+      ],
+      "netLabelWidth": 0.6
+    },
+    {
+      "netId": "SWD_NRST",
+      "pinIds": [
+        "U_MCU.6"
+      ],
+      "netLabelWidth": 1.2
+    },
+    {
+      "netId": "SWDIO",
+      "pinIds": [
+        "U_MCU.18"
+      ],
+      "netLabelWidth": 0.84
+    },
+    {
+      "netId": "SWCLK",
+      "pinIds": [
+        "U_MCU.19"
+      ],
+      "netLabelWidth": 0.84
+    },
+    {
+      "netId": "USER_LED_PA8",
+      "pinIds": [
+        "U_MCU.15"
+      ],
+      "netLabelWidth": 1.68
+    }
+  ],
+  "availableNetLabelOrientations": {
+    "V3V3": [
+      "y+"
+    ],
+    "GND": [
+      "y-"
+    ],
+    "SWD_NRST": [
+      "x-",
+      "x+"
+    ],
+    "SWDIO": [
+      "x-",
+      "x+"
+    ],
+    "SWCLK": [
+      "x-",
+      "x+"
+    ],
+    "USER_LED_PA8": [
+      "x-",
+      "x+"
+    ]
+  },
+  "textBoxes": [
+    {
+      "chipId": "U_MCU",
+      "center": {
+        "x": -0.2,
+        "y": 1.18
+      },
+      "width": 0.55,
+      "height": 0.15,
+      "text": "U_MCU"
+    },
+    {
+      "chipId": "U_MCU",
+      "center": {
+        "x": -0.02,
+        "y": -1.22
+      },
+      "width": 1.36,
+      "height": 0.16,
+      "text": "STM32C071FBP6"
+    },
+    {
+      "chipId": "C_MCU",
+      "center": {
+        "x": -3.05,
+        "y": 0.36
+      },
+      "width": 0.54,
+      "height": 0.14,
+      "text": "C_MCU"
+    },
+    {
+      "chipId": "C_MCU",
+      "center": {
+        "x": -2.28,
+        "y": -0.11
+      },
+      "width": 0.5,
+      "height": 0.15,
+      "text": "100n"
+    }
+  ]
+}

--- a/tests/repros/repro-stm32c071-vss-trace-through-pa0.test.ts
+++ b/tests/repros/repro-stm32c071-vss-trace-through-pa0.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "./assets/repro-stm32c071-vss-trace-through-pa0.input.json"
+import "tests/fixtures/matcher"
+
+/**
+ * STM32C071 MCU with a 100n decoupling capacitor to its left.
+ *
+ * C_MCU.2 -> U_MCU.5 (VSS) is routed as an elbow whose vertical segment sits at
+ * the horizontal midpoint between the capacitor and the chip. That vertical
+ * segment runs straight through the SWD_NRST net label (attached to U_MCU.6 /
+ * PF2, pointing "x-") and past the PA0 pin row, so the trace visually crosses
+ * both the label and the pin lead.
+ */
+
+interface Point {
+  x: number
+  y: number
+}
+interface Rect {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+const EPS = 1e-9
+
+const rectFromCenter = (
+  center: Point,
+  width: number,
+  height: number,
+): Rect => ({
+  minX: center.x - width / 2,
+  maxX: center.x + width / 2,
+  minY: center.y - height / 2,
+  maxY: center.y + height / 2,
+})
+
+const segmentIntersectsRect = (a: Point, b: Point, rect: Rect) => {
+  if (Math.abs(a.x - b.x) < EPS) {
+    const overlap =
+      Math.min(Math.max(a.y, b.y), rect.maxY) -
+      Math.max(Math.min(a.y, b.y), rect.minY)
+    return a.x >= rect.minX - EPS && a.x <= rect.maxX + EPS && overlap > EPS
+  }
+
+  if (Math.abs(a.y - b.y) < EPS) {
+    const overlap =
+      Math.min(Math.max(a.x, b.x), rect.maxX) -
+      Math.max(Math.min(a.x, b.x), rect.minX)
+    return a.y >= rect.minY - EPS && a.y <= rect.maxY + EPS && overlap > EPS
+  }
+
+  return false
+}
+
+const pathIntersectsRect = (path: Point[], rect: Rect) =>
+  path.some((point, index) => {
+    if (index === 0) return false
+    return segmentIntersectsRect(path[index - 1]!, point, rect)
+  })
+
+/** Rect covering the lead drawn between a pin and the body of its chip. */
+const getPinLeadRect = (pinId: string, leadLength = 0.2): Rect => {
+  const chip = (inputProblem as any).chips.find((c: any) =>
+    c.pins.some((p: any) => p.pinId === pinId),
+  )
+  const pin = chip.pins.find((p: any) => p.pinId === pinId)
+  const outward = pin.x < chip.center.x ? -1 : 1
+  const leadEndX = pin.x + outward * leadLength
+  return {
+    minX: Math.min(pin.x, leadEndX),
+    maxX: Math.max(pin.x, leadEndX),
+    minY: pin.y - EPS,
+    maxY: pin.y + EPS,
+  }
+}
+
+test("repro stm32c071 VSS trace crosses PA0 and the SWD_NRST net label", async () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+  solver.solve()
+
+  await expect(solver).toMatchSolverSnapshot(import.meta.path)
+
+  const { traces, netLabelPlacements } =
+    solver.sameNetJunctionAlignmentSolver!.getOutput()
+
+  const vssTrace = traces.find(
+    (trace: any) =>
+      trace.mspPairId === "C_MCU.2-U_MCU.5" ||
+      trace.mspPairId === "U_MCU.5-C_MCU.2",
+  )
+  expect(vssTrace).toBeDefined()
+
+  const swdNrstLabel = netLabelPlacements.find(
+    (placement: any) => placement.netId === "SWD_NRST",
+  )
+  expect(swdNrstLabel).toBeDefined()
+
+  const swdNrstRect = rectFromCenter(
+    swdNrstLabel!.center,
+    swdNrstLabel!.width,
+    swdNrstLabel!.height,
+  )
+
+  // The VSS trace must not run through the SWD_NRST net label
+  expect(pathIntersectsRect(vssTrace!.tracePath, swdNrstRect)).toBe(false)
+
+  // ...nor through the PA0 (U_MCU.7) pin lead
+  expect(
+    pathIntersectsRect(vssTrace!.tracePath, getPinLeadRect("U_MCU.7")),
+  ).toBe(false)
+})


### PR DESCRIPTION
## What

Adds a failing reproduction for a schematic where the VSS trace is routed straight through an anchored net label.

The schematic: an STM32C071FBP6 (20-pin, 0.2 pitch) with a 100n decoupling capacitor to its left. `C_MCU.1` → VDD (pin 4) and `C_MCU.2` → VSS (pin 5) are direct connections; `SWD_NRST` is a net label anchored on PF2 (pin 6) facing `x-`.

## The bug

The elbow for `C_MCU.2-U_MCU.5` puts its riser at the horizontal midpoint between the capacitor and the chip:

```
VSS path:      (-2.600, -0.360) -> (-2.600, -0.560) -> (-1.700, -0.560) -> (-1.700, 0.100) -> (-0.800, 0.100)
SWD_NRST rect: x -2.001 .. -0.801   y -0.200 .. 0.000
```

The vertical segment at `x = -1.7` runs from `y = -0.56` up to `y = 0.10`, cutting straight through the SWD_NRST label rect and across the PA0/PF2 pin rows. `NetLabelPlacementSolver` anchors SWD_NRST at PF2 without accounting for the VSS trace, and nothing downstream separates them.

The snapshot SVG shows the trace crossing the label band.

## Status

**The test fails on this branch — that is the reproduction.** CI will be red until the routing is fixed. Opening as a draft for that reason.

The test asserts two things:

- the VSS trace clears the SWD_NRST label rect — **currently fails**
- the VSS trace clears the PA0 (`U_MCU.7`) pin lead — **currently passes**

The second assertion is there because the originally reported render had the riser closer to the chip, where it crossed the PA0 lead itself. Keeping both means a fix that just shifts the riser toward the chip doesn't trade one symptom for the other.

## Note on the input problem

The input was reconstructed by measuring the reported schematic render rather than exported from core via `DEBUG=Group_doInitialSchematicTraceRender`. Pin coordinates, the capacitor position, and net label widths are estimates that match the rendered layout; the capacitor uses this repo's standard 0.53 × 1.1 symbol. If the original board's exported JSON turns up, swapping it in would make the repro exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)