### PR TITLE
Slide overhanging inline net labels instead of falling back

### DIFF
--- a/lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver.ts
+++ b/lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver.ts
@@ -374,9 +374,11 @@ export const estimateInlineNetLabelWidth = (
  * middle of the segment outwards. Sliding the label along the wire lets it
  * dodge a chip that only crowds one end.
  *
- * When the label is shorter than the segment, candidates are limited to
- * positions that keep it fully on the wire; when it is longer, only the
- * midpoint is offered (it will overhang either way).
+ * When the label is shorter than the segment, candidates keep it fully on the
+ * wire; when it is longer, candidates keep the wire fully under the label (the
+ * overhang shifts between the two ends). Either way the slide range is
+ * |segmentLength - labelWidth| about the midpoint, which lets a label that
+ * doesn't quite fit dodge a chip crowding one end by overhanging the other.
  */
 const getAnchorCandidates = (
   segment: AxisAlignedSegment,
@@ -394,15 +396,15 @@ const getAnchorCandidates = (
       ? { x: value, y: segment.start.y }
       : { x: segment.start.x, y: segment.start.y + (value - start) }
 
-  const slack = segment.length - labelWidth
-  if (slack <= 0) return [pointAt(mid)]
+  const halfRange = Math.abs(segment.length - labelWidth) / 2
+  if (halfRange < 1e-9) return [pointAt(mid)]
 
   const offsets: number[] = [0]
-  for (let offset = step; offset <= slack / 2 + 1e-9; offset += step) {
+  for (let offset = step; offset <= halfRange + 1e-9; offset += step) {
     offsets.push(offset, -offset)
   }
   // Always consider both extremes, even when they fall between samples.
-  offsets.push(slack / 2, -slack / 2)
+  offsets.push(halfRange, -halfRange)
 
   return offsets.map((offset) => pointAt(mid + offset * direction))
 }

--- a/tests/assets/inline-net-label02.json
+++ b/tests/assets/inline-net-label02.json
@@ -1,0 +1,112 @@
+{
+  "chips": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": 0,
+        "y": 0
+      },
+      "width": 0.4,
+      "height": 1,
+      "pins": [
+        {
+          "pinId": "schematic_port_0",
+          "x": -0.6000000000000001,
+          "y": 0.30000000000000004,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_1",
+          "x": -0.6000000000000001,
+          "y": 0.10000000000000003,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_2",
+          "x": -0.6000000000000001,
+          "y": -0.09999999999999998,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_3",
+          "x": -0.6000000000000001,
+          "y": -0.30000000000000004,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_4",
+          "x": 0.6000000000000001,
+          "y": -0.30000000000000004,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "schematic_port_5",
+          "x": 0.6000000000000001,
+          "y": -0.10000000000000003,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "schematic_port_6",
+          "x": 0.6000000000000001,
+          "y": 0.09999999999999998,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "schematic_port_7",
+          "x": 0.6000000000000001,
+          "y": 0.30000000000000004,
+          "_facingDirection": "x+"
+        }
+      ]
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": {
+        "x": 3,
+        "y": 0.13249999999999998
+      },
+      "width": 1.13,
+      "height": 0.915,
+      "pins": [
+        {
+          "pinId": "schematic_port_8",
+          "x": 2.46,
+          "y": 0,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_9",
+          "x": 3.54,
+          "y": 0,
+          "_facingDirection": "x+"
+        }
+      ]
+    }
+  ],
+  "directConnections": [
+    {
+      "netId": "USER_LED_ANODE",
+      "allowInlineNetLabel": true,
+      "inlineNetLabelWidth": 1.8,
+      "pinIds": [
+        "schematic_port_4",
+        "schematic_port_8"
+      ]
+    }
+  ],
+  "netConnections": [],
+  "textBoxes": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": -0.08000000000000002,
+        "y": 0.615
+      },
+      "width": 0.36,
+      "height": 0.25,
+      "text": "U1"
+    }
+  ],
+  "availableNetLabelOrientations": {},
+  "maxMspPairDistance": 2.4
+}

--- a/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label02.snap.svg
+++ b/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label02.snap.svg
@@ -1,0 +1,57 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0.6000000000000001,-0.30000000000000004 2.435,0" data-type="line" data-label="" points="201.34453781512605,376.47058823529414 448.06722689075633,336.1344537815126" fill="none" stroke="hsl(48, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="0.6000000000000001,-0.30000000000000004 1.5175,-0.30000000000000004 1.5175,0 2.435,0" data-type="line" data-label="" points="201.34453781512605,376.47058823529414 324.7058823529412,376.47058823529414 324.7058823529412,336.1344537815126 448.06722689075633,336.1344537815126" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="268.9075630252101" width="161.34453781512605" height="134.45378151260502" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0074375"/></g><g><rect data-type="rect" data-label="schematic_component_1" data-x="3" data-y="0.13249999999999998" x="448.0672268907564" y="256.8067226890756" width="151.93277310924367" height="123.02521008403363" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0074375"/></g><g><rect data-type="rect" data-label="U1" data-x="-0.08000000000000002" data-y="0.615" x="85.7142857142857" y="236.6386554621849" width="48.40336134453783" height="33.613445378151255" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.0074375"/></g><g><rect data-type="rect" data-label="INLINE netId: USER_LED_ANODE
+axis: x
+side: y+" data-x="1.5" data-y="-0.16000000000000003" x="201.34453781512607" y="345.546218487395" width="242.01680672268907" height="24.20168067226888" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0074375"/></g><text data-type="text" data-label="USER_LED_ANODE" data-x="1.5" data-y="-0.16000000000000003" x="322.3529411764706" y="357.6470588235294" fill="green" font-size="24.201680672268907" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">USER_LED_ANODE</text><g><circle data-type="point" data-label="schematic_port_0
+x-" data-x="-0.6000000000000001" data-y="0.30000000000000004" cx="39.999999999999986" cy="295.79831932773106" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_1
+x-" data-x="-0.6000000000000001" data-y="0.10000000000000003" cx="39.999999999999986" cy="322.6890756302521" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_2
+x-" data-x="-0.6000000000000001" data-y="-0.09999999999999998" cx="39.999999999999986" cy="349.5798319327731" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_3
+x-" data-x="-0.6000000000000001" data-y="-0.30000000000000004" cx="39.999999999999986" cy="376.47058823529414" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_4
+x+" data-x="0.6000000000000001" data-y="-0.30000000000000004" cx="201.34453781512605" cy="376.47058823529414" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_5
+x+" data-x="0.6000000000000001" data-y="-0.10000000000000003" cx="201.34453781512605" cy="349.5798319327731" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_6
+x+" data-x="0.6000000000000001" data-y="0.09999999999999998" cx="201.34453781512605" cy="322.6890756302521" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_7
+x+" data-x="0.6000000000000001" data-y="0.30000000000000004" cx="201.34453781512605" cy="295.79831932773106" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_8
+x-" data-x="2.435" data-y="0" cx="448.06722689075633" cy="336.1344537815126" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_9
+x+" data-x="3.565" data-y="0" cx="600" cy="336.1344537815126" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="inline anchor
+USER_LED_ANODE" data-x="1.5" data-y="-0.30000000000000004" cx="322.3529411764706" cy="376.47058823529414" r="3" fill="green"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":134.45378151260505,"c":0,"e":120.67226890756302,"b":0,"d":-134.45378151260505,"f":336.1344537815126};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/solvers/InlineNetLabelSolver/inline-net-label02.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/inline-net-label02.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "../../assets/inline-net-label02.json"
+import "tests/fixtures/matcher"
+
+// Real geometry from @tscircuit/core: a soic8 and an 0603 LED 3 units apart.
+// The label (width 1.8) is longer than every straight run of the routed trace
+// (~0.95), so it must overhang - sliding along the run to clear both chip
+// boxes rather than giving up and falling back to an anchored label.
+test("inline-net-label02 overhangs a short run instead of falling back", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  const placements = solver.inlineNetLabelSolver!.inlineNetLabelPlacements
+  expect(placements.map((p) => p.netId)).toEqual(["USER_LED_ANODE"])
+
+  const [placement] = placements
+  expect(placement!.axis).toBe("x")
+
+  // The label never sits on top of a chip.
+  const labelBounds = {
+    minX: placement!.center.x - placement!.width / 2,
+    maxX: placement!.center.x + placement!.width / 2,
+    minY: placement!.center.y - placement!.height / 2,
+    maxY: placement!.center.y + placement!.height / 2,
+  }
+  for (const chip of (inputProblem as any).chips) {
+    const chipBounds = {
+      minX: chip.center.x - chip.width / 2,
+      maxX: chip.center.x + chip.width / 2,
+      minY: chip.center.y - chip.height / 2,
+      maxY: chip.center.y + chip.height / 2,
+    }
+    const overlaps =
+      labelBounds.minX < chipBounds.maxX &&
+      labelBounds.maxX > chipBounds.minX &&
+      labelBounds.minY < chipBounds.maxY &&
+      labelBounds.maxY > chipBounds.minY
+    expect(overlaps).toBe(false)
+  }
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
Follow-up to #792, addressing [review feedback on core#3085](https://github.com/tscircuit/core/pull/3085): in the U1→LED1 scenario the inline label fell back to an anchored tag — which renders vertically across the very wire the inline label was meant to keep clean.

## Why it fell back

`USER_LED_ANODE` needs 1.8 units; every straight run of the routed trace is ~0.95. Runs it can't fully fit on were only ever tried at their **midpoint**, and from the midpoint the label always collided with U1's or LED1's chip box — so placement declined entirely.

## Fix

Candidates now slide in the doesn't-fit case too. The slide range is `|segmentLength − labelWidth| / 2` about the midpoint in **both** cases:

- label shorter than the run → slides while staying fully on the wire (unchanged behavior);
- label longer than the run → slides while keeping the wire fully under the label, shifting the overhang toward whichever end is open.

Obstruction checks are untouched — the label still never sits on a chip, component text, or a foreign-net trace.

## Result

| before (#792) | after |
|---|---|
| anchored tag crossing the wire | label runs along the wire between the chips |

<img width="500" alt="label overhangs the short run, clearing both chips" src="https://raw.githubusercontent.com/tscircuit/schematic-trace-solver/inline-label-overhang-slide/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label02.snap.svg" />

New test uses the exact input problem dumped from the core scenario (soic8 + 0603 LED, 3 units apart) and asserts the label is placed and overlaps neither chip box.

Candidate generation is byte-identical for labels that fit (`halfRange` equals the old `slack/2`), so no existing snapshots changed. `bun test`: 175 pass / 0 fail. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)