### PR TITLE
Span small jogs when no straight run fits the inline label

### DIFF
--- a/lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver.ts
+++ b/lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver.ts
@@ -24,12 +24,13 @@ export const DEFAULT_INLINE_NET_LABEL_HEIGHT = 0.18
 export const INLINE_NET_LABEL_TRACE_MARGIN = 0.05
 
 /**
- * How much of the label is allowed to hang off the end of the wire it names,
- * as a fraction of the label's length. A short elbow stub is technically clear
- * of every obstacle but reads as a label floating in space, so runs shorter
- * than this are not considered.
+ * Largest perpendicular deviation a route may have and still be labeled as one
+ * span. A route that is straight except for elbow jogs up to this size reads
+ * as a single wire, so its name may be centered over the whole route,
+ * bridging the jogs. Anything more meandering falls back to an anchored net
+ * label.
  */
-export const MIN_INLINE_NET_LABEL_SEGMENT_RATIO = 0.5
+export const INLINE_NET_LABEL_MAX_SPAN_JOG = 0.4
 
 /**
  * A net label drawn parallel to the trace it names, rather than anchored to the
@@ -165,20 +166,14 @@ export class InlineNetLabelSolver extends BaseSolver {
 
     const offset = height / 2 + INLINE_NET_LABEL_TRACE_MARGIN
 
-    // Runs the label fully fits on come first, then longer-to-shorter among the
-    // runs it may overhang. Within a run, try the preferred side before the far
-    // side, and positions near the middle before ones near the ends.
+    // First choice: a straight run the label fully fits on, longest first, so
+    // the text hugs the wire it names. Within a run, try the preferred side
+    // before the far side, and positions near the middle before the ends. The
+    // label never extends past the end of a run - a name hanging off its wire
+    // reads as floating text.
     const usableSegments = segments
-      .filter(
-        (segment) =>
-          segment.length >= width * MIN_INLINE_NET_LABEL_SEGMENT_RATIO,
-      )
-      .sort((a, b) => {
-        const aFits = a.length >= width
-        const bFits = b.length >= width
-        if (aFits !== bFits) return aFits ? -1 : 1
-        return b.length - a.length
-      })
+      .filter((segment) => segment.length >= width)
+      .sort((a, b) => b.length - a.length)
 
     for (const segment of usableSegments) {
       // "Above" the trace: +y for a horizontal trace, and -x for a vertical one
@@ -232,8 +227,135 @@ export class InlineNetLabelSolver extends BaseSolver {
       }
     }
 
+    // Second choice: no single run fits, but a route that is straight except
+    // for small jogs still reads as one wire - center the label over the
+    // route's overall span, bridging the jogs, without extending past its
+    // endpoints.
+    const spanPlacement = this.computeSpanPlacement({
+      trace,
+      directConnection,
+      width,
+      height,
+      offset,
+    })
+    if (spanPlacement) return spanPlacement
+
     // No room anywhere along the trace. Leave the net to the regular anchored
     // net label rather than drawing the name over a chip.
+    return null
+  }
+
+  /**
+   * Places the label over the whole route when the route is straight except
+   * for perpendicular jogs of at most INLINE_NET_LABEL_MAX_SPAN_JOG. The label
+   * sits clear of the route's full perpendicular extent and stays within its
+   * endpoints along the dominant axis.
+   */
+  private computeSpanPlacement({
+    trace,
+    directConnection,
+    width,
+    height,
+    offset,
+  }: {
+    trace: SolvedTracePath
+    directConnection: InputDirectConnection
+    width: number
+    height: number
+    offset: number
+  }): InlineNetLabelPlacement | null {
+    const path = trace.tracePath
+    if (path.length < 2) return null
+
+    let minX = Infinity
+    let maxX = -Infinity
+    let minY = Infinity
+    let maxY = -Infinity
+    for (const point of path) {
+      minX = Math.min(minX, point.x)
+      maxX = Math.max(maxX, point.x)
+      minY = Math.min(minY, point.y)
+      maxY = Math.max(maxY, point.y)
+    }
+
+    const extentX = maxX - minX
+    const extentY = maxY - minY
+    const axis: InlineNetLabelPlacement["axis"] = extentX >= extentY ? "x" : "y"
+    const spanLength = axis === "x" ? extentX : extentY
+    const jog = axis === "x" ? extentY : extentX
+
+    if (jog > INLINE_NET_LABEL_MAX_SPAN_JOG) return null
+    if (spanLength < width) return null
+
+    const spanStart = axis === "x" ? minX : minY
+    const spanEnd = axis === "x" ? maxX : maxY
+    const mid = (spanStart + spanEnd) / 2
+
+    // Slide candidates within the span, centered first (same scheme as the
+    // per-segment stage).
+    const halfRange = (spanLength - width) / 2
+    const offsets: number[] = [0]
+    for (let value = 0.1; value <= halfRange + 1e-9; value += 0.1) {
+      offsets.push(value, -value)
+    }
+    offsets.push(halfRange, -halfRange)
+
+    const sides: InlineNetLabelPlacement["side"][] =
+      axis === "x" ? ["y+", "y-"] : ["x-", "x+"]
+
+    for (const side of sides) {
+      for (const alongOffset of offsets) {
+        const along = mid + alongOffset
+        // The label clears the far side of every jog, not just the run it is
+        // nearest to.
+        const center: Point =
+          side === "y+"
+            ? { x: along, y: maxY + offset }
+            : side === "y-"
+              ? { x: along, y: minY - offset }
+              : side === "x-"
+                ? { x: minX - offset, y: along }
+                : { x: maxX + offset, y: along }
+
+        const halfAlong = width / 2
+        const halfAcross = height / 2
+        const bounds: Bounds =
+          axis === "x"
+            ? {
+                minX: center.x - halfAlong,
+                maxX: center.x + halfAlong,
+                minY: center.y - halfAcross,
+                maxY: center.y + halfAcross,
+              }
+            : {
+                minX: center.x - halfAcross,
+                maxX: center.x + halfAcross,
+                minY: center.y - halfAlong,
+                maxY: center.y + halfAlong,
+              }
+
+        if (this.isObstructed(bounds, trace)) continue
+
+        const anchorPoint: Point =
+          axis === "x"
+            ? { x: along, y: side === "y+" ? maxY : minY }
+            : { x: side === "x-" ? minX : maxX, y: along }
+
+        return {
+          globalConnNetId: trace.globalConnNetId,
+          netId: directConnection.netId,
+          mspPairId: trace.mspPairId,
+          pinIds: [...directConnection.pinIds],
+          axis,
+          anchorPoint,
+          center,
+          width,
+          height,
+          side,
+        }
+      }
+    }
+
     return null
   }
 
@@ -374,11 +496,8 @@ export const estimateInlineNetLabelWidth = (
 /**
  * Points along a segment where the label's midpoint could sit, ordered from the
  * middle of the segment outwards. Sliding the label along the wire lets it
- * dodge a chip that only crowds one end.
- *
- * When the label is shorter than the segment, candidates are limited to
- * positions that keep it fully on the wire; when it is longer, only the
- * midpoint is offered (it will overhang either way).
+ * dodge a chip that only crowds one end. Candidates always keep the label
+ * fully on the wire; callers only pass segments the label fits on.
  */
 const getAnchorCandidates = (
   segment: AxisAlignedSegment,

--- a/tests/assets/inline-net-label02.json
+++ b/tests/assets/inline-net-label02.json
@@ -1,0 +1,112 @@
+{
+  "chips": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": 0,
+        "y": 0
+      },
+      "width": 0.4,
+      "height": 1,
+      "pins": [
+        {
+          "pinId": "schematic_port_0",
+          "x": -0.6000000000000001,
+          "y": 0.30000000000000004,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_1",
+          "x": -0.6000000000000001,
+          "y": 0.10000000000000003,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_2",
+          "x": -0.6000000000000001,
+          "y": -0.09999999999999998,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_3",
+          "x": -0.6000000000000001,
+          "y": -0.30000000000000004,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_4",
+          "x": 0.6000000000000001,
+          "y": -0.30000000000000004,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "schematic_port_5",
+          "x": 0.6000000000000001,
+          "y": -0.10000000000000003,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "schematic_port_6",
+          "x": 0.6000000000000001,
+          "y": 0.09999999999999998,
+          "_facingDirection": "x+"
+        },
+        {
+          "pinId": "schematic_port_7",
+          "x": 0.6000000000000001,
+          "y": 0.30000000000000004,
+          "_facingDirection": "x+"
+        }
+      ]
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": {
+        "x": 3,
+        "y": 0.13249999999999998
+      },
+      "width": 1.13,
+      "height": 0.915,
+      "pins": [
+        {
+          "pinId": "schematic_port_8",
+          "x": 2.46,
+          "y": 0,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_9",
+          "x": 3.54,
+          "y": 0,
+          "_facingDirection": "x+"
+        }
+      ]
+    }
+  ],
+  "directConnections": [
+    {
+      "netId": "USER_LED_ANODE",
+      "allowInlineNetLabel": true,
+      "inlineNetLabelWidth": 1.8,
+      "pinIds": [
+        "schematic_port_4",
+        "schematic_port_8"
+      ]
+    }
+  ],
+  "netConnections": [],
+  "textBoxes": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": -0.08000000000000002,
+        "y": 0.615
+      },
+      "width": 0.36,
+      "height": 0.25,
+      "text": "U1"
+    }
+  ],
+  "availableNetLabelOrientations": {},
+  "maxMspPairDistance": 2.4
+}

--- a/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label02.snap.svg
+++ b/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label02.snap.svg
@@ -1,0 +1,57 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0.6000000000000001,-0.30000000000000004 2.435,0" data-type="line" data-label="" points="201.34453781512605,376.47058823529414 448.06722689075633,336.1344537815126" fill="none" stroke="hsl(48, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="0.6000000000000001,-0.30000000000000004 1.5175,-0.30000000000000004 1.5175,0 2.435,0" data-type="line" data-label="" points="201.34453781512605,376.47058823529414 324.7058823529412,376.47058823529414 324.7058823529412,336.1344537815126 448.06722689075633,336.1344537815126" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="schematic_component_0" data-x="0" data-y="0" x="40" y="268.9075630252101" width="161.34453781512605" height="134.45378151260502" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0074375"/></g><g><rect data-type="rect" data-label="schematic_component_1" data-x="3" data-y="0.13249999999999998" x="448.0672268907564" y="256.8067226890756" width="151.93277310924367" height="123.02521008403363" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.0074375"/></g><g><rect data-type="rect" data-label="U1" data-x="-0.08000000000000002" data-y="0.615" x="85.7142857142857" y="236.6386554621849" width="48.40336134453783" height="33.613445378151255" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.0074375"/></g><g><rect data-type="rect" data-label="INLINE netId: USER_LED_ANODE
+axis: x
+side: y+" data-x="1.5175" data-y="0.14" x="203.69747899159668" y="305.21008403361344" width="242.01680672268907" height="24.201680672268935" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.0074375"/></g><text data-type="text" data-label="USER_LED_ANODE" data-x="1.5175" data-y="0.14" x="324.7058823529412" y="317.3109243697479" fill="green" font-size="24.201680672268907" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">USER_LED_ANODE</text><g><circle data-type="point" data-label="schematic_port_0
+x-" data-x="-0.6000000000000001" data-y="0.30000000000000004" cx="39.999999999999986" cy="295.79831932773106" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_1
+x-" data-x="-0.6000000000000001" data-y="0.10000000000000003" cx="39.999999999999986" cy="322.6890756302521" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_2
+x-" data-x="-0.6000000000000001" data-y="-0.09999999999999998" cx="39.999999999999986" cy="349.5798319327731" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_3
+x-" data-x="-0.6000000000000001" data-y="-0.30000000000000004" cx="39.999999999999986" cy="376.47058823529414" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_4
+x+" data-x="0.6000000000000001" data-y="-0.30000000000000004" cx="201.34453781512605" cy="376.47058823529414" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_5
+x+" data-x="0.6000000000000001" data-y="-0.10000000000000003" cx="201.34453781512605" cy="349.5798319327731" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_6
+x+" data-x="0.6000000000000001" data-y="0.09999999999999998" cx="201.34453781512605" cy="322.6890756302521" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_7
+x+" data-x="0.6000000000000001" data-y="0.30000000000000004" cx="201.34453781512605" cy="295.79831932773106" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_8
+x-" data-x="2.435" data-y="0" cx="448.06722689075633" cy="336.1344537815126" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="schematic_port_9
+x+" data-x="3.565" data-y="0" cx="600" cy="336.1344537815126" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="inline anchor
+USER_LED_ANODE" data-x="1.5175" data-y="0" cx="324.7058823529412" cy="336.1344537815126" r="3" fill="green"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":134.45378151260505,"c":0,"e":120.67226890756302,"b":0,"d":-134.45378151260505,"f":336.1344537815126};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/solvers/InlineNetLabelSolver/inline-net-label02.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/inline-net-label02.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "../../assets/inline-net-label02.json"
+import "tests/fixtures/matcher"
+
+// Real geometry from @tscircuit/core: a soic8 and an 0603 LED 3 units apart.
+// The label (width 1.8) is longer than every straight run of the routed trace
+// (~0.95), but the route is straight except for a 0.3-unit elbow jog, so the
+// name is centered over the route's overall span - bridging the jog - instead
+// of falling back to an anchored label.
+test("inline-net-label02 spans a route with a small jog", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  const placements = solver.inlineNetLabelSolver!.inlineNetLabelPlacements
+  expect(placements.map((p) => p.netId)).toEqual(["USER_LED_ANODE"])
+
+  const [placement] = placements
+  expect(placement!.axis).toBe("x")
+
+  const labelBounds = {
+    minX: placement!.center.x - placement!.width / 2,
+    maxX: placement!.center.x + placement!.width / 2,
+    minY: placement!.center.y - placement!.height / 2,
+    maxY: placement!.center.y + placement!.height / 2,
+  }
+
+  // The label stays within the route's endpoints - no floating overhang.
+  const trace = solver.inlineNetLabelSolver!.traces.find(
+    (t) => t.mspPairId === placement!.mspPairId,
+  )!
+  const routeMinX = Math.min(...trace.tracePath.map((p) => p.x))
+  const routeMaxX = Math.max(...trace.tracePath.map((p) => p.x))
+  const routeMaxY = Math.max(...trace.tracePath.map((p) => p.y))
+  expect(labelBounds.minX).toBeGreaterThanOrEqual(routeMinX - 1e-9)
+  expect(labelBounds.maxX).toBeLessThanOrEqual(routeMaxX + 1e-9)
+
+  // It sits clear of the route's full perpendicular extent (above every jog).
+  expect(labelBounds.minY).toBeGreaterThan(routeMaxY)
+
+  // And never on top of a chip.
+  for (const chip of (inputProblem as any).chips) {
+    const chipBounds = {
+      minX: chip.center.x - chip.width / 2,
+      maxX: chip.center.x + chip.width / 2,
+      minY: chip.center.y - chip.height / 2,
+      maxY: chip.center.y + chip.height / 2,
+    }
+    const overlaps =
+      labelBounds.minX < chipBounds.maxX &&
+      labelBounds.maxX > chipBounds.minX &&
+      labelBounds.minY < chipBounds.maxY &&
+      labelBounds.maxY > chipBounds.minY
+    expect(overlaps).toBe(false)
+  }
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
Replaces #793 (closed) per review direction: an inline label should read as a name sitting **on its wire**, never as floating text overhanging a run.

## The case

Real geometry from [core#3085](https://github.com/tscircuit/core/pull/3085): soic8 → 0603 LED, 3 units apart. `USER_LED_ANODE` (width 1.8) is longer than every straight run of the routed trace (~0.95), so #792's placement declined and the net fell back to an anchored tag — rendered vertically across the very wire the inline label was meant to keep clean.

But the route is straight except for a 0.3-unit elbow jog, and its overall span (1.86) fits the name. A human reads that as one wire and centers the name over it.

## Behavior

Placement is now two-stage:

1. **Straight run** the label fully fits on (unchanged, minus the old overhang-at-midpoint): slide within the run, never past its ends.
2. **Span**: if no run fits but the route's perpendicular extent is ≤ `INLINE_NET_LABEL_MAX_SPAN_JOG` (0.4), center the label over the route's overall extent — bridging the jogs, clear of the route's full perpendicular extent, never extending past its endpoints.

Anything more meandering still falls back to an anchored label. Obstruction checks (chips, component text, foreign-net traces) apply to both stages.

## Result

<img width="500" alt="label centered over the whole route, bridging the elbow jog" src="https://raw.githubusercontent.com/tscircuit/schematic-trace-solver/inline-label-span-jogs/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label02.snap.svg" />

The test asserts the label stays within the route's endpoints, sits clear of its full perpendicular extent, and overlaps no chip.

`bun test`: 175 pass / 0 fail (no churn to existing snapshots — labels that fit a run place identically). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)