### PR TITLE
fix(solvers): prevent crash on empty connections array

### DIFF
--- a/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
+++ b/lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver.ts
@@ -56,21 +56,21 @@ export class MspConnectionPairSolver extends BaseSolver {
     this.globalConnMap = netConnMap
 
     this.pinMap = {}
-    for (const chip of inputProblem.chips) {
-      for (const pin of chip.pins) {
+    for (const chip of inputProblem.chips ?? []) {
+      for (const pin of chip.pins ?? []) {
         this.pinMap[pin.pinId] = { ...pin, chipId: chip.chipId }
       }
     }
 
     this.chipMap = {}
-    for (const chip of inputProblem.chips) {
+    for (const chip of inputProblem.chips ?? []) {
       this.chipMap[chip.chipId] = chip
     }
 
     // Build a mapping from PinId to user-provided netId (if any)
     this.userNetIdByPinId = {}
     this.directConnectionPinPairKeys = new Set()
-    for (const dc of inputProblem.directConnections) {
+    for (const dc of inputProblem.directConnections ?? []) {
       this.directConnectionPinPairKeys.add(getPinPairKey(dc.pinIds))
       if (dc.netId) {
         const [a, b] = dc.pinIds
@@ -78,8 +78,8 @@ export class MspConnectionPairSolver extends BaseSolver {
         this.userNetIdByPinId[b] = dc.netId
       }
     }
-    for (const nc of inputProblem.netConnections) {
-      for (const pid of nc.pinIds) {
+    for (const nc of inputProblem.netConnections ?? []) {
+      for (const pid of nc.pinIds ?? []) {
         this.userNetIdByPinId[pid] = nc.netId
       }
     }

--- a/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
+++ b/lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem.ts
@@ -6,7 +6,7 @@ export const getConnectivityMapsFromInputProblem = (
 ): { directConnMap: ConnectivityMap; netConnMap: ConnectivityMap } => {
   const directConnMap = new ConnectivityMap({})
 
-  for (const directConn of inputProblem.directConnections) {
+  for (const directConn of inputProblem.directConnections ?? []) {
     directConnMap.addConnections([
       directConn.netId
         ? [directConn.netId, ...directConn.pinIds]
@@ -16,7 +16,7 @@ export const getConnectivityMapsFromInputProblem = (
 
   const netConnMap = new ConnectivityMap(directConnMap.netMap)
 
-  for (const netConn of inputProblem.netConnections) {
+  for (const netConn of inputProblem.netConnections ?? []) {
     netConnMap.addConnections([[netConn.netId, ...netConn.pinIds]])
   }
 

--- a/tests/solvers/SchematicTracePipelineSolver/empty-connections-guard.test.ts
+++ b/tests/solvers/SchematicTracePipelineSolver/empty-connections-guard.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import { MspConnectionPairSolver } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import { SchematicTraceLinesSolver } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+test("SchematicTracePipelineSolver handles empty connections array without crashing (#657)", () => {
+  const emptyProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [
+          { pinId: "p1", x: 0.5, y: 0 },
+          { pinId: "p2", x: -0.5, y: 0 },
+        ],
+      },
+    ],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+
+  const solver = new SchematicTracePipelineSolver(emptyProblem)
+  expect(() => solver.solve()).not.toThrow()
+  expect(solver.solved).toBe(true)
+})
+
+test("MspConnectionPairSolver handles empty and undefined connection arrays safely", () => {
+  const emptyProblem = {
+    chips: [],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  } as unknown as InputProblem
+
+  const solver = new MspConnectionPairSolver({ inputProblem: emptyProblem })
+  expect(() => solver.solve()).not.toThrow()
+  expect(solver.solved).toBe(true)
+  expect(solver.mspConnectionPairs).toEqual([])
+})


### PR DESCRIPTION
## Summary

Fixes #657.

This PR adds safety guards to ensure solvers handle empty or undefined connection arrays (\directConnections: []\, \
etConnections: []\) without throwing uncaught exceptions.

### Changes
1. Added nullish coalescing to \getConnectivityMapsFromInputProblem.ts\ for \directConnections\ and \
etConnections\.
2. Added nullish coalescing to \MspConnectionPairSolver.ts\ across \chips\, \pins\, \directConnections\, and \
etConnections\.
3. Created \	ests/solvers/SchematicTracePipelineSolver/empty-connections-guard.test.ts\ verifying that solving an \InputProblem\ with empty connection arrays succeeds cleanly.

### Verification
- \un test tests/solvers/SchematicTracePipelineSolver/empty-connections-guard.test.ts\ (2/2 passing).