### PR TITLE
Fix countTurns using exact float equality instead of epsilon

### DIFF
--- a/lib/solvers/TraceCleanupSolver/countTurns.ts
+++ b/lib/solvers/TraceCleanupSolver/countTurns.ts
@@ -1,5 +1,7 @@
 import type { Point } from "@tscircuit/math-utils"
 
+const EPS = 1e-6
+
 export const countTurns = (points: Point[]): number => {
   let turns = 0
   for (let i = 1; i < points.length - 1; i++) {
@@ -7,8 +9,8 @@ export const countTurns = (points: Point[]): number => {
     const curr = points[i]
     const next = points[i + 1]
 
-    const prevVertical = prev.x === curr.x
-    const nextVertical = curr.x === next.x
+    const prevVertical = Math.abs(prev.x - curr.x) < EPS
+    const nextVertical = Math.abs(curr.x - next.x) < EPS
 
     if (prevVertical !== nextVertical) {
       turns++

--- a/tests/functions/countTurns.test.ts
+++ b/tests/functions/countTurns.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { countTurns } from "lib/solvers/TraceCleanupSolver/countTurns"
+
+test("countTurns treats a straight run with float drift as no turn", () => {
+  // Typical drift from chained += offset math elsewhere in the pipeline
+  // (e.g. TraceOverlapIssueSolver's jog application) - geometrically this
+  // is a straight vertical run, not a turn.
+  const drifted = [
+    { x: 1, y: 0 },
+    { x: 1.0000000001, y: 1 },
+    { x: 1.0000000001, y: 2 },
+  ]
+
+  expect(countTurns(drifted)).toBe(0)
+})
+
+test("countTurns returns 0 for a perfectly straight vertical run", () => {
+  const straight = [
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 1, y: 2 },
+  ]
+
+  expect(countTurns(straight)).toBe(0)
+})
+
+test("countTurns counts a single L-shaped turn", () => {
+  const lShape = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ]
+
+  expect(countTurns(lShape)).toBe(1)
+})
+
+test("countTurns counts both turns in a Z-shape", () => {
+  const zShape = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 2, y: 1 },
+  ]
+
+  expect(countTurns(zShape)).toBe(2)
+})
+
+test("countTurns still counts a real turn well above the drift tolerance", () => {
+  const realTurn = [
+    { x: 1, y: 0 },
+    { x: 1.01, y: 1 },
+    { x: 1.01, y: 2 },
+  ]
+
+  expect(countTurns(realTurn)).toBe(1)
+})


### PR DESCRIPTION
## Summary

- `countTurns` classified segment orientation with strict `prev.x === curr.x`, which breaks on the float drift produced by chained `+=` math elsewhere in the pipeline (e.g. `TraceOverlapIssueSolver`'s jog offsets) - a geometrically straight run could get miscounted as having a turn.
- Switched to an epsilon comparison (`Math.abs(...) < EPS`), matching the pattern already used elsewhere in the codebase (e.g. `isVertical`/`isHorizontal` in `SchematicTraceSingleLineSolver2/collisions.ts`).
- `countTurns` feeds path-scoring in `turnMinimization.ts`, `minimizeTurnsWithFilteredLabels.ts`, and `scoreRailAlignment.ts`, so a wrong turn count can make those solvers reject a genuinely straighter candidate path.
- Added `tests/functions/countTurns.test.ts` - confirmed it fails against the old `===` code and passes against the fix.

## Validation

- `bunx tsc --noEmit`
- `bun test` (185 pass, 4 pre-existing skips, 0 fail, no snapshot changes)
- Verified the new test fails on the pre-fix code via `git stash` before confirming the fix