### PR TITLE
fix(solvers): relocate net labels sitting inside chip obstacles in NetLabelNetLabelCollisionSolver

### DIFF
--- a/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
+++ b/lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver.ts
@@ -110,6 +110,7 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
   private chipIndex: ChipObstacleSpatialIndex
   private traceMap: Record<MspConnectionPairId, SolvedTracePath>
   private skippedCollisionKeys = new Set<string>()
+  private skippedChipCollisionLabels = new Set<string>()
 
   private labelsToTry: NetLabelPlacement[] = []
   private candidateQueue: Candidate[] = []
@@ -163,6 +164,22 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
         if (this.skippedCollisionKeys.has(this.collisionKey(a, b))) continue
         if (boundsOverlap(this.labelBounds(a), this.labelBounds(b)))
           return [a, b]
+      }
+    }
+    return null
+  }
+
+  private findNextChipCollidingLabel(): NetLabelPlacement | null {
+    const labels = this.outputNetLabelPlacements
+    for (let i = 0; i < labels.length; i++) {
+      const label = labels[i]!
+      if (this.skippedChipCollisionLabels.has(label.globalConnNetId)) continue
+      const bounds = this.labelBounds(label)
+      if (
+        this.chipIndex.getChipsInBounds(bounds).length > 0 ||
+        rectIntersectsAnyTextBox(bounds, this.inputProblem)
+      ) {
+        return label
       }
     }
     return null
@@ -309,15 +326,23 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
   }
 
   override _step() {
-    if (!this.currentCollision) {
+    if (!this.currentCollision && !this.currentLabelToMove) {
       const pair = this.findNextCollidingPair()
-      if (!pair) {
-        this.solved = true
+      if (pair) {
+        this.currentCollision = pair
+        this.labelsToTry = [pair[1], pair[0]]
+        this.beginSearchForLabel(this.labelsToTry.shift()!)
         return
       }
-      this.currentCollision = pair
-      this.labelsToTry = [pair[1], pair[0]]
-      this.beginSearchForLabel(this.labelsToTry.shift()!)
+
+      const chipCollidingLabel = this.findNextChipCollidingLabel()
+      if (chipCollidingLabel) {
+        this.labelsToTry = [chipCollidingLabel]
+        this.beginSearchForLabel(this.labelsToTry.shift()!)
+        return
+      }
+
+      this.solved = true
       return
     }
 
@@ -325,28 +350,40 @@ export class NetLabelNetLabelCollisionSolver extends BaseSolver {
       if (this.labelsToTry.length > 0) {
         this.beginSearchForLabel(this.labelsToTry.shift()!)
       } else {
-        this.skippedCollisionKeys.add(
-          this.collisionKey(this.currentCollision[0], this.currentCollision[1]),
-        )
+        if (this.currentCollision) {
+          this.skippedCollisionKeys.add(
+            this.collisionKey(this.currentCollision[0], this.currentCollision[1]),
+          )
+        } else if (this.currentLabelToMove) {
+          this.skippedChipCollisionLabels.add(this.currentLabelToMove.globalConnNetId)
+        }
         this.clearActiveSearch()
       }
       return
     }
 
     const candidate = this.candidateQueue[this.candidateIndex++]!
-    const [labelA, labelB] = this.currentCollision
-    let fixedLabel: NetLabelPlacement
-    if (this.currentLabelToMove === labelB) {
-      fixedLabel = labelA
+    
+    let obstacleLabels: NetLabelPlacement[]
+    if (this.currentCollision) {
+      const [labelA, labelB] = this.currentCollision
+      let fixedLabel: NetLabelPlacement
+      if (this.currentLabelToMove === labelB) {
+        fixedLabel = labelA
+      } else {
+        fixedLabel = labelB
+      }
+      obstacleLabels = [
+        ...this.outputNetLabelPlacements.filter(
+          (l) => l !== labelA && l !== labelB,
+        ),
+        fixedLabel,
+      ]
     } else {
-      fixedLabel = labelB
+      obstacleLabels = this.outputNetLabelPlacements.filter(
+        (l) => l !== this.currentLabelToMove,
+      )
     }
-    const obstacleLabels = [
-      ...this.outputNetLabelPlacements.filter(
-        (l) => l !== labelA && l !== labelB,
-      ),
-      fixedLabel,
-    ]
 
     const status = this.checkCandidate(
       candidate,

--- a/tests/solvers/NetLabelNetLabelCollisionSolver/chip-obstacle-avoidance.test.ts
+++ b/tests/solvers/NetLabelNetLabelCollisionSolver/chip-obstacle-avoidance.test.ts
@@ -16,8 +16,9 @@ test("NetLabelNetLabelCollisionSolver relocates net labels placed inside chip bo
         pins: [
           {
             pinId: "U1.pin1",
-            center: { x: -1, y: 0 },
-            facingDirection: "x-",
+            x: -1,
+            y: 0,
+            _facingDirection: "x-",
           },
         ],
       },
@@ -28,6 +29,11 @@ test("NetLabelNetLabelCollisionSolver relocates net labels placed inside chip bo
   const traces: SolvedTracePath[] = [
     {
       mspPairId: "pair-1" as any,
+      mspConnectionPairIds: ["pair-1" as any],
+      pinIds: ["U1.pin1"],
+      dcConnNetId: "net_VCC",
+      globalConnNetId: "net_VCC",
+      pins: [{ pinId: "U1.pin1", x: -1, y: 0 }],
       tracePath: [
         { x: -1, y: 0 },
         { x: -3, y: 0 },
@@ -45,6 +51,7 @@ test("NetLabelNetLabelCollisionSolver relocates net labels placed inside chip bo
       height: 0.5,
       orientation: "x+",
       mspConnectionPairIds: ["pair-1" as any],
+      pinIds: ["U1.pin1"],
     },
   ]
 

--- a/tests/solvers/NetLabelNetLabelCollisionSolver/chip-obstacle-avoidance.test.ts
+++ b/tests/solvers/NetLabelNetLabelCollisionSolver/chip-obstacle-avoidance.test.ts
@@ -23,17 +23,22 @@ test("NetLabelNetLabelCollisionSolver relocates net labels placed inside chip bo
         ],
       },
     ],
-    connections: [],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
   }
 
   const traces: SolvedTracePath[] = [
     {
       mspPairId: "pair-1" as any,
       mspConnectionPairIds: ["pair-1" as any],
-      pinIds: ["U1.pin1"],
+      pinIds: ["U1.pin1", "U1.pin1"],
       dcConnNetId: "net_VCC",
       globalConnNetId: "net_VCC",
-      pins: [{ pinId: "U1.pin1", x: -1, y: 0 }],
+      pins: [
+        { pinId: "U1.pin1", x: -1, y: 0, chipId: "U1" },
+        { pinId: "U1.pin1", x: -1, y: 0, chipId: "U1" },
+      ],
       tracePath: [
         { x: -1, y: 0 },
         { x: -3, y: 0 },

--- a/tests/solvers/NetLabelNetLabelCollisionSolver/chip-obstacle-avoidance.test.ts
+++ b/tests/solvers/NetLabelNetLabelCollisionSolver/chip-obstacle-avoidance.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "bun:test"
+import { NetLabelNetLabelCollisionSolver } from "lib/solvers/NetLabelNetLabelCollisionSolver/NetLabelNetLabelCollisionSolver"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import { getRectBounds } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
+
+test("NetLabelNetLabelCollisionSolver relocates net labels placed inside chip bodies (#655)", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 0, y: 0 },
+        width: 2,
+        height: 2,
+        pins: [
+          {
+            pinId: "U1.pin1",
+            center: { x: -1, y: 0 },
+            facingDirection: "x-",
+          },
+        ],
+      },
+    ],
+    connections: [],
+  }
+
+  const traces: SolvedTracePath[] = [
+    {
+      mspPairId: "pair-1" as any,
+      tracePath: [
+        { x: -1, y: 0 },
+        { x: -3, y: 0 },
+      ],
+    },
+  ]
+
+  // Label initially placed at (0, 0) inside chip U1 with bounds [-0.5, -0.25, 0.5, 0.25]
+  const initialPlacements: NetLabelPlacement[] = [
+    {
+      globalConnNetId: "net_VCC",
+      anchorPoint: { x: -1, y: 0 },
+      center: { x: 0, y: 0 },
+      width: 1,
+      height: 0.5,
+      orientation: "x+",
+      mspConnectionPairIds: ["pair-1" as any],
+    },
+  ]
+
+  const solver = new NetLabelNetLabelCollisionSolver({
+    inputProblem,
+    traces,
+    netLabelPlacements: initialPlacements,
+  })
+
+  solver.solve()
+
+  const { netLabelPlacements } = solver.getOutput()
+  expect(netLabelPlacements.length).toBe(1)
+
+  const placed = netLabelPlacements[0]!
+  const bounds = getRectBounds(placed.center, placed.width, placed.height)
+
+  // Verify the label has been moved out of the chip body (center was 0, 0)
+  const isInsideChip =
+    bounds.minX < 1 && bounds.maxX > -1 && bounds.minY < 1 && bounds.maxY > -1
+  expect(isInsideChip).toBe(false)
+})


### PR DESCRIPTION
## Summary

Fixes #655.

Previously, \`NetLabelNetLabelCollisionSolver\` only initiated candidate search when a label collided with *another net label* (\`findNextCollidingPair\`). A net label that sat inside a chip body without colliding with any other label was never evaluated against obstacles or relocated, leaving illegible labels buried inside components.

### Changes
1. **Chip Obstacle Detection**: Added \`findNextChipCollidingLabel\` to detect labels whose bounding boxes intersect chip bodies (via \`ChipObstacleSpatialIndex\`) or text boxes (\`rectIntersectsAnyTextBox\`).
2. **Standalone Relocation**: In \`_step()\`, after label-label pairs are resolved, the solver queries \`findNextChipCollidingLabel()\` and tests candidate orientations and anchors along available trace segments to move the label outside obstacle bounds.
3. **Unit Tests**: Added \`tests/solvers/NetLabelNetLabelCollisionSolver/chip-obstacle-avoidance.test.ts\` verifying that a label initially placed overlapping a chip body is relocated completely outside the chip bounding box.

### Verification
- \`bun test tests/solvers/NetLabelNetLabelCollisionSolver/chip-obstacle-avoidance.test.ts\` (1/1 passing).
