### PR TITLE
fix: return stable schematic solver name

### DIFF
--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -71,7 +71,9 @@ interface Options {
 }
 
 export class SchematicTracePipelineSolver extends BaseSolver {
-  static solverName = "SchematicTracePipelineSolver"
+  getSolverName(): string {
+    return "SchematicTracePipelineSolver"
+  }
 
   mspConnectionPairSolver?: MspConnectionPairSolver
   // guidelinesSolver?: GuidelinesSolver

--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -71,6 +71,8 @@ interface Options {
 }
 
 export class SchematicTracePipelineSolver extends BaseSolver {
+  static solverName = "SchematicTracePipelineSolver"
+
   mspConnectionPairSolver?: MspConnectionPairSolver
   // guidelinesSolver?: GuidelinesSolver
   schematicTraceLinesSolver?: SchematicTraceLinesSolver

--- a/tests/solver-name.test.ts
+++ b/tests/solver-name.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "../lib"
+
+test("SchematicTracePipelineSolver has a stable solver name", () => {
+  expect(SchematicTracePipelineSolver.solverName).toBe(
+    "SchematicTracePipelineSolver",
+  )
+})

--- a/tests/solver-name.test.ts
+++ b/tests/solver-name.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from "bun:test"
 import { SchematicTracePipelineSolver } from "../lib"
 
 test("SchematicTracePipelineSolver has a stable solver name", () => {
-  expect(SchematicTracePipelineSolver.solverName).toBe(
-    "SchematicTracePipelineSolver",
-  )
+  const solver = Object.create(
+    SchematicTracePipelineSolver.prototype,
+  ) as SchematicTracePipelineSolver
+
+  expect(solver.getSolverName()).toBe("SchematicTracePipelineSolver")
 })


### PR DESCRIPTION
## Summary
- implement getSolverName() on SchematicTracePipelineSolver
- return a literal name that survives class-name minification
- cover the public solver export with a focused regression test

## Why
solver-utils already uses the instance getSolverName() method throughout GenericSolverDebugger. Returning the readable name from the source solver avoids static metadata and constructor wrappers in core.

## Verification
- bun test tests/solver-name.test.ts
- bunx tsc --noEmit
- bun run build
- bun run format:check