### PR TITLE
Fix: Early exit guard on empty connections array (Fixes #657)

### DIFF
--- a/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver.ts
@@ -325,6 +325,14 @@ export class SchematicTracePipelineSolver extends BaseSolver {
     this.endTimeOfPhase = {}
     this.timeSpentOnPhase = {}
     this.firstIterationOfPhase = {}
+
+    // Early exit: if there are no connections to route, mark as solved immediately
+    if (
+      this.inputProblem.directConnections.length === 0 &&
+      this.inputProblem.netConnections.length === 0
+    ) {
+      this.solved = true
+    }
   }
 
   override getConstructorParams(): ConstructorParameters<

--- a/tests/assets/empty-connections.json
+++ b/tests/assets/empty-connections.json
@@ -1,0 +1,18 @@
+{
+  "chips": [
+    {
+      "chipId": "U1",
+      "center": { "x": 0, "y": 0 },
+      "width": 1.6,
+      "height": 0.6,
+      "pins": [
+        { "pinId": "U1.1", "x": -0.8, "y": 0.2 },
+        { "pinId": "U1.2", "x": -0.8, "y": 0 },
+        { "pinId": "U1.3", "x": 0.8, "y": 0 }
+      ]
+    }
+  ],
+  "directConnections": [],
+  "netConnections": [],
+  "availableNetLabelOrientations": {}
+}

--- a/tests/examples/empty-connections.test.ts
+++ b/tests/examples/empty-connections.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "../assets/empty-connections.json"
+
+test("empty-connections: solver does not crash on empty connections array", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  // Should not throw
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBeFalsy()
+})
+
+test("empty-connections: solver handles completely empty input", () => {
+  const emptyInput = {
+    chips: [],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+
+  const solver = new SchematicTracePipelineSolver(emptyInput as any)
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBeFalsy()
+})


### PR DESCRIPTION
This PR fixes issue #657 where the router crashes on empty connections array. Added early exit guard in SchematicTracePipelineSolver.ts and test cases for empty connections.