### PR TITLE
speed up available net orientation search

### DIFF
--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationObstacleIndex.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationObstacleIndex.ts
@@ -1,0 +1,182 @@
+import type { Bounds, Point } from "@tscircuit/math-utils"
+import Flatbush from "flatbush"
+import type { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { segmentIntersectsRect } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/collisions"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { EPS } from "./constants"
+import { segmentCrossesBoundsInterior } from "./geometry"
+
+export type IndexedTraceSegment = {
+  trace: SolvedTracePath
+  start: Point
+  end: Point
+}
+
+export class AvailableNetOrientationObstacleIndex {
+  private chipObstacleSpatialIndex: ChipObstacleSpatialIndex
+  private labelIndex: Flatbush | null = null
+  private traceSegmentIndex: Flatbush | null = null
+  private traceSegments: IndexedTraceSegment[] = []
+
+  constructor(params: {
+    chipObstacleSpatialIndex: ChipObstacleSpatialIndex
+    netLabelPlacements: NetLabelPlacement[]
+    traces: SolvedTracePath[]
+  }) {
+    this.chipObstacleSpatialIndex = params.chipObstacleSpatialIndex
+    this.rebuild(params)
+  }
+
+  rebuild(params: {
+    netLabelPlacements: NetLabelPlacement[]
+    traces: SolvedTracePath[]
+  }) {
+    this.labelIndex = this.buildLabelIndex(params.netLabelPlacements)
+    this.traceSegments = this.getTraceSegments(params.traces)
+    this.traceSegmentIndex = this.buildTraceSegmentIndex(this.traceSegments)
+  }
+
+  getLabelIndicesInBounds(bounds: Bounds) {
+    if (!this.labelIndex) return []
+    return this.labelIndex.search(
+      bounds.minX,
+      bounds.minY,
+      bounds.maxX,
+      bounds.maxY,
+    )
+  }
+
+  getTraceSegmentsInBounds(bounds: Bounds) {
+    if (!this.traceSegmentIndex) return []
+    const searchBounds = getPaddedBounds(bounds, EPS)
+    return this.traceSegmentIndex
+      .search(
+        searchBounds.minX,
+        searchBounds.minY,
+        searchBounds.maxX,
+        searchBounds.maxY,
+      )
+      .map((segmentIndex) => this.traceSegments[segmentIndex]!)
+  }
+
+  getLabelIndicesNearTracePath(tracePath: Point[]) {
+    const labelIndices = new Set<number>()
+    for (let pointIndex = 0; pointIndex < tracePath.length - 1; pointIndex++) {
+      const segmentBounds = getPaddedBounds(
+        getSegmentBounds(tracePath[pointIndex]!, tracePath[pointIndex + 1]!),
+        EPS,
+      )
+      for (const labelIndex of this.getLabelIndicesInBounds(segmentBounds)) {
+        labelIndices.add(labelIndex)
+      }
+    }
+    return [...labelIndices].sort((a, b) => a - b)
+  }
+
+  doesTracePathCrossChip(tracePath: Point[]) {
+    for (let pointIndex = 0; pointIndex < tracePath.length - 1; pointIndex++) {
+      const start = tracePath[pointIndex]!
+      const end = tracePath[pointIndex + 1]!
+      const nearbyChips = this.chipObstacleSpatialIndex.getChipsInBounds(
+        getPaddedBounds(getSegmentBounds(start, end), EPS),
+      )
+      for (const chip of nearbyChips) {
+        if (segmentCrossesBoundsInterior(start, end, chip.bounds)) return true
+      }
+    }
+    return false
+  }
+
+  doesTraceCrossBoundsInterior(bounds: Bounds) {
+    for (const segment of this.getTraceSegmentsInBounds(bounds)) {
+      if (segmentCrossesBoundsInterior(segment.start, segment.end, bounds)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  doesTraceIntersectBounds(params: {
+    bounds: Bounds
+    excludedGlobalConnNetId: string
+  }) {
+    for (const segment of this.getTraceSegmentsInBounds(params.bounds)) {
+      if (segment.trace.globalConnNetId === params.excludedGlobalConnNetId) {
+        continue
+      }
+      if (segmentIntersectsRect(segment.start, segment.end, params.bounds)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  private buildLabelIndex(netLabelPlacements: NetLabelPlacement[]) {
+    if (netLabelPlacements.length === 0) return null
+
+    const labelIndex = new Flatbush(netLabelPlacements.length)
+    for (const label of netLabelPlacements) {
+      labelIndex.add(
+        label.center.x - label.width / 2,
+        label.center.y - label.height / 2,
+        label.center.x + label.width / 2,
+        label.center.y + label.height / 2,
+      )
+    }
+    labelIndex.finish()
+    return labelIndex
+  }
+
+  private getTraceSegments(traces: SolvedTracePath[]) {
+    const traceSegments: IndexedTraceSegment[] = []
+    for (const trace of traces) {
+      for (
+        let pointIndex = 0;
+        pointIndex < trace.tracePath.length - 1;
+        pointIndex++
+      ) {
+        traceSegments.push({
+          trace,
+          start: trace.tracePath[pointIndex]!,
+          end: trace.tracePath[pointIndex + 1]!,
+        })
+      }
+    }
+    return traceSegments
+  }
+
+  private buildTraceSegmentIndex(traceSegments: IndexedTraceSegment[]) {
+    if (traceSegments.length === 0) return null
+
+    const traceSegmentIndex = new Flatbush(traceSegments.length)
+    for (const segment of traceSegments) {
+      traceSegmentIndex.add(
+        Math.min(segment.start.x, segment.end.x),
+        Math.min(segment.start.y, segment.end.y),
+        Math.max(segment.start.x, segment.end.x),
+        Math.max(segment.start.y, segment.end.y),
+      )
+    }
+    traceSegmentIndex.finish()
+    return traceSegmentIndex
+  }
+}
+
+function getSegmentBounds(start: Point, end: Point): Bounds {
+  return {
+    minX: Math.min(start.x, end.x),
+    minY: Math.min(start.y, end.y),
+    maxX: Math.max(start.x, end.x),
+    maxY: Math.max(start.y, end.y),
+  }
+}
+
+function getPaddedBounds(bounds: Bounds, padding: number): Bounds {
+  return {
+    minX: bounds.minX - padding,
+    minY: bounds.minY - padding,
+    maxX: bounds.maxX + padding,
+    maxY: bounds.maxY + padding,
+  }
+}

--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -17,7 +17,12 @@ import type {
 } from "lib/types/InputProblem"
 import { dir, type FacingDirection } from "lib/utils/dir"
 import { rectIntersectsAnyTextBox } from "lib/utils/textBoxBounds"
-import { EPS, LABEL_SEARCH_STEP, WICK_CLEARANCE } from "./constants"
+import {
+  EPS,
+  LABEL_SEARCH_STEP,
+  MAX_RECORDED_CANDIDATES,
+  WICK_CLEARANCE,
+} from "./constants"
 import {
   getConnectorTracePath,
   getMaxSearchDistance,
@@ -27,8 +32,6 @@ import {
   rangesOverlap,
   rectsOverlap,
   simplifyOrthogonalPath,
-  traceCrossesBoundsInterior,
-  tracePathCrossesAnyBounds,
   tracePathIntersectsBounds,
 } from "./geometry"
 import { orderRoutedLabelsBeforeOverlappingPortLabels } from "./orderRoutedLabelsBeforeOverlappingPortLabels"
@@ -43,6 +46,7 @@ import type {
   EvaluatedCandidate,
 } from "./types"
 import { visualizeAvailableNetOrientationSolver } from "./visualize"
+import { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
 
 const LABEL_TRACE_CLEARANCE = 0.1
 
@@ -64,6 +68,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
   private chipObstacleSpatialIndex: ChipObstacleSpatialIndex
   private maxSearchDistance: number
   private pinMap: Record<string, InputPin & { chipId: string }>
+  private obstacleIndex: AvailableNetOrientationObstacleIndex
 
   constructor(params: AvailableNetOrientationSolverParams) {
     super()
@@ -79,6 +84,11 @@ export class AvailableNetOrientationSolver extends BaseSolver {
       params.inputProblem._chipObstacleSpatialIndex ??
       new ChipObstacleSpatialIndex(params.inputProblem.chips)
     this.maxSearchDistance = getMaxSearchDistance(params.inputProblem)
+    this.obstacleIndex = new AvailableNetOrientationObstacleIndex({
+      chipObstacleSpatialIndex: this.chipObstacleSpatialIndex,
+      netLabelPlacements: this.outputNetLabelPlacements,
+      traces: this.traces,
+    })
     this.crowdedPortOnlyLabelIndices = this.getCrowdedPortOnlyLabelIndices()
     this.queuedLabelIndices = this.getProcessableLabelIndices()
     this.setCurrentLabel(this.queuedLabelIndices[0] ?? null)
@@ -309,6 +319,10 @@ export class AvailableNetOrientationSolver extends BaseSolver {
       ...toNetLabelPlacementPatch(candidate),
     }
     this.addConnectorTrace(label, candidate, labelIndex)
+    this.obstacleIndex.rebuild({
+      netLabelPlacements: this.outputNetLabelPlacements,
+      traces: this.traces,
+    })
   }
 
   private addConnectorTrace(
@@ -553,7 +567,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
         anchorY - label.anchorPoint.y,
         anchorX - label.anchorPoint.x,
       )
-      this.currentCandidateResults.push(result)
+      this.recordCandidateResult(result)
       if (result.status !== "valid") continue
 
       result.selected = true
@@ -605,7 +619,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
         labelIndex,
         "rotate",
       )
-      this.currentCandidateResults.push(result)
+      this.recordCandidateResult(result)
       if (result.status === "valid") {
         result.selected = true
         return result
@@ -637,7 +651,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
         labelIndex,
         "trace-anchor",
       )
-      this.currentCandidateResults.push(result)
+      this.recordCandidateResult(result)
 
       if (result.status === "valid") {
         result.selected = true
@@ -682,7 +696,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
         labelIndex,
         "outward-trace-anchor",
       )
-      this.currentCandidateResults.push(preservedColumnResult)
+      this.recordCandidateResult(preservedColumnResult)
       if (preservedColumnResult.status === "valid") {
         preservedColumnResult.selected = true
         return preservedColumnResult
@@ -716,7 +730,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
           "outward-trace-anchor",
           distance,
         )
-        this.currentCandidateResults.push(result)
+        this.recordCandidateResult(result)
 
         if (result.status === "valid") {
           result.selected = true
@@ -891,7 +905,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
         distance,
         outwardDistance,
       )
-      this.currentCandidateResults.push(result)
+      this.recordCandidateResult(result)
 
       if (result.status === "valid") {
         result.selected = true
@@ -924,6 +938,19 @@ export class AvailableNetOrientationSolver extends BaseSolver {
         phase,
       }),
     }
+  }
+
+  private recordCandidateResult(candidate: EvaluatedCandidate) {
+    this.stats.candidateEvaluations = (this.stats.candidateEvaluations ?? 0) + 1
+    if (this.currentCandidateResults.length < MAX_RECORDED_CANDIDATES) {
+      this.currentCandidateResults.push(candidate)
+    } else if (candidate.status === "valid") {
+      this.currentCandidateResults[MAX_RECORDED_CANDIDATES - 1] = candidate
+    }
+    this.stats.maxRecordedCandidates = Math.max(
+      this.stats.maxRecordedCandidates ?? 0,
+      this.currentCandidateResults.length,
+    )
   }
 
   private getCandidateConnectorTrace(
@@ -1269,13 +1296,13 @@ export class AvailableNetOrientationSolver extends BaseSolver {
       labelIndex,
     )
 
-    for (const chip of this.chipObstacleSpatialIndex.chips) {
-      if (tracePathCrossesAnyBounds(connectorTrace, chip.bounds)) {
-        return "chip-collision"
-      }
+    if (this.obstacleIndex.doesTracePathCrossChip(connectorTrace)) {
+      return "chip-collision"
     }
 
-    for (let i = 0; i < this.outputNetLabelPlacements.length; i++) {
+    for (const i of this.obstacleIndex.getLabelIndicesNearTracePath(
+      connectorTrace,
+    )) {
       if (i === labelIndex) continue
       if (this.shouldIgnorePendingCrowdedLabel(labelIndex, i)) continue
       const otherLabel = this.outputNetLabelPlacements[i]!
@@ -1345,7 +1372,7 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     if (rectIntersectsAnyTextBox(bounds, this.inputProblem)) {
       return "text-collision"
     }
-    if (traceCrossesBoundsInterior(bounds, this.traceMap)) {
+    if (this.obstacleIndex.doesTraceCrossBoundsInterior(bounds)) {
       return "trace-collision"
     }
     if (this.isTraceTooCloseToLabel(bounds, label)) {
@@ -1361,14 +1388,10 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     if (!this.shouldCheckTraceClearanceForLabel(label)) return false
 
     const clearanceBounds = this.getLabelTraceClearanceBounds(bounds)
-    for (const trace of Object.values(this.traceMap)) {
-      if (trace.globalConnNetId === label.globalConnNetId) continue
-      if (tracePathIntersectsBounds(trace.tracePath, clearanceBounds)) {
-        return true
-      }
-    }
-
-    return false
+    return this.obstacleIndex.doesTraceIntersectBounds({
+      bounds: clearanceBounds,
+      excludedGlobalConnNetId: label.globalConnNetId,
+    })
   }
 
   private getLabelTraceClearanceBounds(bounds: Bounds): Bounds {
@@ -1496,7 +1519,17 @@ export class AvailableNetOrientationSolver extends BaseSolver {
   }
 
   private intersectsAnyOtherNetLabel(bounds: Bounds, labelIndex: number) {
-    for (let i = 0; i < this.outputNetLabelPlacements.length; i++) {
+    const searchBounds = {
+      minX: bounds.minX - LABEL_SEARCH_STEP,
+      minY: bounds.minY - LABEL_SEARCH_STEP,
+      maxX: bounds.maxX + LABEL_SEARCH_STEP,
+      maxY: bounds.maxY + LABEL_SEARCH_STEP,
+    }
+    const nearbyLabelIndices = this.obstacleIndex
+      .getLabelIndicesInBounds(searchBounds)
+      .sort((a, b) => a - b)
+
+    for (const i of nearbyLabelIndices) {
       if (i === labelIndex) continue
       if (this.shouldIgnorePendingCrowdedLabel(labelIndex, i)) continue
       const label = this.outputNetLabelPlacements[i]!
@@ -1515,7 +1548,16 @@ export class AvailableNetOrientationSolver extends BaseSolver {
   }
 
   private sharesChipBoundary(bounds: Bounds) {
-    for (const chip of this.chipObstacleSpatialIndex.chips) {
+    const boundarySearchBounds = {
+      minX: bounds.minX - WICK_CLEARANCE - EPS,
+      minY: bounds.minY - WICK_CLEARANCE - EPS,
+      maxX: bounds.maxX + WICK_CLEARANCE + EPS,
+      maxY: bounds.maxY + WICK_CLEARANCE + EPS,
+    }
+    const nearbyChips =
+      this.chipObstacleSpatialIndex.getChipsInBounds(boundarySearchBounds)
+
+    for (const chip of nearbyChips) {
       const chipBounds = chip.bounds
       const adjacentToVerticalSide =
         Math.abs(bounds.minX - chipBounds.maxX) <= WICK_CLEARANCE + EPS ||

--- a/lib/solvers/AvailableNetOrientationSolver/constants.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/constants.ts
@@ -1,4 +1,6 @@
 export const LABEL_SEARCH_STEP = 0.05
+// Keep failed searches from retaining an unbounded visualization history.
+export const MAX_RECORDED_CANDIDATES = 2_000
 export const WICK_CLEARANCE = 0.001
 export const EPS = 1e-9
 export const TRACE_BOUNDARY_TOLERANCE = WICK_CLEARANCE + EPS

--- a/tests/repros/repro161-power-section-autolayout.test.ts
+++ b/tests/repros/repro161-power-section-autolayout.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { MAX_RECORDED_CANDIDATES } from "lib/solvers/AvailableNetOrientationSolver/constants"
 import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
 import type { InputProblem } from "lib/types/InputProblem"
 import "tests/fixtures/matcher"
@@ -30,5 +31,11 @@ test("core repro161 power section trace routing", () => {
   for (const railY of horizontalRailYs) {
     expect(railY).toBeCloseTo(EXPECTED_V3V3_RAIL_Y)
   }
+  expect(
+    solver.availableNetOrientationSolver!.stats.candidateEvaluations,
+  ).toBeGreaterThan(MAX_RECORDED_CANDIDATES)
+  expect(
+    solver.availableNetOrientationSolver!.stats.maxRecordedCandidates,
+  ).toBe(MAX_RECORDED_CANDIDATES)
   expect(solver).toMatchSolverSnapshot(import.meta.path)
 })

--- a/tests/solvers/AvailableNetOrientationSolver/AvailableNetOrientationObstacleIndex.test.ts
+++ b/tests/solvers/AvailableNetOrientationSolver/AvailableNetOrientationObstacleIndex.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from "bun:test"
+import { AvailableNetOrientationObstacleIndex } from "lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationObstacleIndex"
+import { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+
+const netLabelPlacements: NetLabelPlacement[] = [
+  {
+    globalConnNetId: "net-1",
+    mspConnectionPairIds: ["trace-1"],
+    pinIds: ["pin-1", "pin-2"],
+    orientation: "x+",
+    anchorPoint: { x: 0, y: 0 },
+    center: { x: 1, y: 0 },
+    width: 2,
+    height: 1,
+  },
+  {
+    globalConnNetId: "net-2",
+    mspConnectionPairIds: [],
+    pinIds: ["pin-3"],
+    orientation: "x-",
+    anchorPoint: { x: 11, y: 10 },
+    center: { x: 10, y: 10 },
+    width: 2,
+    height: 1,
+  },
+]
+
+const traces: SolvedTracePath[] = [
+  {
+    mspPairId: "trace-1",
+    dcConnNetId: "net-1",
+    globalConnNetId: "net-1",
+    pins: [
+      { pinId: "pin-1", chipId: "chip-1", x: -2, y: 3 },
+      { pinId: "pin-2", chipId: "chip-2", x: 2, y: 3 },
+    ],
+    tracePath: [
+      { x: -2, y: 3 },
+      { x: 2, y: 3 },
+    ],
+    mspConnectionPairIds: ["trace-1"],
+    pinIds: ["pin-1", "pin-2"],
+  },
+]
+
+const chipObstacleSpatialIndex = new ChipObstacleSpatialIndex([
+  {
+    chipId: "chip-obstacle",
+    center: { x: 0, y: 3 },
+    width: 1,
+    height: 1,
+    pins: [],
+  },
+])
+
+test("queries only nearby net labels and trace segments", () => {
+  const obstacleIndex = new AvailableNetOrientationObstacleIndex({
+    chipObstacleSpatialIndex,
+    netLabelPlacements,
+    traces,
+  })
+
+  expect(
+    obstacleIndex.getLabelIndicesInBounds({
+      minX: -0.1,
+      minY: -0.1,
+      maxX: 0.1,
+      maxY: 0.1,
+    }),
+  ).toEqual([0])
+  expect(
+    obstacleIndex.getTraceSegmentsInBounds({
+      minX: -0.1,
+      minY: 2.9,
+      maxX: 0.1,
+      maxY: 3.1,
+    }),
+  ).toHaveLength(1)
+  expect(
+    obstacleIndex.getTraceSegmentsInBounds({
+      minX: -0.1,
+      minY: 9.9,
+      maxX: 0.1,
+      maxY: 10.1,
+    }),
+  ).toHaveLength(0)
+  expect(obstacleIndex.doesTracePathCrossChip(traces[0]!.tracePath)).toBe(true)
+  expect(
+    obstacleIndex.getLabelIndicesNearTracePath([
+      { x: 2 + 5e-10, y: -1 },
+      { x: 2 + 5e-10, y: 1 },
+    ]),
+  ).toEqual([0])
+})
+
+test("rebuilds after a net label moves", () => {
+  const obstacleIndex = new AvailableNetOrientationObstacleIndex({
+    chipObstacleSpatialIndex,
+    netLabelPlacements,
+    traces,
+  })
+  const movedNetLabelPlacements = [
+    { ...netLabelPlacements[0]!, center: { x: 20, y: 20 } },
+    netLabelPlacements[1]!,
+  ]
+
+  obstacleIndex.rebuild({
+    netLabelPlacements: movedNetLabelPlacements,
+    traces,
+  })
+
+  expect(
+    obstacleIndex.getLabelIndicesInBounds({
+      minX: -0.1,
+      minY: -0.1,
+      maxX: 0.1,
+      maxY: 0.1,
+    }),
+  ).toHaveLength(0)
+})


### PR DESCRIPTION
### Motivation
- Large schematic inputs spend most of their trace-solving time checking net-label orientation candidates against every obstacle.

<img width="1231" height="34" alt="image" src="https://github.com/user-attachments/assets/85c8e8c9-023a-4958-9e49-f2f311a38e51" />

<img width="817" height="73" alt="image" src="https://github.com/user-attachments/assets/dca33622-79ec-4d75-a574-126e1c8bf4a7" />

implemented Flatbush spatial indexing  for better optimisation 

<img width="780" height="171" alt="image" src="https://github.com/user-attachments/assets/e5858a7c-99d8-4c13-a0a7-773dd9a2b7ed" />
