### PR TITLE
Publish npm releases with OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -7,25 +7,30 @@ on:
     paths:
       - 'lib/**'
   workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.1
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
-      - run: npm install -g pver
+          package-manager-cache: false
+      - run: npm install -g npm@11 pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@tscircuit/schematic-trace-solver",
   "main": "dist/index.js",
   "version": "0.0.137",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/schematic-trace-solver"
+  },
   "type": "module",
   "scripts": {
     "start": "cosmos",


### PR DESCRIPTION
### Motivation
- The npm publishing token expired after its 90-day lifetime and blocked releases.

### Before
- Releases depended on a rotating organization npm token.

### After
- Releases authenticate through npm trusted publishing with GitHub OIDC.