### PR TITLE
skip blocked available-net orientation intervals

### DIFF
--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -17,12 +17,14 @@ import type {
 } from "lib/types/InputProblem"
 import { dir, type FacingDirection } from "lib/utils/dir"
 import { rectIntersectsAnyTextBox } from "lib/utils/textBoxBounds"
+import { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
 import {
   EPS,
   LABEL_SEARCH_STEP,
   MAX_RECORDED_CANDIDATES,
   WICK_CLEARANCE,
 } from "./constants"
+import { doesFixedConnectorPrefixIntersectObstacles } from "./doesFixedConnectorPrefixIntersectObstacles"
 import {
   getConnectorTracePath,
   getMaxSearchDistance,
@@ -34,6 +36,7 @@ import {
   simplifyOrthogonalPath,
   tracePathIntersectsBounds,
 } from "./geometry"
+import { getNextBoundaryCandidateDistance } from "./getNextBoundaryCandidateDistance"
 import { orderRoutedLabelsBeforeOverlappingPortLabels } from "./orderRoutedLabelsBeforeOverlappingPortLabels"
 import { getPinMap, getTracePins, toNetLabelPlacementPatch } from "./traces"
 import type {
@@ -46,7 +49,6 @@ import type {
   EvaluatedCandidate,
 } from "./types"
 import { visualizeAvailableNetOrientationSolver } from "./visualize"
-import { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
 
 const LABEL_TRACE_CLEARANCE = 0.1
 
@@ -831,37 +833,55 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     }
 
     const maxSteps = Math.ceil(this.maxSearchDistance / LABEL_SEARCH_STEP)
-
     for (let step = 1; step <= maxSteps; step++) {
       for (const sign of [-1, 1]) {
-        const lateralOffset = sign * step * LABEL_SEARCH_STEP
-        const baseAnchor = {
-          x: initialBaseAnchor.x + lateralDir.x * lateralOffset,
-          y: initialBaseAnchor.y + lateralDir.y * lateralOffset,
-        }
-
-        const maxSearchDistance = this.getLateralColumnMaxDistance(
-          label,
-          orientation,
-          baseAnchor,
-        )
-
-        const candidate = this.findValidCandidateInShiftColumn({
+        const candidate = this.findValidCandidateInLateralColumn({
           label,
           labelIndex,
           orientation,
           direction,
-          baseAnchor,
-          maxSearchDistance,
-          outwardDistance: lateralOffset,
-          phase: "lateral-shift",
+          initialBaseAnchor,
+          lateralDir,
+          lateralOffset: sign * step * LABEL_SEARCH_STEP,
         })
-
         if (candidate) return candidate
       }
     }
 
     return null
+  }
+
+  private findValidCandidateInLateralColumn(params: {
+    label: NetLabelPlacement
+    labelIndex: number
+    orientation: FacingDirection
+    direction: Point
+    initialBaseAnchor: Point
+    lateralDir: Point
+    lateralOffset: number
+  }) {
+    const baseAnchor = {
+      x:
+        params.initialBaseAnchor.x + params.lateralDir.x * params.lateralOffset,
+      y:
+        params.initialBaseAnchor.y + params.lateralDir.y * params.lateralOffset,
+    }
+    const maxSearchDistance = this.getLateralColumnMaxDistance(
+      params.label,
+      params.orientation,
+      baseAnchor,
+    )
+
+    return this.findValidCandidateInShiftColumn({
+      label: params.label,
+      labelIndex: params.labelIndex,
+      orientation: params.orientation,
+      direction: params.direction,
+      baseAnchor,
+      maxSearchDistance,
+      outwardDistance: params.lateralOffset,
+      phase: "lateral-shift",
+    })
   }
 
   private findValidCandidateInShiftColumn(params: {
@@ -887,11 +907,26 @@ export class AvailableNetOrientationSolver extends BaseSolver {
       stopOnTraceCollision = true,
     } = params
 
-    for (
-      let distance = LABEL_SEARCH_STEP;
-      distance <= maxSearchDistance + EPS;
-      distance += LABEL_SEARCH_STEP
+    // A blocked connector prefix cannot be repaired by moving farther along
+    // the same lateral column, so reject the column before scanning it.
+    if (
+      phase === "lateral-shift" &&
+      this.isLateralColumnConnectorBlocked({
+        label,
+        labelIndex,
+        orientation,
+        direction,
+        baseAnchor,
+        maxSearchDistance,
+      })
     ) {
+      this.stats.skippedBlockedLateralColumns =
+        (this.stats.skippedBlockedLateralColumns ?? 0) + 1
+      return null
+    }
+
+    let distance = LABEL_SEARCH_STEP
+    while (distance <= maxSearchDistance + EPS) {
       const anchorPoint = {
         x: baseAnchor.x + direction.x * distance,
         y: baseAnchor.y + direction.y * distance,
@@ -912,9 +947,98 @@ export class AvailableNetOrientationSolver extends BaseSolver {
         return result
       }
       if (stopOnTraceCollision && result.status === "trace-collision") break
+
+      // Intermediate grid points overlap the same obstacle, so resume at its
+      // boundary and let the normal collision check validate that point.
+      const nextBoundaryDistance = getNextBoundaryCandidateDistance({
+        candidate,
+        candidateStatus: result.status,
+        currentDistance: distance,
+        direction,
+        inputProblem: this.inputProblem,
+        netLabelPlacements: this.outputNetLabelPlacements,
+        labelIndex,
+        crowdedLabelIndices: this.crowdedPortOnlyLabelIndices,
+        queuedLabelIndices: this.queuedLabelIndices,
+        blockedStandaloneLabelIndex: this.blockedStandaloneLabelIndex,
+        chipObstacleSpatialIndex: this.chipObstacleSpatialIndex,
+        obstacleIndex: this.obstacleIndex,
+      })
+      if (
+        nextBoundaryDistance !== null &&
+        nextBoundaryDistance > distance + LABEL_SEARCH_STEP
+      ) {
+        this.stats.skippedGridCandidates =
+          (this.stats.skippedGridCandidates ?? 0) +
+          Math.floor((nextBoundaryDistance - distance) / LABEL_SEARCH_STEP) -
+          1
+        distance = nextBoundaryDistance
+        continue
+      }
+      distance += LABEL_SEARCH_STEP
     }
 
     return null
+  }
+
+  private isLateralColumnConnectorBlocked(params: {
+    label: NetLabelPlacement
+    labelIndex: number
+    orientation: FacingDirection
+    direction: Point
+    baseAnchor: Point
+    maxSearchDistance: number
+  }) {
+    const firstCandidate = this.createCandidate(
+      params.label,
+      {
+        x: params.baseAnchor.x + params.direction.x * LABEL_SEARCH_STEP,
+        y: params.baseAnchor.y + params.direction.y * LABEL_SEARCH_STEP,
+      },
+      params.orientation,
+    )
+    const lastCandidate = this.createCandidate(
+      params.label,
+      {
+        x: params.baseAnchor.x + params.direction.x * params.maxSearchDistance,
+        y: params.baseAnchor.y + params.direction.y * params.maxSearchDistance,
+      },
+      params.orientation,
+    )
+    const firstConnectorTrace = this.getCandidateConnectorTrace(
+      params.label,
+      {
+        anchorPoint: firstCandidate.anchorPoint,
+        orientation: params.orientation,
+        phase: "lateral-shift",
+      },
+      params.labelIndex,
+    )
+    const lastConnectorTrace = this.getCandidateConnectorTrace(
+      params.label,
+      {
+        anchorPoint: lastCandidate.anchorPoint,
+        orientation: params.orientation,
+        phase: "lateral-shift",
+      },
+      params.labelIndex,
+    )
+    const ignoredLabelIndices = new Set<number>()
+    if (this.crowdedPortOnlyLabelIndices.has(params.labelIndex)) {
+      for (const otherLabelIndex of this.queuedLabelIndices) {
+        if (this.crowdedPortOnlyLabelIndices.has(otherLabelIndex)) {
+          ignoredLabelIndices.add(otherLabelIndex)
+        }
+      }
+    }
+    return doesFixedConnectorPrefixIntersectObstacles({
+      firstConnectorTrace,
+      lastConnectorTrace,
+      labelIndex: params.labelIndex,
+      ignoredLabelIndices,
+      netLabelPlacements: this.outputNetLabelPlacements,
+      obstacleIndex: this.obstacleIndex,
+    })
   }
 
   private evaluateCandidate(

--- a/lib/solvers/AvailableNetOrientationSolver/doesFixedConnectorPrefixIntersectObstacles.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/doesFixedConnectorPrefixIntersectObstacles.ts
@@ -1,0 +1,49 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { getRectBounds } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
+import type { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
+import { tracePathIntersectsBounds } from "./geometry"
+
+export function doesFixedConnectorPrefixIntersectObstacles(params: {
+  firstConnectorTrace: Point[]
+  lastConnectorTrace: Point[]
+  labelIndex: number
+  ignoredLabelIndices: Set<number>
+  netLabelPlacements: NetLabelPlacement[]
+  obstacleIndex: AvailableNetOrientationObstacleIndex
+}) {
+  const fixedPrefix = getCommonTracePrefix(
+    params.firstConnectorTrace,
+    params.lastConnectorTrace,
+  )
+  if (fixedPrefix.length < 2) return false
+  if (params.obstacleIndex.doesTracePathCrossChip(fixedPrefix)) return true
+
+  for (const otherLabelIndex of params.obstacleIndex.getLabelIndicesNearTracePath(
+    fixedPrefix,
+  )) {
+    if (otherLabelIndex === params.labelIndex) continue
+    if (params.ignoredLabelIndices.has(otherLabelIndex)) continue
+    const otherLabel = params.netLabelPlacements[otherLabelIndex]!
+    const otherBounds = getRectBounds(
+      otherLabel.center,
+      otherLabel.width,
+      otherLabel.height,
+    )
+    if (tracePathIntersectsBounds(fixedPrefix, otherBounds)) return true
+  }
+
+  return false
+}
+
+function getCommonTracePrefix(firstTrace: Point[], lastTrace: Point[]) {
+  const commonPrefix: Point[] = []
+  const comparablePointCount = Math.min(firstTrace.length, lastTrace.length)
+  for (let pointIndex = 0; pointIndex < comparablePointCount; pointIndex++) {
+    const firstPoint = firstTrace[pointIndex]!
+    const lastPoint = lastTrace[pointIndex]!
+    if (firstPoint.x !== lastPoint.x || firstPoint.y !== lastPoint.y) break
+    commonPrefix.push(firstPoint)
+  }
+  return commonPrefix
+}

--- a/lib/solvers/AvailableNetOrientationSolver/getNextBoundaryCandidateDistance.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/getNextBoundaryCandidateDistance.ts
@@ -1,0 +1,196 @@
+import type { Point } from "@tscircuit/math-utils"
+import type { ChipObstacleSpatialIndex } from "lib/data-structures/ChipObstacleSpatialIndex"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import { getRectBounds } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
+import type { InputProblem } from "lib/types/InputProblem"
+import { boundsOverlap, getTextBoxBounds } from "lib/utils/textBoxBounds"
+import type { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
+import { EPS, LABEL_SEARCH_STEP, WICK_CLEARANCE } from "./constants"
+import { rangesOverlap, rectsOverlap } from "./geometry"
+import type { Bounds, CandidateLabel, CandidateStatus } from "./types"
+
+export function getNextBoundaryCandidateDistance(params: {
+  candidate: CandidateLabel
+  candidateStatus: CandidateStatus
+  currentDistance: number
+  direction: Point
+  inputProblem: InputProblem
+  netLabelPlacements: NetLabelPlacement[]
+  labelIndex: number
+  crowdedLabelIndices: Set<number>
+  queuedLabelIndices: number[]
+  blockedStandaloneLabelIndex: number | null
+  chipObstacleSpatialIndex: ChipObstacleSpatialIndex
+  obstacleIndex: AvailableNetOrientationObstacleIndex
+}): number | null {
+  const candidateBounds = getRectBounds(
+    params.candidate.center,
+    params.candidate.width,
+    params.candidate.height,
+  )
+  const blockingBounds = getBlockingBounds({ ...params, candidateBounds })
+  if (blockingBounds.length === 0) return null
+
+  let distanceToClear = 0
+  for (const bounds of blockingBounds) {
+    distanceToClear = Math.max(
+      distanceToClear,
+      getDistanceToClearBounds({
+        candidateBounds,
+        blockingBounds: bounds,
+        direction: params.direction,
+      }),
+    )
+  }
+  if (distanceToClear <= EPS) return null
+
+  const boundaryDistance = params.currentDistance + distanceToClear
+  const boundaryStep = Math.ceil((boundaryDistance - EPS) / LABEL_SEARCH_STEP)
+  return boundaryStep * LABEL_SEARCH_STEP
+}
+
+function getBlockingBounds(params: {
+  candidateBounds: Bounds
+  candidateStatus: CandidateStatus
+  inputProblem: InputProblem
+  netLabelPlacements: NetLabelPlacement[]
+  labelIndex: number
+  crowdedLabelIndices: Set<number>
+  queuedLabelIndices: number[]
+  blockedStandaloneLabelIndex: number | null
+  chipObstacleSpatialIndex: ChipObstacleSpatialIndex
+  obstacleIndex: AvailableNetOrientationObstacleIndex
+}): Bounds[] {
+  if (params.candidateStatus === "chip-collision") {
+    const searchBounds = getPaddedBounds(
+      params.candidateBounds,
+      WICK_CLEARANCE + EPS,
+    )
+    return params.chipObstacleSpatialIndex
+      .getChipsInBounds(searchBounds)
+      .map((chip) => chip.bounds)
+      .filter((bounds) =>
+        doesCandidateBoundsCollideWithChip(params.candidateBounds, bounds),
+      )
+  }
+
+  if (params.candidateStatus === "text-collision") {
+    return (params.inputProblem.textBoxes ?? [])
+      .map((textBox) => getTextBoxBounds(textBox))
+      .filter((bounds) => boundsOverlap(bounds, params.candidateBounds))
+  }
+
+  if (params.candidateStatus !== "netlabel-collision") return []
+
+  const searchBounds = getPaddedBounds(
+    params.candidateBounds,
+    LABEL_SEARCH_STEP,
+  )
+  const blockingBounds: Bounds[] = []
+  for (const otherLabelIndex of params.obstacleIndex.getLabelIndicesInBounds(
+    searchBounds,
+  )) {
+    if (otherLabelIndex === params.labelIndex) continue
+    if (
+      shouldIgnorePendingCrowdedLabel({
+        labelIndex: params.labelIndex,
+        otherLabelIndex,
+        crowdedLabelIndices: params.crowdedLabelIndices,
+        queuedLabelIndices: params.queuedLabelIndices,
+      })
+    ) {
+      continue
+    }
+    const otherLabel = params.netLabelPlacements[otherLabelIndex]!
+    const otherBounds = getRectBounds(
+      otherLabel.center,
+      otherLabel.width,
+      otherLabel.height,
+    )
+    if (
+      otherLabelIndex === params.blockedStandaloneLabelIndex &&
+      (otherLabel.orientation === "y+" || otherLabel.orientation === "y-")
+    ) {
+      otherBounds.minX -= LABEL_SEARCH_STEP
+      otherBounds.maxX += LABEL_SEARCH_STEP
+    }
+    if (rectsOverlap(params.candidateBounds, otherBounds)) {
+      blockingBounds.push(otherBounds)
+    }
+  }
+  return blockingBounds
+}
+
+function doesCandidateBoundsCollideWithChip(
+  candidateBounds: Bounds,
+  chipBounds: Bounds,
+) {
+  if (rectsOverlap(candidateBounds, chipBounds)) return true
+
+  const touchesVerticalSide =
+    Math.abs(candidateBounds.minX - chipBounds.maxX) <= WICK_CLEARANCE + EPS ||
+    Math.abs(candidateBounds.maxX - chipBounds.minX) <= WICK_CLEARANCE + EPS
+  if (
+    touchesVerticalSide &&
+    rangesOverlap(
+      candidateBounds.minY,
+      candidateBounds.maxY,
+      chipBounds.minY,
+      chipBounds.maxY,
+    )
+  ) {
+    return true
+  }
+
+  const touchesHorizontalSide =
+    Math.abs(candidateBounds.minY - chipBounds.maxY) <= WICK_CLEARANCE + EPS ||
+    Math.abs(candidateBounds.maxY - chipBounds.minY) <= WICK_CLEARANCE + EPS
+  return (
+    touchesHorizontalSide &&
+    rangesOverlap(
+      candidateBounds.minX,
+      candidateBounds.maxX,
+      chipBounds.minX,
+      chipBounds.maxX,
+    )
+  )
+}
+
+function shouldIgnorePendingCrowdedLabel(params: {
+  labelIndex: number
+  otherLabelIndex: number
+  crowdedLabelIndices: Set<number>
+  queuedLabelIndices: number[]
+}) {
+  return (
+    params.crowdedLabelIndices.has(params.labelIndex) &&
+    params.crowdedLabelIndices.has(params.otherLabelIndex) &&
+    params.queuedLabelIndices.includes(params.otherLabelIndex)
+  )
+}
+
+function getDistanceToClearBounds(params: {
+  candidateBounds: Bounds
+  blockingBounds: Bounds
+  direction: Point
+}) {
+  if (params.direction.x > 0) {
+    return params.blockingBounds.maxX - params.candidateBounds.minX
+  }
+  if (params.direction.x < 0) {
+    return params.candidateBounds.maxX - params.blockingBounds.minX
+  }
+  if (params.direction.y > 0) {
+    return params.blockingBounds.maxY - params.candidateBounds.minY
+  }
+  return params.candidateBounds.maxY - params.blockingBounds.minY
+}
+
+function getPaddedBounds(bounds: Bounds, padding: number): Bounds {
+  return {
+    minX: bounds.minX - padding,
+    minY: bounds.minY - padding,
+    maxX: bounds.maxX + padding,
+    maxY: bounds.maxY + padding,
+  }
+}

--- a/tests/repros/repro161-power-section-autolayout.test.ts
+++ b/tests/repros/repro161-power-section-autolayout.test.ts
@@ -33,9 +33,12 @@ test("core repro161 power section trace routing", () => {
   }
   expect(
     solver.availableNetOrientationSolver!.stats.candidateEvaluations,
-  ).toBeGreaterThan(MAX_RECORDED_CANDIDATES)
+  ).toBeLessThan(MAX_RECORDED_CANDIDATES)
   expect(
     solver.availableNetOrientationSolver!.stats.maxRecordedCandidates,
-  ).toBe(MAX_RECORDED_CANDIDATES)
+  ).toBeLessThan(MAX_RECORDED_CANDIDATES)
+  expect(
+    solver.availableNetOrientationSolver!.stats.skippedBlockedLateralColumns,
+  ).toBeGreaterThan(0)
   expect(solver).toMatchSolverSnapshot(import.meta.path)
 })


### PR DESCRIPTION
### Motivation
- AvailableNetOrientationSolver exhaustively checks grid positions that are already blocked by the same obstacle or an invariant connector prefix.

### Before
- Board 872 required 634,966 candidate evaluations, with a 1,646.66 ms median orientation stage and 2,243.54 ms median total solve.

### After
- Obstacle-boundary jumps and blocked-column pruning reduce board 872 to 61,794 evaluations, an 89.00 ms median orientation stage, and 308.53 ms median total solve while preserving identical solver output and all existing snapshots.