### PR TITLE
Support two-pin inline net labels

### DIFF
--- a/lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver.ts
+++ b/lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver.ts
@@ -52,8 +52,9 @@ export interface InlineNetLabelPlacement {
   pinIds: PinId[]
 
   /**
-   * A generated single-ended trace stub. Present only for an eligible
-   * single-pin net connection; routed point-to-point traces omit it.
+   * A generated single-ended trace stub. Present for a single-pin net or for
+   * one endpoint of an unrouted two-pin net; routed point-to-point traces omit
+   * it.
    */
   stubTracePath?: [Point, Point]
 
@@ -85,12 +86,15 @@ interface InlineNetLabelSolverInput {
   netLabelPlacements: NetLabelPlacement[]
 }
 
+type InlineEligibleConnection = InputDirectConnection | InputNetConnection
+
 const getPinPairKey = (pinIds: readonly string[]) =>
   [...pinIds].sort().join("::")
 
 /**
  * Places "inline net labels" - net names drawn alongside the trace they belong
- * to - for direct connections that opted in via `allowInlineNetLabel`.
+ * to - for one- or two-pin connections that opted in via
+ * `allowInlineNetLabel`.
  *
  * Any regular (anchored) net label placement for the same net is dropped, so a
  * net is never labeled twice.
@@ -102,11 +106,8 @@ export class InlineNetLabelSolver extends BaseSolver {
 
   inlineNetLabelPlacements: InlineNetLabelPlacement[] = []
 
-  /** Direct connections that opted in, still waiting to be processed */
-  queuedDirectConnections: InputDirectConnection[]
-
-  /** Single-pin net connections that opted in, still waiting to be processed */
-  queuedPortOnlyNetConnections: InputNetConnection[]
+  /** Eligible one- or two-pin connections still waiting to be processed. */
+  queuedConnections: InlineEligibleConnection[]
 
   private tracesByPinPairKey: Map<string, SolvedTracePath[]>
   private hasAlignedPortOnlyStubs = false
@@ -117,12 +118,18 @@ export class InlineNetLabelSolver extends BaseSolver {
     this.traces = input.traces
     this.inputNetLabelPlacements = input.netLabelPlacements
 
-    this.queuedDirectConnections = this.inputProblem.directConnections.filter(
-      (dc) => dc.allowInlineNetLabel && dc.netId,
-    )
-    this.queuedPortOnlyNetConnections = this.inputProblem.netConnections.filter(
-      (nc) => nc.allowInlineNetLabel && nc.pinIds.length === 1 && nc.netId,
-    )
+    this.queuedConnections = [
+      ...this.inputProblem.directConnections.filter(
+        (connection) => connection.allowInlineNetLabel && connection.netId,
+      ),
+      ...this.inputProblem.netConnections.filter(
+        (connection) =>
+          connection.allowInlineNetLabel &&
+          connection.pinIds.length >= 1 &&
+          connection.pinIds.length <= 2 &&
+          connection.netId,
+      ),
+    ]
 
     this.tracesByPinPairKey = new Map()
     for (const trace of this.traces) {
@@ -147,22 +154,28 @@ export class InlineNetLabelSolver extends BaseSolver {
   }
 
   override _step() {
-    const directConnection = this.queuedDirectConnections.shift()
-    if (directConnection) {
-      const placement = this.computeInlinePlacement(directConnection)
-      if (placement) {
-        this.inlineNetLabelPlacements.push(placement)
-      }
-      return
-    }
+    const connection = this.queuedConnections.shift()
+    if (connection) {
+      const routedTraces =
+        connection.pinIds.length === 2
+          ? (this.tracesByPinPairKey.get(getPinPairKey(connection.pinIds)) ??
+            [])
+          : []
 
-    const portOnlyNetConnection = this.queuedPortOnlyNetConnections.shift()
-    if (portOnlyNetConnection) {
-      const placement = this.computePortOnlyInlinePlacement(
-        portOnlyNetConnection,
-      )
-      if (placement) {
-        this.inlineNetLabelPlacements.push(placement)
+      if (routedTraces.length > 0) {
+        const placement = this.computeInlinePlacement(connection)
+        if (placement) this.inlineNetLabelPlacements.push(placement)
+      } else {
+        // A one-pin net has one conventional endpoint label, while a skipped
+        // two-pin route has one at each endpoint. Convert a two-pin pair
+        // atomically so a collision at one endpoint cannot leave mixed inline
+        // and anchored representations for the same net.
+        const terminalPlacements = connection.pinIds.map((pinId) =>
+          this.computeTerminalInlinePlacement(connection, pinId),
+        )
+        if (terminalPlacements.every((placement) => placement !== null)) {
+          this.inlineNetLabelPlacements.push(...terminalPlacements)
+        }
       }
       return
     }
@@ -183,20 +196,20 @@ export class InlineNetLabelSolver extends BaseSolver {
   }
 
   /**
-   * Converts a conventional port-only anchored placement into an inline label
-   * on a generated outward stub. The stub follows the pin's true facing
-   * direction; an anchored label may finish in another direction after an
-   * elbow, which is not the direction a terminal stub should leave the pin.
+   * Converts one conventional endpoint placement into an inline label on a
+   * generated outward stub. The stub follows the pin's true facing direction;
+   * an anchored label may finish in another direction after an elbow, which is
+   * not the direction a terminal stub should leave the pin.
    */
-  private computePortOnlyInlinePlacement(
-    netConnection: InputNetConnection,
+  private computeTerminalInlinePlacement(
+    connection: InlineEligibleConnection,
+    pinId: PinId,
   ): InlineNetLabelPlacement | null {
-    const [pinId] = netConnection.pinIds
-    if (!pinId) return null
+    if (!connection.netId) return null
 
     const anchoredPlacement = this.inputNetLabelPlacements.find(
       (placement) =>
-        placement.netId === netConnection.netId &&
+        placement.netId === connection.netId &&
         placement.pinIds.length === 1 &&
         placement.pinIds[0] === pinId,
     )
@@ -208,11 +221,11 @@ export class InlineNetLabelSolver extends BaseSolver {
     const inputPin = inputChip?.pins.find((pin) => pin.pinId === pinId)
 
     const height =
-      netConnection.inlineNetLabelHeight ?? DEFAULT_INLINE_NET_LABEL_HEIGHT
+      connection.inlineNetLabelHeight ?? DEFAULT_INLINE_NET_LABEL_HEIGHT
     const width =
-      netConnection.inlineNetLabelWidth ??
-      netConnection.netLabelWidth ??
-      estimateInlineNetLabelWidth(netConnection.netId, height)
+      connection.inlineNetLabelWidth ??
+      connection.netLabelWidth ??
+      estimateInlineNetLabelWidth(connection.netId, height)
 
     // Leave a small wire tail at both ends of the text so it unmistakably
     // reads as a label on a trace rather than free-standing text.
@@ -273,7 +286,7 @@ export class InlineNetLabelSolver extends BaseSolver {
 
     return {
       globalConnNetId: anchoredPlacement.globalConnNetId,
-      netId: netConnection.netId,
+      netId: connection.netId,
       pinIds: [pinId],
       stubTracePath: [start, end],
       axis,
@@ -286,12 +299,12 @@ export class InlineNetLabelSolver extends BaseSolver {
   }
 
   private computeInlinePlacement(
-    directConnection: InputDirectConnection,
+    connection: InlineEligibleConnection,
   ): InlineNetLabelPlacement | null {
     // Only connections the router actually drew a trace for can carry an inline
     // label - there's nothing to run parallel to otherwise.
     const traces =
-      this.tracesByPinPairKey.get(getPinPairKey(directConnection.pinIds)) ?? []
+      this.tracesByPinPairKey.get(getPinPairKey(connection.pinIds)) ?? []
     if (traces.length === 0) return null
 
     const trace = traces[0]!
@@ -299,11 +312,11 @@ export class InlineNetLabelSolver extends BaseSolver {
     if (segments.length === 0) return null
 
     const height =
-      directConnection.inlineNetLabelHeight ?? DEFAULT_INLINE_NET_LABEL_HEIGHT
+      connection.inlineNetLabelHeight ?? DEFAULT_INLINE_NET_LABEL_HEIGHT
     const width =
-      directConnection.inlineNetLabelWidth ??
-      directConnection.netLabelWidth ??
-      estimateInlineNetLabelWidth(directConnection.netId!, height)
+      connection.inlineNetLabelWidth ??
+      connection.netLabelWidth ??
+      estimateInlineNetLabelWidth(connection.netId!, height)
 
     const offset = height / 2 + INLINE_NET_LABEL_TRACE_MARGIN
 
@@ -360,9 +373,9 @@ export class InlineNetLabelSolver extends BaseSolver {
 
           return {
             globalConnNetId: trace.globalConnNetId,
-            netId: directConnection.netId,
+            netId: connection.netId,
             mspPairId: trace.mspPairId,
-            pinIds: [...directConnection.pinIds],
+            pinIds: [...connection.pinIds],
             axis: segment.axis,
             anchorPoint,
             center,
@@ -380,7 +393,7 @@ export class InlineNetLabelSolver extends BaseSolver {
     // endpoints.
     const spanPlacement = this.computeSpanPlacement({
       trace,
-      directConnection,
+      connection,
       width,
       height,
       offset,
@@ -400,13 +413,13 @@ export class InlineNetLabelSolver extends BaseSolver {
    */
   private computeSpanPlacement({
     trace,
-    directConnection,
+    connection,
     width,
     height,
     offset,
   }: {
     trace: SolvedTracePath
-    directConnection: InputDirectConnection
+    connection: InlineEligibleConnection
     width: number
     height: number
     offset: number
@@ -496,9 +509,9 @@ export class InlineNetLabelSolver extends BaseSolver {
 
         return {
           globalConnNetId: trace.globalConnNetId,
-          netId: directConnection.netId,
+          netId: connection.netId,
           mspPairId: trace.mspPairId,
-          pinIds: [...directConnection.pinIds],
+          pinIds: [...connection.pinIds],
           axis,
           anchorPoint,
           center,

--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -43,7 +43,9 @@ export interface InputDirectConnection {
    *
    * Only set this for connections whose net name is worth showing on the wire -
    * the solver trusts the caller (e.g. @tscircuit/core) to make that decision.
-   * An inline label is only emitted when the connection actually got routed.
+   * When the connection is routed, the label is placed along the trace. If
+   * routing is intentionally skipped, both endpoint labels may instead become
+   * outward inline stubs.
    */
   allowInlineNetLabel?: boolean
 
@@ -67,9 +69,10 @@ export interface InputNetConnection {
   netLabelHeight?: number
 
   /**
-   * When true, a named single-pin net may be drawn as a short outward trace
-   * stub with its net name placed inline. Multi-pin net connections retain the
-   * regular anchored-label behavior.
+   * When true, a named one- or two-pin net may use inline labels. A single-pin
+   * net gets an outward stub. A routed two-pin net gets one label along its
+   * trace; when that route is intentionally skipped, both endpoints get
+   * outward stubs. Nets with more than two pins retain anchored labels.
    */
   allowInlineNetLabel?: boolean
 

--- a/tests/assets/inline-net-label-two-pin-net.json
+++ b/tests/assets/inline-net-label-two-pin-net.json
@@ -1,0 +1,67 @@
+{
+  "chips": [
+    {
+      "chipId": "U1",
+      "center": { "x": -1, "y": 1 },
+      "width": 1,
+      "height": 1,
+      "sectionId": "routed",
+      "pins": [
+        { "pinId": "U1.1", "x": -0.5, "y": 1, "_facingDirection": "x+" }
+      ]
+    },
+    {
+      "chipId": "U2",
+      "center": { "x": 1, "y": 1 },
+      "width": 1,
+      "height": 1,
+      "sectionId": "routed",
+      "pins": [
+        { "pinId": "U2.1", "x": 0.5, "y": 1, "_facingDirection": "x-" }
+      ]
+    },
+    {
+      "chipId": "U3",
+      "center": { "x": -2, "y": -1 },
+      "width": 1,
+      "height": 1,
+      "sectionId": "left",
+      "pins": [
+        { "pinId": "U3.1", "x": -1.5, "y": -1, "_facingDirection": "x+" }
+      ]
+    },
+    {
+      "chipId": "U4",
+      "center": { "x": 2, "y": -1 },
+      "width": 1,
+      "height": 1,
+      "sectionId": "right",
+      "pins": [
+        { "pinId": "U4.1", "x": 1.5, "y": -1, "_facingDirection": "x-" }
+      ]
+    }
+  ],
+  "directConnections": [],
+  "netConnections": [
+    {
+      "netId": "NET_ROUTED",
+      "pinIds": ["U1.1", "U2.1"],
+      "netLabelWidth": 0.9,
+      "allowInlineNetLabel": true,
+      "inlineNetLabelWidth": 0.9,
+      "inlineNetLabelHeight": 0.12
+    },
+    {
+      "netId": "NET_SECTIONED",
+      "pinIds": ["U3.1", "U4.1"],
+      "netLabelWidth": 1.1,
+      "allowInlineNetLabel": true,
+      "inlineNetLabelWidth": 1.1,
+      "inlineNetLabelHeight": 0.12
+    }
+  ],
+  "availableNetLabelOrientations": {
+    "NET_ROUTED": ["x-", "x+"],
+    "NET_SECTIONED": ["x-", "x+"]
+  }
+}

--- a/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label-two-pin-net.snap.svg
+++ b/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label-two-pin-net.snap.svg
@@ -1,0 +1,57 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-0.5,1 0.5,1" data-type="line" data-label="" points="264,208 376,208" fill="none" stroke="hsl(253, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="-0.5,1 0.5,1" data-type="line" data-label="" points="264,208 376,208" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="-1.5,-1 -0.19999999999999996,-1" data-type="line" data-label="" points="152,432 297.6,432" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="1.5,-1 0.19999999999999996,-1" data-type="line" data-label="" points="488,432 342.4,432" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="U1" data-x="-1" data-y="1" x="152" y="152" width="112" height="112" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428"/></g><g><rect data-type="rect" data-label="U2" data-x="1" data-y="1" x="376" y="152" width="112" height="112" fill="hsl(165, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428"/></g><g><rect data-type="rect" data-label="U3" data-x="-2" data-y="-1" x="40" y="376" width="112" height="112" fill="hsl(166, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428"/></g><g><rect data-type="rect" data-label="U4" data-x="2" data-y="-1" x="488" y="376" width="112" height="112" fill="hsl(167, 100%, 50%, 0.8)" stroke="black" stroke-width="0.008928571428571428"/></g><g><rect data-type="rect" data-label="INLINE netId: NET_ROUTED
+axis: x
+side: y+" data-x="0" data-y="1.11" x="269.6" y="188.96" width="100.79999999999995" height="13.439999999999998" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428"/></g><g><rect data-type="rect" data-label="INLINE netId: NET_SECTIONED
+axis: x
+side: y+" data-x="-0.85" data-y="-0.89" x="163.20000000000005" y="412.96000000000004" width="123.19999999999996" height="13.43999999999994" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428"/></g><g><rect data-type="rect" data-label="INLINE netId: NET_SECTIONED
+axis: x
+side: y+" data-x="0.85" data-y="-0.89" x="353.6" y="412.96000000000004" width="123.19999999999993" height="13.43999999999994" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.008928571428571428"/></g><text data-type="text" data-label="NET_ROUTED" data-x="0" data-y="1.11" x="320" y="195.68" fill="green" font-size="13.44" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">NET_ROUTED</text><text data-type="text" data-label="NET_SECTIONED" data-x="-1.4" data-y="-0.89" x="163.20000000000002" y="419.68" fill="green" font-size="13.44" font-family="sans-serif" text-anchor="start" dominant-baseline="central">NET_SECTIONED</text><text data-type="text" data-label="NET_SECTIONED" data-x="1.4" data-y="-0.89" x="476.79999999999995" y="419.68" fill="green" font-size="13.44" font-family="sans-serif" text-anchor="end" dominant-baseline="central">NET_SECTIONED</text><g><circle data-type="point" data-label="U1.1
+x+" data-x="-0.5" data-y="1" cx="264" cy="208" r="3" fill="hsl(319, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U2.1
+x-" data-x="0.5" data-y="1" cx="376" cy="208" r="3" fill="hsl(200, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U3.1
+x+" data-x="-1.5" data-y="-1" cx="152" cy="432" r="3" fill="hsl(81, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U4.1
+x-" data-x="1.5" data-y="-1" cx="488" cy="432" r="3" fill="hsl(322, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="inline anchor
+NET_ROUTED" data-x="0" data-y="1" cx="320" cy="208" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
+NET_SECTIONED" data-x="-0.85" data-y="-1" cx="224.8" cy="432" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
+NET_SECTIONED" data-x="0.85" data-y="-1" cx="415.2" cy="432" r="3" fill="green"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":112,"c":0,"e":320,"b":0,"d":-112,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/solvers/InlineNetLabelSolver/inline-net-label-two-pin-net.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/inline-net-label-two-pin-net.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "../../assets/inline-net-label-two-pin-net.json"
+import "tests/fixtures/matcher"
+
+test("two-pin named nets use a routed inline label or two terminal stubs", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  const output = solver.inlineNetLabelSolver!.getOutput()
+  const routedPlacements = output.inlineNetLabelPlacements.filter(
+    (placement) => placement.netId === "NET_ROUTED",
+  )
+  const sectionedPlacements = output.inlineNetLabelPlacements.filter(
+    (placement) => placement.netId === "NET_SECTIONED",
+  )
+
+  expect(routedPlacements).toHaveLength(1)
+  expect(routedPlacements[0]!.pinIds).toHaveLength(2)
+  expect(routedPlacements[0]!.stubTracePath).toBeUndefined()
+
+  expect(sectionedPlacements).toHaveLength(2)
+  expect(
+    sectionedPlacements.every(
+      (placement) =>
+        placement.pinIds.length === 1 && placement.stubTracePath?.length === 2,
+    ),
+  ).toBe(true)
+  expect(output.netLabelPlacements).toHaveLength(0)
+  expect(
+    output.traces.filter((trace) =>
+      trace.mspPairId.startsWith("available-net-orientation-"),
+    ),
+  ).toHaveLength(0)
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})

--- a/tests/solvers/InlineNetLabelSolver/two-pin-terminal-stubs-atomic.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/two-pin-terminal-stubs-atomic.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import { InlineNetLabelSolver } from "lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+test("two-pin terminal stubs fall back atomically when one endpoint is obstructed", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: -2, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U1.1", x: -1.5, y: 0, _facingDirection: "x+" }],
+      },
+      {
+        chipId: "U2",
+        center: { x: 2, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U2.1", x: 1.5, y: 0, _facingDirection: "x-" }],
+      },
+    ],
+    directConnections: [],
+    netConnections: [
+      {
+        netId: "NET_SIGNAL",
+        pinIds: ["U1.1", "U2.1"],
+        allowInlineNetLabel: true,
+        inlineNetLabelWidth: 1.1,
+        inlineNetLabelHeight: 0.12,
+      },
+    ],
+    textBoxes: [
+      {
+        center: { x: -0.85, y: 0.11 },
+        width: 1.1,
+        height: 0.12,
+        text: "obstacle",
+      },
+    ],
+    availableNetLabelOrientations: { NET_SIGNAL: ["x-", "x+"] },
+  }
+  const netLabelPlacements: NetLabelPlacement[] = [
+    {
+      globalConnNetId: "NET_SIGNAL",
+      netId: "NET_SIGNAL",
+      mspConnectionPairIds: [],
+      pinIds: ["U1.1"],
+      orientation: "x+",
+      anchorPoint: { x: -1.5, y: 0 },
+      center: { x: -0.9, y: 0 },
+      width: 1.1,
+      height: 0.12,
+    },
+    {
+      globalConnNetId: "NET_SIGNAL",
+      netId: "NET_SIGNAL",
+      mspConnectionPairIds: [],
+      pinIds: ["U2.1"],
+      orientation: "x-",
+      anchorPoint: { x: 1.5, y: 0 },
+      center: { x: 0.9, y: 0 },
+      width: 1.1,
+      height: 0.12,
+    },
+  ]
+
+  const solver = new InlineNetLabelSolver({
+    inputProblem,
+    traces: [],
+    netLabelPlacements,
+  })
+  solver.solve()
+
+  expect(solver.inlineNetLabelPlacements).toHaveLength(0)
+  expect(solver.getOutput().netLabelPlacements).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary
- allow opted-in two-pin netConnections to use one inline label on a routed trace
- emit matched outward endpoint stubs when a two-pin route is intentionally omitted
- preserve both anchored labels atomically if either endpoint stub conflicts

## Validation
- bun test --max-concurrency 4 --timeout 40000 --reporter=dot
- bunx tsc --noEmit
- bun run build
- visual snapshot review of routed and section-suppressed two-pin nets

Follow-up to #848.