### PR TITLE
Avoid anchored net label overlap with inline labels

### DIFF
--- a/lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver.ts
+++ b/lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver.ts
@@ -18,6 +18,7 @@ import {
   getAxisAlignedSegments,
 } from "./getAxisAlignedSegments"
 import { alignPortOnlyInlineNetLabelStubs } from "./alignPortOnlyInlineNetLabelStubs"
+import { pushAnchoredNetLabelsAwayFromInlineLabels } from "./pushAnchoredNetLabelsAwayFromInlineLabels"
 
 export const DEFAULT_INLINE_NET_LABEL_HEIGHT = 0.18
 
@@ -111,6 +112,11 @@ export class InlineNetLabelSolver extends BaseSolver {
 
   private tracesByPinPairKey: Map<string, SolvedTracePath[]>
   private hasAlignedPortOnlyStubs = false
+  private postProcessedOutput?: {
+    traces: SolvedTracePath[]
+    netLabelPlacements: NetLabelPlacement[]
+    inlineNetLabelPlacements: InlineNetLabelPlacement[]
+  }
 
   constructor(input: InlineNetLabelSolverInput) {
     super()
@@ -188,6 +194,11 @@ export class InlineNetLabelSolver extends BaseSolver {
         netLabelPlacements: this.inputNetLabelPlacements,
       })
       this.hasAlignedPortOnlyStubs = true
+      return
+    }
+
+    if (!this.postProcessedOutput) {
+      this.postProcessedOutput = this.buildPostProcessedOutput()
       return
     }
 
@@ -584,18 +595,29 @@ export class InlineNetLabelSolver extends BaseSolver {
     )
   }
 
-  getOutput() {
+  private buildPostProcessedOutput() {
     const superseded = this.getSupersededNetLabelKeys()
+    const retainedNetLabelPlacements = this.inputNetLabelPlacements.filter(
+      (placement) => !superseded.has(placement.globalConnNetId),
+    )
+    const outputTraces = this.getOutputTraces(superseded)
+    const pushed = pushAnchoredNetLabelsAwayFromInlineLabels({
+      inputProblem: this.inputProblem,
+      traces: outputTraces,
+      netLabelPlacements: retainedNetLabelPlacements,
+      inlineNetLabelPlacements: this.inlineNetLabelPlacements,
+    })
+    this.stats.pushedAnchoredNetLabelCount = pushed.movedLabelCount
     return {
-      // AvailableNetOrientationSolver may have routed an elbow from a port to
-      // the anchored label that this inline placement supersedes. Keep the
-      // actual net trace, but discard that now-orphaned label connector.
-      traces: this.getOutputTraces(superseded),
-      netLabelPlacements: this.inputNetLabelPlacements.filter(
-        (placement) => !superseded.has(placement.globalConnNetId),
-      ),
+      traces: pushed.traces,
+      netLabelPlacements: pushed.netLabelPlacements,
       inlineNetLabelPlacements: this.inlineNetLabelPlacements,
     }
+  }
+
+  getOutput() {
+    if (this.postProcessedOutput) return this.postProcessedOutput
+    return this.buildPostProcessedOutput()
   }
 
   override visualize(): GraphicsObject {

--- a/lib/solvers/InlineNetLabelSolver/pushAnchoredNetLabelsAwayFromInlineLabels.ts
+++ b/lib/solvers/InlineNetLabelSolver/pushAnchoredNetLabelsAwayFromInlineLabels.ts
@@ -1,0 +1,530 @@
+import type { Bounds, Point } from "@tscircuit/math-utils"
+import {
+  getPinMap,
+  getTracePins,
+} from "lib/solvers/AvailableNetOrientationSolver/traces"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import { dir, type FacingDirection } from "lib/utils/dir"
+import { boundsOverlap, getTextBoxBounds } from "lib/utils/textBoxBounds"
+import type { InlineNetLabelPlacement } from "./InlineNetLabelSolver"
+
+const LABEL_CLEARANCE = 0.05
+const POINT_EPSILON = 1e-6
+const CONTIGUOUS_LABEL_GAP = 0.01
+const MAX_OUTWARD_DISTANCE = 5
+
+const getBounds = (placement: {
+  center: Point
+  width: number
+  height: number
+  axis?: "x" | "y"
+}): Bounds => {
+  const renderedWidth =
+    placement.axis === "y" ? placement.height : placement.width
+  const renderedHeight =
+    placement.axis === "y" ? placement.width : placement.height
+  return {
+    minX: placement.center.x - renderedWidth / 2,
+    maxX: placement.center.x + renderedWidth / 2,
+    minY: placement.center.y - renderedHeight / 2,
+    maxY: placement.center.y + renderedHeight / 2,
+  }
+}
+
+const pointsEqual = (a: Point, b: Point) =>
+  Math.abs(a.x - b.x) <= POINT_EPSILON && Math.abs(a.y - b.y) <= POINT_EPSILON
+
+const pathIntersectsBounds = (path: Point[], bounds: Bounds) => {
+  for (let index = 0; index < path.length - 1; index++) {
+    const start = path[index]!
+    const end = path[index + 1]!
+    const segmentBounds: Bounds = {
+      minX: Math.min(start.x, end.x),
+      maxX: Math.max(start.x, end.x),
+      minY: Math.min(start.y, end.y),
+      maxY: Math.max(start.y, end.y),
+    }
+    if (boundsOverlap(segmentBounds, bounds)) return true
+  }
+  return false
+}
+
+const isPointOnPath = (point: Point, path: Point[]) => {
+  for (let index = 0; index < path.length - 1; index++) {
+    const start = path[index]!
+    const end = path[index + 1]!
+    const minX = Math.min(start.x, end.x) - POINT_EPSILON
+    const maxX = Math.max(start.x, end.x) + POINT_EPSILON
+    const minY = Math.min(start.y, end.y) - POINT_EPSILON
+    const maxY = Math.max(start.y, end.y) + POINT_EPSILON
+    const isHorizontal = Math.abs(start.y - end.y) <= POINT_EPSILON
+    const isVertical = Math.abs(start.x - end.x) <= POINT_EPSILON
+    if (
+      ((isHorizontal && Math.abs(point.y - start.y) <= POINT_EPSILON) ||
+        (isVertical && Math.abs(point.x - start.x) <= POINT_EPSILON)) &&
+      point.x >= minX &&
+      point.x <= maxX &&
+      point.y >= minY &&
+      point.y <= maxY
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+const getRequiredOutwardDistance = (
+  label: NetLabelPlacement,
+  inlineBounds: Bounds[],
+) => {
+  const labelBounds = getBounds(label)
+
+  if (label.orientation === "x-" || label.orientation === "x+") {
+    const nearby = inlineBounds.filter(
+      (bounds) =>
+        labelBounds.minY < bounds.maxY && labelBounds.maxY > bounds.minY,
+    )
+    if (nearby.length === 0) return 0
+    if (label.orientation === "x-") {
+      const targetMaxX = Math.min(...nearby.map((bounds) => bounds.minX))
+      return Math.max(0, labelBounds.maxX - targetMaxX + LABEL_CLEARANCE)
+    }
+    const targetMinX = Math.max(...nearby.map((bounds) => bounds.maxX))
+    return Math.max(0, targetMinX - labelBounds.minX + LABEL_CLEARANCE)
+  }
+
+  const nearby = inlineBounds.filter(
+    (bounds) =>
+      labelBounds.minX < bounds.maxX && labelBounds.maxX > bounds.minX,
+  )
+  if (nearby.length === 0) return 0
+  if (label.orientation === "y-") {
+    const targetMaxY = Math.min(...nearby.map((bounds) => bounds.minY))
+    return Math.max(0, labelBounds.maxY - targetMaxY + LABEL_CLEARANCE)
+  }
+  const targetMinY = Math.max(...nearby.map((bounds) => bounds.maxY))
+  return Math.max(0, targetMinY - labelBounds.minY + LABEL_CLEARANCE)
+}
+
+const moveLabel = (
+  label: NetLabelPlacement,
+  orientation: FacingDirection,
+  distance: number,
+): NetLabelPlacement => {
+  const direction = dir(orientation)
+  return {
+    ...label,
+    anchorPoint: {
+      x: label.anchorPoint.x + direction.x * distance,
+      y: label.anchorPoint.y + direction.y * distance,
+    },
+    center: {
+      x: label.center.x + direction.x * distance,
+      y: label.center.y + direction.y * distance,
+    },
+  }
+}
+
+const getDistanceToShoveBoundsPast = (
+  obstacleBounds: Bounds,
+  movingBounds: Bounds,
+  orientation: FacingDirection,
+) => {
+  switch (orientation) {
+    case "x-":
+      return obstacleBounds.maxX - movingBounds.minX + LABEL_CLEARANCE
+    case "x+":
+      return movingBounds.maxX - obstacleBounds.minX + LABEL_CLEARANCE
+    case "y-":
+      return obstacleBounds.maxY - movingBounds.minY + LABEL_CLEARANCE
+    case "y+":
+      return movingBounds.maxY - obstacleBounds.minY + LABEL_CLEARANCE
+  }
+}
+
+const boundsGapOnPerpendicularAxis = (
+  a: Bounds,
+  b: Bounds,
+  orientation: FacingDirection,
+) => {
+  if (orientation === "x-" || orientation === "x+") {
+    return Math.max(0, a.minY - b.maxY, b.minY - a.maxY)
+  }
+  return Math.max(0, a.minX - b.maxX, b.minX - a.maxX)
+}
+
+const sharesOwnerChip = (
+  label: NetLabelPlacement,
+  ownerChipIds: Set<string>,
+  chipIdByPinId: Map<string, string>,
+) =>
+  label.pinIds.some((pinId) => ownerChipIds.has(chipIdByPinId.get(pinId) ?? ""))
+
+const isGeneratedLabelConnector = (trace: SolvedTracePath) =>
+  trace.mspPairId.startsWith("available-net-orientation-") ||
+  trace.mspPairId.startsWith("inline-net-label-clearance-")
+
+const findConnectorTraceIndex = (
+  label: NetLabelPlacement,
+  traces: SolvedTracePath[],
+) =>
+  traces.findIndex((trace) => {
+    if (trace.globalConnNetId !== label.globalConnNetId) return false
+    if (!isGeneratedLabelConnector(trace)) return false
+    const first = trace.tracePath[0]
+    const last = trace.tracePath.at(-1)
+    return Boolean(
+      (first && pointsEqual(first, label.anchorPoint)) ||
+        (last && pointsEqual(last, label.anchorPoint)),
+    )
+  })
+
+const canAddConnectorAtAnchor = (
+  label: NetLabelPlacement,
+  traces: SolvedTracePath[],
+  pinMap: ReturnType<typeof getPinMap>,
+) => {
+  if (
+    label.pinIds.some((pinId) => {
+      const pin = pinMap[pinId]
+      return pin && pointsEqual(pin, label.anchorPoint)
+    })
+  ) {
+    return true
+  }
+  return traces.some(
+    (trace) =>
+      trace.globalConnNetId === label.globalConnNetId &&
+      isPointOnPath(label.anchorPoint, trace.tracePath),
+  )
+}
+
+const moveConnectorEndpoint = (
+  trace: SolvedTracePath,
+  oldAnchor: Point,
+  newAnchor: Point,
+): SolvedTracePath => {
+  const tracePath = trace.tracePath.map((point) => ({ ...point }))
+  if (pointsEqual(tracePath[0]!, oldAnchor)) tracePath[0] = newAnchor
+  if (pointsEqual(tracePath.at(-1)!, oldAnchor)) {
+    tracePath[tracePath.length - 1] = newAnchor
+  }
+  return { ...trace, tracePath }
+}
+
+const createConnectorTrace = ({
+  label,
+  labelIndex,
+  newAnchor,
+  pinMap,
+}: {
+  label: NetLabelPlacement
+  labelIndex: number
+  newAnchor: Point
+  pinMap: ReturnType<typeof getPinMap>
+}): SolvedTracePath => {
+  const mspPairId = `inline-net-label-clearance-${labelIndex}-${label.netId ?? label.globalConnNetId}`
+  return {
+    mspPairId,
+    dcConnNetId: label.dcConnNetId ?? label.globalConnNetId,
+    globalConnNetId: label.globalConnNetId,
+    userNetId: label.netId,
+    pins: getTracePins(label, pinMap),
+    tracePath: [label.anchorPoint, newAnchor],
+    mspConnectionPairIds: [mspPairId],
+    pinIds: label.pinIds,
+  }
+}
+
+const getContiguousLabelGroup = ({
+  triggerIndex,
+  labels,
+  chipIdByPinId,
+}: {
+  triggerIndex: number
+  labels: NetLabelPlacement[]
+  chipIdByPinId: Map<string, string>
+}) => {
+  const trigger = labels[triggerIndex]!
+  const ownerChipIds = new Set(
+    trigger.pinIds.flatMap((pinId) => {
+      const chipId = chipIdByPinId.get(pinId)
+      return chipId ? [chipId] : []
+    }),
+  )
+  const candidates = labels
+    .map((label, labelIndex) => ({ label, labelIndex }))
+    .filter(
+      ({ label }) =>
+        label.orientation === trigger.orientation &&
+        label.mspConnectionPairIds.length === 0 &&
+        sharesOwnerChip(label, ownerChipIds, chipIdByPinId),
+    )
+  const group = new Set([triggerIndex])
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const { label, labelIndex } of candidates) {
+      if (group.has(labelIndex)) continue
+      if (
+        [...group].some(
+          (memberIndex) =>
+            boundsGapOnPerpendicularAxis(
+              getBounds(labels[memberIndex]!),
+              getBounds(label),
+              trigger.orientation,
+            ) <= CONTIGUOUS_LABEL_GAP,
+        )
+      ) {
+        group.add(labelIndex)
+        changed = true
+      }
+    }
+  }
+  return { group, ownerChipIds }
+}
+
+/**
+ * Pushes conventional endpoint labels past nearby inline label text.
+ *
+ * Contiguous conventional labels on the same component side move as a group,
+ * keeping their connector tips aligned. When that new column encounters
+ * another label belonging to the same component, the obstacle is shoved one
+ * column farther outward and receives its own short connector. The entire
+ * proposal is rejected if a chip, component text, inline label, fixed label,
+ * or unrelated trace would still be hit.
+ */
+export const pushAnchoredNetLabelsAwayFromInlineLabels = ({
+  inputProblem,
+  traces,
+  netLabelPlacements,
+  inlineNetLabelPlacements,
+}: {
+  inputProblem: InputProblem
+  traces: SolvedTracePath[]
+  netLabelPlacements: NetLabelPlacement[]
+  inlineNetLabelPlacements: InlineNetLabelPlacement[]
+}): {
+  traces: SolvedTracePath[]
+  netLabelPlacements: NetLabelPlacement[]
+  movedLabelCount: number
+} => {
+  const outputTraces = traces.map((trace) => ({
+    ...trace,
+    tracePath: trace.tracePath.map((point) => ({ ...point })),
+  }))
+  const outputLabels = netLabelPlacements.map((label) => ({ ...label }))
+  const inlineBounds = inlineNetLabelPlacements.map(getBounds)
+  const pinMap = getPinMap(inputProblem)
+  const chipIdByPinId = new Map<string, string>()
+  for (const chip of inputProblem.chips) {
+    for (const pin of chip.pins) chipIdByPinId.set(pin.pinId, chip.chipId)
+  }
+  const movedLabelIndices = new Set<number>()
+
+  for (
+    let triggerIndex = 0;
+    triggerIndex < outputLabels.length;
+    triggerIndex++
+  ) {
+    const trigger = outputLabels[triggerIndex]!
+    const distance = getRequiredOutwardDistance(trigger, inlineBounds)
+    if (distance <= POINT_EPSILON || distance > MAX_OUTWARD_DISTANCE) continue
+
+    const { group, ownerChipIds } = getContiguousLabelGroup({
+      triggerIndex,
+      labels: outputLabels,
+      chipIdByPinId,
+    })
+    const distances = new Map<number, number>(
+      [...group].map((labelIndex) => [labelIndex, distance]),
+    )
+
+    let failed = false
+    for (let iteration = 0; iteration < outputLabels.length; iteration++) {
+      let adjustedObstacle = false
+      for (const [movingIndex, movingDistance] of distances) {
+        const movingBounds = getBounds(
+          moveLabel(
+            outputLabels[movingIndex]!,
+            trigger.orientation,
+            movingDistance,
+          ),
+        )
+        for (
+          let obstacleIndex = 0;
+          obstacleIndex < outputLabels.length;
+          obstacleIndex++
+        ) {
+          if (group.has(obstacleIndex)) continue
+          const obstacle = outputLabels[obstacleIndex]!
+          const existingObstacleDistance = distances.get(obstacleIndex) ?? 0
+          const obstacleBounds = getBounds(
+            moveLabel(obstacle, trigger.orientation, existingObstacleDistance),
+          )
+          if (!boundsOverlap(movingBounds, obstacleBounds)) continue
+          if (
+            !sharesOwnerChip(obstacle, ownerChipIds, chipIdByPinId) ||
+            (findConnectorTraceIndex(obstacle, outputTraces) === -1 &&
+              !canAddConnectorAtAnchor(obstacle, outputTraces, pinMap))
+          ) {
+            failed = true
+            break
+          }
+          const shoveDistance = getDistanceToShoveBoundsPast(
+            getBounds(obstacle),
+            movingBounds,
+            trigger.orientation,
+          )
+          if (
+            shoveDistance > MAX_OUTWARD_DISTANCE ||
+            shoveDistance <= existingObstacleDistance + POINT_EPSILON
+          ) {
+            failed = true
+            break
+          }
+          distances.set(obstacleIndex, shoveDistance)
+          adjustedObstacle = true
+        }
+        if (failed) break
+      }
+      if (failed || !adjustedObstacle) break
+    }
+    if (failed) continue
+
+    const proposals = new Map<number, NetLabelPlacement>()
+    for (const [labelIndex, labelDistance] of distances) {
+      proposals.set(
+        labelIndex,
+        moveLabel(
+          outputLabels[labelIndex]!,
+          trigger.orientation,
+          labelDistance,
+        ),
+      )
+    }
+
+    const finalLabelAt = (labelIndex: number) =>
+      proposals.get(labelIndex) ?? outputLabels[labelIndex]!
+    for (const [labelIndex, movedLabel] of proposals) {
+      const movedBounds = getBounds(movedLabel)
+      if (inlineBounds.some((bounds) => boundsOverlap(movedBounds, bounds))) {
+        failed = true
+        break
+      }
+      if (
+        inputProblem.chips.some((chip) =>
+          boundsOverlap(movedBounds, {
+            minX: chip.center.x - chip.width / 2,
+            maxX: chip.center.x + chip.width / 2,
+            minY: chip.center.y - chip.height / 2,
+            maxY: chip.center.y + chip.height / 2,
+          }),
+        ) ||
+        (inputProblem.textBoxes ?? []).some((textBox) =>
+          boundsOverlap(movedBounds, getTextBoxBounds(textBox)),
+        )
+      ) {
+        failed = true
+        break
+      }
+      if (
+        outputLabels.some(
+          (_, otherIndex) =>
+            otherIndex !== labelIndex &&
+            boundsOverlap(movedBounds, getBounds(finalLabelAt(otherIndex))),
+        )
+      ) {
+        failed = true
+        break
+      }
+      if (
+        outputTraces.some(
+          (trace) =>
+            trace.globalConnNetId !== movedLabel.globalConnNetId &&
+            pathIntersectsBounds(trace.tracePath, movedBounds),
+        )
+      ) {
+        failed = true
+        break
+      }
+    }
+    if (failed) continue
+
+    const connectorUpdates: Array<{
+      labelIndex: number
+      connectorIndex: number
+      trace: SolvedTracePath
+    }> = []
+    for (const [labelIndex, movedLabel] of proposals) {
+      const label = outputLabels[labelIndex]!
+      const connectorIndex = findConnectorTraceIndex(label, outputTraces)
+      if (
+        connectorIndex === -1 &&
+        !canAddConnectorAtAnchor(label, outputTraces, pinMap)
+      ) {
+        failed = true
+        break
+      }
+      const connector =
+        connectorIndex === -1
+          ? createConnectorTrace({
+              label,
+              labelIndex,
+              newAnchor: movedLabel.anchorPoint,
+              pinMap,
+            })
+          : moveConnectorEndpoint(
+              outputTraces[connectorIndex]!,
+              label.anchorPoint,
+              movedLabel.anchorPoint,
+            )
+      const connectorObstructed =
+        inlineBounds.some((bounds) =>
+          pathIntersectsBounds(connector.tracePath, bounds),
+        ) ||
+        inputProblem.chips.some((chip) =>
+          pathIntersectsBounds(connector.tracePath, {
+            minX: chip.center.x - chip.width / 2,
+            maxX: chip.center.x + chip.width / 2,
+            minY: chip.center.y - chip.height / 2,
+            maxY: chip.center.y + chip.height / 2,
+          }),
+        ) ||
+        (inputProblem.textBoxes ?? []).some((textBox) =>
+          pathIntersectsBounds(connector.tracePath, getTextBoxBounds(textBox)),
+        ) ||
+        outputLabels.some(
+          (_, otherIndex) =>
+            otherIndex !== labelIndex &&
+            pathIntersectsBounds(
+              connector.tracePath,
+              getBounds(finalLabelAt(otherIndex)),
+            ),
+        )
+      if (connectorObstructed) {
+        failed = true
+        break
+      }
+      connectorUpdates.push({ labelIndex, connectorIndex, trace: connector })
+    }
+    if (failed) continue
+
+    for (const [labelIndex, movedLabel] of proposals) {
+      outputLabels[labelIndex] = movedLabel
+      movedLabelIndices.add(labelIndex)
+    }
+    for (const update of connectorUpdates) {
+      if (update.connectorIndex === -1) outputTraces.push(update.trace)
+      else outputTraces[update.connectorIndex] = update.trace
+    }
+  }
+
+  return {
+    traces: outputTraces,
+    netLabelPlacements: outputLabels,
+    movedLabelCount: movedLabelIndices.size,
+  }
+}

--- a/tests/assets/inline-net-label-anchored-label-clearance.json
+++ b/tests/assets/inline-net-label-anchored-label-clearance.json
@@ -1,0 +1,56 @@
+{
+  "chips": [
+    {
+      "chipId": "U1",
+      "center": { "x": 0, "y": 0.2 },
+      "width": 1.4,
+      "height": 1,
+      "pins": [
+        {
+          "pinId": "U1.minus",
+          "x": -0.7,
+          "y": 0.4,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U1.plus",
+          "x": -0.7,
+          "y": 0.2,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "U1.swclk",
+          "x": -0.7,
+          "y": 0,
+          "_facingDirection": "x-"
+        }
+      ]
+    }
+  ],
+  "directConnections": [],
+  "netConnections": [
+    {
+      "netId": "D_MINUS",
+      "pinIds": ["U1.minus"],
+      "netLabelWidth": 0.96
+    },
+    {
+      "netId": "D_PLUS",
+      "pinIds": ["U1.plus"],
+      "netLabelWidth": 0.84
+    },
+    {
+      "netId": "SWCLK",
+      "pinIds": ["U1.swclk"],
+      "netLabelWidth": 0.48,
+      "allowInlineNetLabel": true,
+      "inlineNetLabelWidth": 0.48,
+      "inlineNetLabelHeight": 0.12
+    }
+  ],
+  "availableNetLabelOrientations": {
+    "D_MINUS": ["x-"],
+    "D_PLUS": ["x-"],
+    "SWCLK": ["x-"]
+  }
+}

--- a/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label-anchored-label-clearance.snap.svg
+++ b/tests/solvers/InlineNetLabelSolver/__snapshots__/inline-net-label-anchored-label-clearance.snap.svg
@@ -1,0 +1,54 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-0.7,0.2 -1.3290000000000002,0.2" data-type="line" data-label="" points="337.7926421404682,320 219.98662207357856,320" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="-0.7,0.4 -1.3290000000000002,0.4" data-type="line" data-label="" points="337.7926421404682,282.54180602006693 219.98662207357856,282.54180602006693" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="-0.7,0 -1.38,0" data-type="line" data-label="" points="337.7926421404682,357.4581939799331 210.43478260869568,357.4581939799331" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="U1" data-x="0" data-y="0.2" x="337.79264214046816" y="226.35451505016724" width="262.2073578595318" height="187.29096989966553" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.005339285714285715"/></g><g><rect data-type="rect" data-label="netId: D_MINUS
+globalConnNetId: connectivity_net0" data-x="-1.81" data-y="0.4" x="40" y="263.81270903010034" width="179.79933110367892" height="37.45819397993313" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.005339285714285715"/></g><g><rect data-type="rect" data-label="netId: D_PLUS
+globalConnNetId: connectivity_net1" data-x="-1.75" data-y="0.2" x="62.474916387959894" y="301.2709030100334" width="157.324414715719" height="37.45819397993313" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.005339285714285715"/></g><g><rect data-type="rect" data-label="INLINE netId: SWCLK
+axis: x
+side: y+" data-x="-1.04" data-y="0.11" x="229.16387959866222" y="325.61872909698997" width="89.89966555183949" height="22.474916387959865" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.005339285714285715"/></g><text data-type="text" data-label="SWCLK" data-x="-0.8" data-y="0.11" x="319.0635451505017" y="336.8561872909699" fill="green" font-size="22.474916387959862" font-family="sans-serif" text-anchor="end" dominant-baseline="central">SWCLK</text><g><circle data-type="point" data-label="U1.minus
+x-" data-x="-0.7" data-y="0.4" cx="337.7926421404682" cy="282.54180602006693" r="3" fill="hsl(166, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.plus
+x-" data-x="-0.7" data-y="0.2" cx="337.7926421404682" cy="320" r="3" fill="hsl(92, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.swclk
+x-" data-x="-0.7" data-y="0" cx="337.7926421404682" cy="357.4581939799331" r="3" fill="hsl(308, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.3290000000000002" data-y="0.4" cx="219.98662207357856" cy="282.54180602006693" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-1.3290000000000002" data-y="0.2" cx="219.98662207357856" cy="320" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="inline anchor
+SWCLK" data-x="-1.04" data-y="0" cx="274.11371237458195" cy="357.4581939799331" r="3" fill="green"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":187.29096989966553,"c":0,"e":468.8963210702341,"b":0,"d":-187.29096989966553,"f":357.4581939799331};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/solvers/InlineNetLabelSolver/inline-net-label-anchored-label-clearance.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/inline-net-label-anchored-label-clearance.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import inputProblem from "../../assets/inline-net-label-anchored-label-clearance.json"
+import "tests/fixtures/matcher"
+
+test("regular labels are drawn beyond adjacent inline labels", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  const output = solver.inlineNetLabelSolver!.getOutput()
+  const regularLabels = output.netLabelPlacements.filter((label) =>
+    ["D_MINUS", "D_PLUS"].includes(label.netId ?? ""),
+  )
+  expect(solver.inlineNetLabelSolver!.stats.pushedAnchoredNetLabelCount).toBe(2)
+  expect(regularLabels).toHaveLength(2)
+  expect(regularLabels[0]!.anchorPoint.x).toBeCloseTo(
+    regularLabels[1]!.anchorPoint.x,
+  )
+  expect(regularLabels[0]!.anchorPoint.x).toBeLessThan(-0.7)
+  expect(
+    output.traces.filter((trace) =>
+      trace.mspPairId.startsWith("inline-net-label-clearance-"),
+    ),
+  ).toHaveLength(2)
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})

--- a/tests/solvers/InlineNetLabelSolver/push-anchored-net-labels-away.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/push-anchored-net-labels-away.test.ts
@@ -1,0 +1,227 @@
+import { expect, test } from "bun:test"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
+import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import { pushAnchoredNetLabelsAwayFromInlineLabels } from "lib/solvers/InlineNetLabelSolver/pushAnchoredNetLabelsAwayFromInlineLabels"
+import type { InlineNetLabelPlacement } from "lib/solvers/InlineNetLabelSolver/InlineNetLabelSolver"
+
+test("pushes a regular endpoint label and its wick past nearby inline text", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [],
+      },
+    ],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+  const netLabelPlacements: NetLabelPlacement[] = [
+    {
+      globalConnNetId: "regular-net",
+      netId: "D_PLUS",
+      mspConnectionPairIds: [],
+      pinIds: ["U1.1"],
+      orientation: "x-",
+      anchorPoint: { x: -0.7, y: 0.2 },
+      center: { x: -1.2, y: 0.2 },
+      width: 1,
+      height: 0.2,
+    },
+  ]
+  const traces: SolvedTracePath[] = [
+    {
+      mspPairId: "available-net-orientation-0-D_PLUS",
+      dcConnNetId: "regular-net",
+      globalConnNetId: "regular-net",
+      pins: [] as any,
+      tracePath: [
+        { x: -0.5, y: 0.2 },
+        { x: -0.7, y: 0.2 },
+      ],
+      mspConnectionPairIds: [],
+      pinIds: ["U1.1"],
+    },
+  ]
+  const inlineNetLabelPlacements: InlineNetLabelPlacement[] = [
+    {
+      globalConnNetId: "inline-net",
+      netId: "SWCLK",
+      pinIds: ["U1.2"],
+      stubTracePath: [
+        { x: -0.5, y: 0 },
+        { x: -1.7, y: 0 },
+      ],
+      axis: "x",
+      anchorPoint: { x: -1.1, y: 0 },
+      center: { x: -1.1, y: 0.11 },
+      width: 1.2,
+      height: 0.12,
+      side: "y+",
+    },
+  ]
+
+  const output = pushAnchoredNetLabelsAwayFromInlineLabels({
+    inputProblem,
+    traces,
+    netLabelPlacements,
+    inlineNetLabelPlacements,
+  })
+
+  expect(output.movedLabelCount).toBe(1)
+  expect(output.netLabelPlacements[0]!.anchorPoint.x).toBeCloseTo(-1.75)
+  expect(output.netLabelPlacements[0]!.center.x).toBeCloseTo(-2.25)
+  expect(output.traces[0]!.tracePath[0]).toEqual({ x: -0.5, y: 0.2 })
+  expect(output.traces[0]!.tracePath[1]!.x).toBeCloseTo(-1.75)
+  expect(output.traces[0]!.tracePath[1]!.y).toBeCloseTo(0.2)
+})
+
+test("leaves a label without a movable connector in place", () => {
+  const label: NetLabelPlacement = {
+    globalConnNetId: "regular-net",
+    netId: "D_PLUS",
+    mspConnectionPairIds: ["routed-pair"],
+    pinIds: ["U1.1", "J1.1"],
+    orientation: "x-",
+    anchorPoint: { x: -0.7, y: 0.2 },
+    center: { x: -1.2, y: 0.2 },
+    width: 1,
+    height: 0.2,
+  }
+  const inlineLabel: InlineNetLabelPlacement = {
+    globalConnNetId: "inline-net",
+    netId: "SWCLK",
+    pinIds: ["U1.2"],
+    axis: "x",
+    anchorPoint: { x: -1.1, y: 0 },
+    center: { x: -1.1, y: 0.11 },
+    width: 1.2,
+    height: 0.12,
+    side: "y+",
+  }
+
+  const output = pushAnchoredNetLabelsAwayFromInlineLabels({
+    inputProblem: {
+      chips: [],
+      directConnections: [],
+      netConnections: [],
+      availableNetLabelOrientations: {},
+    },
+    traces: [],
+    netLabelPlacements: [label],
+    inlineNetLabelPlacements: [inlineLabel],
+  })
+
+  expect(output.movedLabelCount).toBe(0)
+  expect(output.netLabelPlacements[0]).toEqual(label)
+})
+
+test("moves a contiguous label row together and shoves an anchored obstacle", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 0, y: 0.2 },
+        width: 1.4,
+        height: 1,
+        pins: [
+          { pinId: "U1.minus", x: -0.7, y: 0.4, _facingDirection: "x-" },
+          { pinId: "U1.plus", x: -0.7, y: 0.2, _facingDirection: "x-" },
+          { pinId: "U1.inline", x: -0.7, y: 0, _facingDirection: "x-" },
+          { pinId: "U1.gnd1", x: -0.7, y: 0.5, _facingDirection: "x-" },
+          { pinId: "U1.gnd2", x: -2.5, y: 0.5, _facingDirection: "x+" },
+        ],
+      },
+    ],
+    directConnections: [],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+  }
+  const netLabelPlacements: NetLabelPlacement[] = [
+    {
+      globalConnNetId: "minus-net",
+      netId: "D_MINUS",
+      mspConnectionPairIds: [],
+      pinIds: ["U1.minus"],
+      orientation: "x-",
+      anchorPoint: { x: -0.7, y: 0.4 },
+      center: { x: -1.2, y: 0.4 },
+      width: 1,
+      height: 0.2,
+    },
+    {
+      globalConnNetId: "plus-net",
+      netId: "D_PLUS",
+      mspConnectionPairIds: [],
+      pinIds: ["U1.plus"],
+      orientation: "x-",
+      anchorPoint: { x: -0.7, y: 0.2 },
+      center: { x: -1.2, y: 0.2 },
+      width: 1,
+      height: 0.2,
+    },
+    {
+      globalConnNetId: "gnd-net",
+      netId: "GND",
+      mspConnectionPairIds: ["gnd-route"],
+      pinIds: ["U1.gnd1", "U1.gnd2"],
+      orientation: "y-",
+      anchorPoint: { x: -2.5, y: 0.5 },
+      center: { x: -2.5, y: 0.3 },
+      width: 0.4,
+      height: 0.4,
+    },
+  ]
+  const traces: SolvedTracePath[] = [
+    {
+      mspPairId: "gnd-route",
+      dcConnNetId: "gnd-net",
+      globalConnNetId: "gnd-net",
+      pins: [] as any,
+      tracePath: [
+        { x: -0.7, y: 0.5 },
+        { x: -2.5, y: 0.5 },
+      ],
+      mspConnectionPairIds: ["gnd-route"],
+      pinIds: ["U1.gnd1", "U1.gnd2"],
+    },
+  ]
+  const inlineNetLabelPlacements: InlineNetLabelPlacement[] = [
+    {
+      globalConnNetId: "inline-net",
+      netId: "SWCLK",
+      pinIds: ["U1.inline"],
+      stubTracePath: [
+        { x: -0.7, y: 0 },
+        { x: -1.9, y: 0 },
+      ],
+      axis: "x",
+      anchorPoint: { x: -1.3, y: 0 },
+      center: { x: -1.1, y: 0.11 },
+      width: 1.2,
+      height: 0.12,
+      side: "y+",
+    },
+  ]
+
+  const output = pushAnchoredNetLabelsAwayFromInlineLabels({
+    inputProblem,
+    traces,
+    netLabelPlacements,
+    inlineNetLabelPlacements,
+  })
+
+  expect(output.movedLabelCount).toBe(3)
+  expect(output.netLabelPlacements[0]!.anchorPoint.x).toBeCloseTo(-1.75)
+  expect(output.netLabelPlacements[1]!.anchorPoint.x).toBeCloseTo(-1.75)
+  expect(output.netLabelPlacements[2]!.center.x).toBeLessThan(-2.5)
+  expect(
+    output.traces.filter((trace) =>
+      trace.mspPairId.startsWith("inline-net-label-clearance-"),
+    ),
+  ).toHaveLength(3)
+})


### PR DESCRIPTION
## Summary
- post-process conventional endpoint labels so they sit beyond nearby inline-label text
- keep contiguous chip-side label rows aligned and move same-chip obstacles to the next outer lane
- extend or create connector wicks only when the resulting geometry remains collision-free

## Verification
- bun test (199 pass, 4 skip)
- bun run build
- visual pipeline regression snapshot for anchored/inline label clearance