### PR TITLE
Mark TIDA page 02 ground nets in repro

### DIFF
--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -67,6 +67,8 @@ export interface InputNetConnection {
   pinIds: Array<PinId>
   netLabelWidth?: number
   netLabelHeight?: number
+  /** True when this connection represents an electrical ground rail. */
+  isGround?: boolean
 
   /**
    * When true, a named one- or two-pin net may use inline labels. A single-pin

--- a/tests/repros/assets/repro-tida010076-page02.input.json
+++ b/tests/repros/assets/repro-tida010076-page02.input.json
@@ -1567,6 +1567,7 @@
     },
     {
       "netId": "NET_GND",
+      "isGround": true,
       "netLabelWidth": 0.96,
       "pinIds": [
         "schematic_port_119",
@@ -1611,6 +1612,7 @@
     },
     {
       "netId": "NET_AGND",
+      "isGround": true,
       "netLabelWidth": 0.42,
       "netLabelHeight": 1.08,
       "pinIds": [

--- a/tests/repros/repro-tida010076-page02.test.ts
+++ b/tests/repros/repro-tida010076-page02.test.ts
@@ -15,6 +15,12 @@ test("repro TIDA-010076 page 02 net-label placement", () => {
   expect(inputProblem.chips).toHaveLength(21)
   expect(inputProblem.directConnections).toHaveLength(13)
   expect(inputProblem.netConnections).toHaveLength(96)
+  expect(
+    inputProblem.netConnections
+      .filter((connection) => connection.isGround)
+      .map((connection) => connection.netId)
+      .sort(),
+  ).toEqual(["NET_AGND", "NET_GND"])
   expect(inputProblem.availableNetLabelOrientations?.NET_AGND).toEqual(["y-"])
 
   const solver = new SchematicTracePipelineSolver(inputProblem, {


### PR DESCRIPTION
## Summary
- add isGround metadata to input net connections
- mark NET_GND and NET_AGND as ground rails in the TIDA-010076 page-02 repro
- assert the complete ground-net set carried by the fixture

## Test plan
- bunx tsc --noEmit
- bun test tests (198 pass, 4 skip, 0 fail)