### PR TITLE
Separate inline fallback label width from routing

### DIFF
--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -18,7 +18,6 @@ import type {
 import { dir, type FacingDirection } from "lib/utils/dir"
 import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
 import { rectIntersectsAnyTextBox } from "lib/utils/textBoxBounds"
-import { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
 import {
   EPS,
   LABEL_SEARCH_STEP,
@@ -48,6 +47,7 @@ import type {
   EvaluatedCandidate,
 } from "./types"
 import { visualizeAvailableNetOrientationSolver } from "./visualize"
+import { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
 
 const LABEL_TRACE_CLEARANCE = 0.1
 

--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -16,7 +16,9 @@ import type {
   InputProblem,
 } from "lib/types/InputProblem"
 import { dir, type FacingDirection } from "lib/utils/dir"
+import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
 import { rectIntersectsAnyTextBox } from "lib/utils/textBoxBounds"
+import { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
 import {
   EPS,
   LABEL_SEARCH_STEP,
@@ -46,7 +48,6 @@ import type {
   EvaluatedCandidate,
 } from "./types"
 import { visualizeAvailableNetOrientationSolver } from "./visualize"
-import { AvailableNetOrientationObstacleIndex } from "./AvailableNetOrientationObstacleIndex"
 
 const LABEL_TRACE_CLEARANCE = 0.1
 
@@ -1292,26 +1293,11 @@ export class AvailableNetOrientationSolver extends BaseSolver {
   }
 
   private getNetLabelWidth(label: NetLabelPlacement) {
-    if (label.netId) {
-      const ncWidth = this.inputProblem.netConnections.find(
-        (connection) => connection.netId === label.netId,
-      )?.netLabelWidth
-      if (ncWidth !== undefined) return ncWidth
-
-      const dcWidthByNetId = this.inputProblem.directConnections.find(
-        (dc) => dc.netId === label.netId,
-      )?.netLabelWidth
-      if (dcWidthByNetId !== undefined) return dcWidthByNetId
-    }
-
-    const dcWidthByPinId = this.inputProblem.directConnections.find((dc) =>
-      dc.pinIds.some((pid) => label.pinIds.includes(pid)),
-    )?.netLabelWidth
-    if (dcWidthByPinId !== undefined) return dcWidthByPinId
-
-    return this.inputProblem.netConnections.find((nc) =>
-      nc.pinIds.some((pid) => label.pinIds.includes(pid)),
-    )?.netLabelWidth
+    return getNetLabelWidthForConnection({
+      inputProblem: this.inputProblem,
+      netId: label.netId,
+      pinIds: label.pinIds,
+    })
   }
 
   private getNetLabelHeight(label: NetLabelPlacement) {

--- a/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
+++ b/lib/solvers/AvailableNetOrientationSolver/AvailableNetOrientationSolver.ts
@@ -181,13 +181,23 @@ export class AvailableNetOrientationSolver extends BaseSolver {
       const bY = this.outputNetLabelPlacements[b]!.anchorPoint.y
       return requiredOrientation === "y+" ? bY - aY : aY - bY
     })
-    const blockedLabelWidth = this.getNetLabelWidth(blockedLabel)
+    const blockedLabelWidth = getNetLabelWidthForConnection({
+      inputProblem: this.inputProblem,
+      netId: blockedLabel.netId,
+      pinIds: blockedLabel.pinIds,
+    })
     let columnLabelIndex: number | undefined
     if (blockedLabelWidth !== undefined) {
       columnLabelIndex = labelsToOrder.find((index) => {
         if (index === blockedStandaloneLabelIndex) return false
         const label = this.outputNetLabelPlacements[index]!
-        return this.getNetLabelWidth(label) === blockedLabelWidth
+        return (
+          getNetLabelWidthForConnection({
+            inputProblem: this.inputProblem,
+            netId: label.netId,
+            pinIds: label.pinIds,
+          }) === blockedLabelWidth
+        )
       })
     }
     if (columnLabelIndex !== undefined) {
@@ -482,7 +492,11 @@ export class AvailableNetOrientationSolver extends BaseSolver {
 
     const { width, height } = getDimsForOrientation({
       orientation,
-      netLabelWidth: this.getNetLabelWidth(label),
+      netLabelWidth: getNetLabelWidthForConnection({
+        inputProblem: this.inputProblem,
+        netId: label.netId,
+        pinIds: label.pinIds,
+      }),
       netLabelHeight: this.getNetLabelHeight(label),
     })
 
@@ -1095,7 +1109,11 @@ export class AvailableNetOrientationSolver extends BaseSolver {
   private labelIntersectsDifferentNetTrace(label: NetLabelPlacement) {
     const { width, height } = getDimsForOrientation({
       orientation: label.orientation,
-      netLabelWidth: this.getNetLabelWidth(label),
+      netLabelWidth: getNetLabelWidthForConnection({
+        inputProblem: this.inputProblem,
+        netId: label.netId,
+        pinIds: label.pinIds,
+      }),
       netLabelHeight: this.getNetLabelHeight(label),
     })
     const center = getCenterFromAnchor(
@@ -1119,7 +1137,11 @@ export class AvailableNetOrientationSolver extends BaseSolver {
     const anchorPoint = this.getWickOffsetAnchor(label.anchorPoint, orientation)
     const { width, height } = getDimsForOrientation({
       orientation,
-      netLabelWidth: this.getNetLabelWidth(label),
+      netLabelWidth: getNetLabelWidthForConnection({
+        inputProblem: this.inputProblem,
+        netId: label.netId,
+        pinIds: label.pinIds,
+      }),
       netLabelHeight: this.getNetLabelHeight(label),
     })
 
@@ -1198,7 +1220,11 @@ export class AvailableNetOrientationSolver extends BaseSolver {
   ) {
     const { width, height } = getDimsForOrientation({
       orientation,
-      netLabelWidth: this.getNetLabelWidth(label),
+      netLabelWidth: getNetLabelWidthForConnection({
+        inputProblem: this.inputProblem,
+        netId: label.netId,
+        pinIds: label.pinIds,
+      }),
       netLabelHeight: this.getNetLabelHeight(label),
     })
     const labelLength =
@@ -1279,7 +1305,11 @@ export class AvailableNetOrientationSolver extends BaseSolver {
   ): CandidateLabel {
     const { width, height } = getDimsForOrientation({
       orientation,
-      netLabelWidth: this.getNetLabelWidth(label),
+      netLabelWidth: getNetLabelWidthForConnection({
+        inputProblem: this.inputProblem,
+        netId: label.netId,
+        pinIds: label.pinIds,
+      }),
       netLabelHeight: this.getNetLabelHeight(label),
     })
     return {
@@ -1290,14 +1320,6 @@ export class AvailableNetOrientationSolver extends BaseSolver {
       height,
       center: getCenterFromAnchor(anchorPoint, orientation, width, height),
     }
-  }
-
-  private getNetLabelWidth(label: NetLabelPlacement) {
-    return getNetLabelWidthForConnection({
-      inputProblem: this.inputProblem,
-      netId: label.netId,
-      pinIds: label.pinIds,
-    })
   }
 
   private getNetLabelHeight(label: NetLabelPlacement) {

--- a/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
@@ -1,14 +1,15 @@
-import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
-import type { InputProblem, PinId } from "lib/types/InputProblem"
-import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import type { MspConnectionPairId } from "../MspConnectionPairSolver/MspConnectionPairSolver"
-import { SingleNetLabelPlacementSolver } from "./SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver"
-import type { FacingDirection } from "lib/utils/dir"
 import type { Point } from "@tscircuit/math-utils"
 import type { GraphicsObject } from "graphics-debug"
-import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import type { InputProblem, PinId } from "lib/types/InputProblem"
+import type { FacingDirection } from "lib/utils/dir"
 import { getColorFromString } from "lib/utils/getColorFromString"
+import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
 import { getConnectivityMapsFromInputProblem } from "../MspConnectionPairSolver/getConnectivityMapFromInputProblem"
+import type { MspConnectionPairId } from "../MspConnectionPairSolver/MspConnectionPairSolver"
+import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { SingleNetLabelPlacementSolver } from "./SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver"
 
 /**
  * A group of traces that have at least one overlapping segment and
@@ -261,31 +262,15 @@ export class NetLabelPlacementSolver extends BaseSolver {
   private getNetLabelWidthForGroup(
     group: OverlappingSameNetTraceGroup,
   ): number | undefined {
-    if (group.netId) {
-      const ncWidth = this.inputProblem.netConnections.find(
-        (nc) => nc.netId === group.netId,
-      )?.netLabelWidth
-      if (ncWidth !== undefined) return ncWidth
-
-      const dcWidthByNetId = this.inputProblem.directConnections.find(
-        (dc) => dc.netId === group.netId,
-      )?.netLabelWidth
-      if (dcWidthByNetId !== undefined) return dcWidthByNetId
-    }
-
     const pinIds = group.overlappingTraces?.pins.map((p) => p.pinId) ?? []
     if (group.portOnlyPinId) {
       pinIds.push(group.portOnlyPinId)
     }
-
-    const dcWidthByPinId = this.inputProblem.directConnections.find((dc) =>
-      dc.pinIds.some((pid) => pinIds.includes(pid)),
-    )?.netLabelWidth
-    if (dcWidthByPinId !== undefined) return dcWidthByPinId
-
-    return this.inputProblem.netConnections.find((nc) =>
-      nc.pinIds.some((pid) => pinIds.includes(pid)),
-    )?.netLabelWidth
+    return getNetLabelWidthForConnection({
+      inputProblem: this.inputProblem,
+      netId: group.netId,
+      pinIds,
+    })
   }
 
   private getNetLabelHeightForGroup(

--- a/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
+++ b/lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver.ts
@@ -1,15 +1,15 @@
-import type { Point } from "@tscircuit/math-utils"
-import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import type { InputProblem, PinId } from "lib/types/InputProblem"
-import type { FacingDirection } from "lib/utils/dir"
-import { getColorFromString } from "lib/utils/getColorFromString"
-import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
-import { getConnectivityMapsFromInputProblem } from "../MspConnectionPairSolver/getConnectivityMapFromInputProblem"
-import type { MspConnectionPairId } from "../MspConnectionPairSolver/MspConnectionPairSolver"
 import type { SolvedTracePath } from "../SchematicTraceLinesSolver/SchematicTraceLinesSolver"
-import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import type { MspConnectionPairId } from "../MspConnectionPairSolver/MspConnectionPairSolver"
 import { SingleNetLabelPlacementSolver } from "./SingleNetLabelPlacementSolver/SingleNetLabelPlacementSolver"
+import type { FacingDirection } from "lib/utils/dir"
+import type { Point } from "@tscircuit/math-utils"
+import type { GraphicsObject } from "graphics-debug"
+import { visualizeInputProblem } from "../SchematicTracePipelineSolver/visualizeInputProblem"
+import { getColorFromString } from "lib/utils/getColorFromString"
+import { getConnectivityMapsFromInputProblem } from "../MspConnectionPairSolver/getConnectivityMapFromInputProblem"
+import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
 
 /**
  * A group of traces that have at least one overlapping segment and

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
@@ -7,6 +7,7 @@ import { getDimsForOrientation } from "lib/solvers/NetLabelPlacementSolver/Singl
 import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { InputChip, InputProblem } from "lib/types/InputProblem"
 import type { FacingDirection } from "lib/utils/dir"
+import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
 import { getTextBoxBounds, type RectPadding } from "lib/utils/textBoxBounds"
 import { getPinDirection } from "../SchematicTraceSingleLineSolver/getPinDirection"
 import { calculateDirectShortPath } from "./calculateDirectShortPath"
@@ -240,25 +241,13 @@ export class SchematicTraceSingleLineSolver2 extends BaseSolver {
   }
 
   private getNetLabelWidthForConnectionPair(netId: string) {
-    const ncWidth = this.inputProblem.netConnections.find(
-      (nc) => nc.netId === netId,
-    )?.netLabelWidth
-    if (ncWidth !== undefined) return ncWidth
-
-    const dcWidthByNetId = this.inputProblem.directConnections.find(
-      (dc) => dc.netId === netId,
-    )?.netLabelWidth
-    if (dcWidthByNetId !== undefined) return dcWidthByNetId
-
     const pinIds = this.pins.map((p) => p.pinId)
-    const dcWidthByPinId = this.inputProblem.directConnections.find((dc) =>
-      dc.pinIds.some((pid) => pinIds.includes(pid)),
-    )?.netLabelWidth
-    if (dcWidthByPinId !== undefined) return dcWidthByPinId
-
-    return this.inputProblem.netConnections.find((nc) =>
-      nc.pinIds.some((pid) => pinIds.includes(pid)),
-    )?.netLabelWidth
+    return getNetLabelWidthForConnection({
+      inputProblem: this.inputProblem,
+      netId,
+      pinIds,
+      includeFallbackNetLabelWidth: false,
+    })
   }
 
   private getNetLabelHeightForConnectionPair(netId: string) {

--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2.ts
@@ -202,7 +202,12 @@ export class SchematicTraceSingleLineSolver2 extends BaseSolver {
     const orientations =
       this.inputProblem.availableNetLabelOrientations[netId] ??
       (["x+", "x-", "y+", "y-"] as FacingDirection[])
-    const netLabelWidth = this.getNetLabelWidthForConnectionPair(netId)
+    const netLabelWidth = getNetLabelWidthForConnection({
+      inputProblem: this.inputProblem,
+      netId,
+      pinIds: this.pins.map((pin) => pin.pinId),
+      includeFallbackNetLabelWidth: false,
+    })
     const netLabelHeight = this.getNetLabelHeightForConnectionPair(netId)
     const padding: Required<RectPadding> = {
       minX: 0,
@@ -238,16 +243,6 @@ export class SchematicTraceSingleLineSolver2 extends BaseSolver {
     }
 
     return padding
-  }
-
-  private getNetLabelWidthForConnectionPair(netId: string) {
-    const pinIds = this.pins.map((p) => p.pinId)
-    return getNetLabelWidthForConnection({
-      inputProblem: this.inputProblem,
-      netId,
-      pinIds,
-      includeFallbackNetLabelWidth: false,
-    })
   }
 
   private getNetLabelHeightForConnectionPair(netId: string) {

--- a/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
+++ b/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
@@ -1,12 +1,13 @@
 import type { Point } from "@tscircuit/math-utils"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import {
   getCenterFromAnchor,
   getDimsForOrientation,
 } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
-import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { InputProblem } from "lib/types/InputProblem"
 import { dedupeOrientations } from "lib/utils/dedupeOrientations"
 import type { FacingDirection } from "lib/utils/dir"
+import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
 import { getOrientationConstraint } from "lib/utils/getOrientationConstraint"
 import {
   EPS,
@@ -310,20 +311,12 @@ const getNetLabelWidth = (
   inputProblem: InputProblem,
   label: NetLabelPlacement,
 ) => {
-  const ncWidthByNetId = inputProblem.netConnections.find(
-    (connection) => connection.netId === label.netId,
-  )?.netLabelWidth
-  if (ncWidthByNetId !== undefined) return ncWidthByNetId
-
-  const dcWidth = inputProblem.directConnections.find((dc) =>
-    dc.pinIds.some((pid) => label.pinIds.includes(pid)),
-  )?.netLabelWidth
-  if (dcWidth !== undefined) return dcWidth
-
-  const ncWidthByPinId = inputProblem.netConnections.find((nc) =>
-    nc.pinIds.some((pid) => label.pinIds.includes(pid)),
-  )?.netLabelWidth
-  if (ncWidthByPinId !== undefined) return ncWidthByPinId
+  const configuredWidth = getNetLabelWidthForConnection({
+    inputProblem,
+    netId: label.netId,
+    pinIds: label.pinIds,
+  })
+  if (configuredWidth !== undefined) return configuredWidth
 
   if (label.orientation === "y+" || label.orientation === "y-") {
     return label.height

--- a/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
+++ b/lib/solvers/TraceAnchoredNetLabelOverlapSolver/candidates.ts
@@ -1,14 +1,14 @@
 import type { Point } from "@tscircuit/math-utils"
-import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import {
   getCenterFromAnchor,
   getDimsForOrientation,
 } from "lib/solvers/NetLabelPlacementSolver/SingleNetLabelPlacementSolver/geometry"
+import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import type { InputProblem } from "lib/types/InputProblem"
 import { dedupeOrientations } from "lib/utils/dedupeOrientations"
 import type { FacingDirection } from "lib/utils/dir"
-import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
 import { getOrientationConstraint } from "lib/utils/getOrientationConstraint"
+import { getNetLabelWidthForConnection } from "lib/utils/getNetLabelWidthForConnection"
 import {
   EPS,
   getManhattanDistance,

--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -36,6 +36,13 @@ export interface InputDirectConnection {
   netLabelWidth?: number
 
   /**
+   * Width of the conventional anchored label to use only when an inline label
+   * cannot be placed. Unlike `netLabelWidth`, this does not affect whether or
+   * how the point-to-point connection is routed.
+   */
+  fallbackNetLabelWidth?: number
+
+  /**
    * When true, this point-to-point connection may be labeled with an "inline
    * net label": the net name is drawn parallel to (and offset from) the routed
    * trace instead of being placed as a separate anchored net label at the end
@@ -66,6 +73,7 @@ export interface InputNetConnection {
   netId: string
   pinIds: Array<PinId>
   netLabelWidth?: number
+  fallbackNetLabelWidth?: number
   netLabelHeight?: number
 
   /**

--- a/lib/utils/getNetLabelWidthForConnection.ts
+++ b/lib/utils/getNetLabelWidthForConnection.ts
@@ -2,6 +2,7 @@ import type {
   InputDirectConnection,
   InputNetConnection,
   InputProblem,
+  NetId,
   PinId,
 } from "lib/types/InputProblem"
 
@@ -29,7 +30,7 @@ export const getNetLabelWidthForConnection = ({
   includeFallbackNetLabelWidth = true,
 }: {
   inputProblem: InputProblem
-  netId?: string
+  netId?: NetId
   pinIds: readonly PinId[]
   includeFallbackNetLabelWidth?: boolean
 }): number | undefined => {

--- a/lib/utils/getNetLabelWidthForConnection.ts
+++ b/lib/utils/getNetLabelWidthForConnection.ts
@@ -1,0 +1,62 @@
+import type {
+  InputDirectConnection,
+  InputNetConnection,
+  InputProblem,
+  PinId,
+} from "lib/types/InputProblem"
+
+type ConnectionWithLabelWidth = InputDirectConnection | InputNetConnection
+
+const getConfiguredWidth = (
+  connections: Array<ConnectionWithLabelWidth | undefined>,
+  includeFallbackNetLabelWidth: boolean,
+) => {
+  const explicitWidth = connections.find(
+    (connection) => connection?.netLabelWidth !== undefined,
+  )?.netLabelWidth
+  if (explicitWidth !== undefined) return explicitWidth
+  if (!includeFallbackNetLabelWidth) return undefined
+
+  return connections.find(
+    (connection) => connection?.fallbackNetLabelWidth !== undefined,
+  )?.fallbackNetLabelWidth
+}
+
+export const getNetLabelWidthForConnection = ({
+  inputProblem,
+  netId,
+  pinIds,
+  includeFallbackNetLabelWidth = true,
+}: {
+  inputProblem: InputProblem
+  netId?: string
+  pinIds: readonly PinId[]
+  includeFallbackNetLabelWidth?: boolean
+}): number | undefined => {
+  if (netId) {
+    const widthByNetId = getConfiguredWidth(
+      [
+        inputProblem.netConnections.find(
+          (connection) => connection.netId === netId,
+        ),
+        inputProblem.directConnections.find(
+          (connection) => connection.netId === netId,
+        ),
+      ],
+      includeFallbackNetLabelWidth,
+    )
+    if (widthByNetId !== undefined) return widthByNetId
+  }
+
+  return getConfiguredWidth(
+    [
+      inputProblem.directConnections.find((connection) =>
+        connection.pinIds.some((pinId) => pinIds.includes(pinId)),
+      ),
+      inputProblem.netConnections.find((connection) =>
+        connection.pinIds.some((pinId) => pinIds.includes(pinId)),
+      ),
+    ],
+    includeFallbackNetLabelWidth,
+  )
+}

--- a/tests/solvers/InlineNetLabelSolver/__snapshots__/fallback-net-label-width.snap.svg
+++ b/tests/solvers/InlineNetLabelSolver/__snapshots__/fallback-net-label-width.snap.svg
@@ -1,0 +1,69 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="5.575,1.4 2.045,2.6" data-type="line" data-label="" points="447.56446991404016,256.8863419293219 258.75835721107927,192.70296084049664" fill="none" stroke="hsl(193, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="5.575,1.2 2.045,2.4" data-type="line" data-label="" points="447.56446991404016,267.5835721107927 258.75835721107927,203.40019102196752" fill="none" stroke="hsl(191, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="5.575,1 2.045,2.2" data-type="line" data-label="" points="447.56446991404016,278.2808022922636 258.75835721107927,214.0974212034384" fill="none" stroke="hsl(72, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="5.575,0.8 2.045,2" data-type="line" data-label="" points="447.56446991404016,288.97803247373446 258.75835721107927,224.79465138490926" fill="none" stroke="hsl(74, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="5.575,0.6 2.045,0.7" data-type="line" data-label="" points="447.56446991404016,299.67526265520536 258.75835721107927,294.3266475644699" fill="none" stroke="hsl(184, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="5.575,1.4 5.375,1.4 5.375,2.6 2.045,2.6" data-type="line" data-label="" points="447.56446991404016,256.8863419293219 436.86723973256926,256.8863419293219 436.86723973256926,192.70296084049664 258.75835721107927,192.70296084049664" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="5.575,1.2 3.81,1.2 3.81,2.4 2.045,2.4" data-type="line" data-label="" points="447.56446991404016,267.5835721107927 353.1614135625597,267.5835721107927 353.1614135625597,203.40019102196752 258.75835721107927,203.40019102196752" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="5.575,1 3.71,1 3.71,2.2 2.045,2.2" data-type="line" data-label="" points="447.56446991404016,278.2808022922636 347.81279847182424,278.2808022922636 347.81279847182424,214.0974212034384 258.75835721107927,214.0974212034384" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="5.575,0.8 2.245,0.8 2.245,2 2.045,2" data-type="line" data-label="" points="447.56446991404016,288.97803247373446 269.4555873925501,288.97803247373446 269.4555873925501,224.79465138490926 258.75835721107927,224.79465138490926" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="5.575,0.6 3.81,0.6 3.81,0.7 2.045,0.7" data-type="line" data-label="" points="447.56446991404016,299.67526265520536 353.1614135625597,299.67526265520536 353.1614135625597,294.3266475644699 258.75835721107927,294.3266475644699" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="U1" data-x="0" data-y="0" x="40" y="161.9484240687679" width="218.75835721107927" height="339.6370582617001" fill="hsl(164, 100%, 50%, 0.8)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="J4" data-x="7" data-y="-0.4" x="447.5644699140401" y="246.189111747851" width="152.43553008595984" height="213.94460362941737" fill="hsl(186, 100%, 50%, 0.8)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="TB67S579FTG" data-x="2.405" data-y="3.525" x="242.71251193887292" y="138.41451766953202" width="70.60171919770775" height="9.627507163323742" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="U1" data-x="1.865" data-y="3.29" x="239.50334288443167" y="149.11174785100286" width="19.25501432664757" height="13.371537726838596" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="J4" data-x="6.095" data-y="1.715" x="465.74976122254054" y="233.35243553008593" width="19.255014326647597" height="13.371537726838568" fill="rgba(160, 0, 220, 0.14)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="INLINE netId: OUT_A_P
+axis: x
+side: y+" data-x="3.71" data-y="2.71" x="330.69723018147084" y="183.6103151862464" width="34.23113658070679" height="6.418338108882523" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="INLINE netId: OUT_A_N
+axis: x
+side: y+" data-x="4.6925" data-y="1.31" x="383.24737344794653" y="258.4909264565425" width="34.231136580706846" height="6.418338108882551" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="INLINE netId: OUT_B_N
+axis: x
+side: y+" data-x="4.6425" data-y="1.11" x="380.5730659025787" y="269.18815663801337" width="34.231136580706846" height="6.4183381088824945" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="INLINE netId: OUT_B_P
+axis: x
+side: y+" data-x="3.91" data-y="0.91" x="341.39446036294174" y="279.8853868194842" width="34.23113658070679" height="6.418338108882551" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018696428571428572"/></g><g><rect data-type="rect" data-label="INLINE netId: SERIAL_IN
+axis: x
+side: y+" data-x="4.6925" data-y="0.71" x="378.9684813753582" y="290.5826170009551" width="42.788920725883486" height="6.4183381088824945" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.018696428571428572"/></g><text data-type="text" data-label="OUT_A_P" data-x="3.71" data-y="2.71" x="347.81279847182424" y="186.81948424068767" fill="green" font-size="6.418338108882521" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">OUT_A_P</text><text data-type="text" data-label="OUT_A_N" data-x="4.6925" data-y="1.31" x="400.3629417382999" y="261.7000955109838" fill="green" font-size="6.418338108882521" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">OUT_A_N</text><text data-type="text" data-label="OUT_B_N" data-x="4.6425" data-y="1.11" x="397.68863419293217" y="272.3973256924546" fill="green" font-size="6.418338108882521" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">OUT_B_N</text><text data-type="text" data-label="OUT_B_P" data-x="3.91" data-y="0.91" x="358.51002865329514" y="283.0945558739255" fill="green" font-size="6.418338108882521" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">OUT_B_P</text><text data-type="text" data-label="SERIAL_IN" data-x="4.6925" data-y="0.71" x="400.3629417382999" y="293.79178605539636" fill="green" font-size="6.418338108882521" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">SERIAL_IN</text><g><circle data-type="point" data-label="U1.4
+x+" data-x="2.045" data-y="2.6" cx="258.75835721107927" cy="192.70296084049664" r="3" fill="hsl(322, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.6
+x+" data-x="2.045" data-y="2.4" cx="258.75835721107927" cy="203.40019102196752" r="3" fill="hsl(324, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.7
+x+" data-x="2.045" data-y="2.2" cx="258.75835721107927" cy="214.0974212034384" r="3" fill="hsl(325, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.9
+x+" data-x="2.045" data-y="2" cx="258.75835721107927" cy="224.79465138490926" r="3" fill="hsl(327, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="U1.48
+x+" data-x="2.045" data-y="0.7" cx="258.75835721107927" cy="294.3266475644699" r="3" fill="hsl(318, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="J4.1
+x-" data-x="5.575" data-y="1.4" cx="447.56446991404016" cy="256.8863419293219" r="3" fill="hsl(221, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="J4.2
+x-" data-x="5.575" data-y="1.2" cx="447.56446991404016" cy="267.5835721107927" r="3" fill="hsl(222, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="J4.3
+x-" data-x="5.575" data-y="1" cx="447.56446991404016" cy="278.2808022922636" r="3" fill="hsl(223, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="J4.4
+x-" data-x="5.575" data-y="0.8" cx="447.56446991404016" cy="288.97803247373446" r="3" fill="hsl(224, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="J4.5
+x-" data-x="5.575" data-y="0.6" cx="447.56446991404016" cy="299.67526265520536" r="3" fill="hsl(225, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="inline anchor
+OUT_A_P" data-x="3.71" data-y="2.6" cx="347.81279847182424" cy="192.70296084049664" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
+OUT_A_N" data-x="4.6925" data-y="1.2" cx="400.3629417382999" cy="267.5835721107927" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
+OUT_B_N" data-x="4.6425" data-y="1" cx="397.68863419293217" cy="278.2808022922636" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
+OUT_B_P" data-x="3.91" data-y="0.8" cx="358.51002865329514" cy="288.97803247373446" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
+SERIAL_IN" data-x="4.6925" data-y="0.6" cx="400.3629417382999" cy="299.67526265520536" r="3" fill="green"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":53.48615090735434,"c":0,"e":149.37917860553964,"b":0,"d":-53.48615090735434,"f":331.76695319961794};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/solvers/InlineNetLabelSolver/fallback-net-label-width.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/fallback-net-label-width.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import type {
+  InputDirectConnection,
+  InputProblem,
+} from "lib/types/InputProblem"
+import "tests/fixtures/matcher"
+
+const inlineConnection = (
+  netId: string,
+  pinIds: [string, string],
+  fallbackNetLabelWidth: number,
+  inlineNetLabelWidth: number,
+): InputDirectConnection => ({
+  netId,
+  pinIds,
+  allowInlineNetLabel: true,
+  fallbackNetLabelWidth,
+  inlineNetLabelWidth,
+  inlineNetLabelHeight: 0.12,
+})
+
+const routedInputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "U1",
+      center: { x: 0, y: 0 },
+      width: 3.29,
+      height: 6.35,
+      sectionId: "driver",
+      pins: [
+        { pinId: "U1.4", x: 2.045, y: 2.6, _facingDirection: "x+" },
+        { pinId: "U1.6", x: 2.045, y: 2.4, _facingDirection: "x+" },
+        { pinId: "U1.7", x: 2.045, y: 2.2, _facingDirection: "x+" },
+        { pinId: "U1.9", x: 2.045, y: 2, _facingDirection: "x+" },
+        { pinId: "U1.48", x: 2.045, y: 0.7, _facingDirection: "x+" },
+      ],
+    },
+    {
+      chipId: "J4",
+      center: { x: 7, y: -0.4 },
+      width: 2.05,
+      height: 4,
+      sectionId: "driver",
+      pins: [
+        { pinId: "J4.1", x: 5.575, y: 1.4, _facingDirection: "x-" },
+        { pinId: "J4.2", x: 5.575, y: 1.2, _facingDirection: "x-" },
+        { pinId: "J4.3", x: 5.575, y: 1, _facingDirection: "x-" },
+        { pinId: "J4.4", x: 5.575, y: 0.8, _facingDirection: "x-" },
+        { pinId: "J4.5", x: 5.575, y: 0.6, _facingDirection: "x-" },
+      ],
+    },
+  ],
+  directConnections: [
+    inlineConnection("OUT_A_P", ["J4.1", "U1.4"], 0.96, 0.64),
+    inlineConnection("OUT_A_N", ["J4.2", "U1.6"], 0.96, 0.64),
+    inlineConnection("OUT_B_N", ["J4.3", "U1.7"], 0.96, 0.64),
+    inlineConnection("OUT_B_P", ["J4.4", "U1.9"], 0.96, 0.64),
+    inlineConnection("SERIAL_IN", ["J4.5", "U1.48"], 1.2, 0.8),
+  ],
+  netConnections: [],
+  textBoxes: [
+    {
+      chipId: "U1",
+      center: { x: 2.405, y: 3.525 },
+      width: 1.32,
+      height: 0.18,
+      text: "TB67S579FTG",
+    },
+    {
+      chipId: "U1",
+      center: { x: 1.865, y: 3.29 },
+      width: 0.36,
+      height: 0.25,
+      text: "U1",
+    },
+    {
+      chipId: "J4",
+      center: { x: 6.095, y: 1.715 },
+      width: 0.36,
+      height: 0.25,
+      text: "J4",
+    },
+  ],
+  availableNetLabelOrientations: {},
+  maxMspPairDistance: 20,
+}
+
+test("fallback label width does not split routable inline connections", () => {
+  const solver = new SchematicTracePipelineSolver(routedInputProblem)
+
+  solver.solve()
+
+  expect(solver.schematicTraceLinesSolver!.solvedTracePaths).toHaveLength(5)
+  expect(solver.schematicTraceLinesSolver!.failedConnectionPairs).toHaveLength(
+    0,
+  )
+
+  const output = solver.inlineNetLabelSolver!.getOutput()
+  expect(output.traces).toHaveLength(5)
+  expect(output.inlineNetLabelPlacements).toHaveLength(5)
+  expect(
+    output.inlineNetLabelPlacements.every(
+      (placement) => placement.stubTracePath === undefined,
+    ),
+  ).toBe(true)
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})
+
+test("fallback label width sizes anchored labels when routing is skipped", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: -3, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U1.1", x: -2.5, y: 0, _facingDirection: "x+" }],
+      },
+      {
+        chipId: "U2",
+        center: { x: 3, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U2.1", x: 2.5, y: 0, _facingDirection: "x-" }],
+      },
+    ],
+    directConnections: [
+      {
+        netId: "SIGNAL",
+        pinIds: ["U1.1", "U2.1"],
+        allowInlineNetLabel: true,
+        fallbackNetLabelWidth: 0.96,
+        inlineNetLabelWidth: 0.64,
+        inlineNetLabelHeight: 0.12,
+      },
+    ],
+    netConnections: [],
+    availableNetLabelOrientations: {},
+    maxMspPairDistance: 1,
+  }
+
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+  solver.solve()
+
+  const [fallbackPlacement] = solver.netLabelPlacementSolver!.netLabelPlacements
+  expect(fallbackPlacement).toBeDefined()
+  expect(Math.max(fallbackPlacement!.width, fallbackPlacement!.height)).toBe(
+    0.96,
+  )
+})


### PR DESCRIPTION

<img width="886" height="274" alt="Screenshot 2026-08-24 at 8 36 04 PM" src="https://github.com/user-attachments/assets/559e01ad-2b86-49f0-b4a1-702a88d6a7b5" />

## Summary

- add fallbackNetLabelWidth for the conventional anchored label used only when inline placement fails
- centralize net-label width lookup across placement and orientation stages
- explicitly exclude fallback-only width from trace-line routing decisions
- add a focused TB67S579FTG-derived regression proving five routable signals remain continuous

## Context

This is the prerequisite for tscircuit/core#3405. Core needs to provide the full rendered width of an AGC_OUT anchored fallback label so an unrelated GND trace can avoid it. Reusing netLabelWidth for that purpose also enlarged routing-time text padding and caused several right-side traces to fail and become paired terminal stubs.

The separate fallback field preserves the existing routed traces while giving anchored fallback placement and collision stages the correct geometry.

## Testing

- bun test: 205 pass, 4 existing skips, 0 fail
- bunx tsc --noEmit
- bun run build
- focused solver snapshot and semantic assertions for routed and fallback cases