### PR TITLE
Add display names for schematic solver ports

### DIFF
--- a/lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem.ts
+++ b/lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem.ts
@@ -44,7 +44,7 @@ export const visualizeInputProblem = (
 
     for (const pin of chip.pins) {
       graphics.points.push({
-        label: `${pin.pinId}\n${pin._facingDirection ?? getPinDirection(pin, chip)}`,
+        label: `${pin.displayName ?? pin.pinId}\n${pin._facingDirection ?? getPinDirection(pin, chip)}`,
         x: pin.x,
         y: pin.y,
         color: getColorFromString(pin.pinId, 0.8),

--- a/lib/types/InputProblem.ts
+++ b/lib/types/InputProblem.ts
@@ -8,6 +8,13 @@ export type SectionId = string
 
 export interface InputPin {
   pinId: PinId
+
+  /**
+   * User-facing label for this schematic port. `pinId` remains the stable,
+   * opaque routing identity and must not be shown in schematic output.
+   */
+  displayName?: string
+
   x: number
   y: number
 

--- a/tests/fixtures/convertSolverOutputToCircuitJson.test.ts
+++ b/tests/fixtures/convertSolverOutputToCircuitJson.test.ts
@@ -3,9 +3,11 @@ import {
   any_circuit_element,
   type SchematicPort,
   type SchematicTrace,
+  type SourcePort,
 } from "circuit-json"
 import { convertCircuitJsonToSchematicSvg } from "circuit-to-svg"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
+import { visualizeInputProblem } from "lib/solvers/SchematicTracePipelineSolver/visualizeInputProblem"
 import type { InputProblem } from "lib/types/InputProblem"
 import { convertSolverOutputToCircuitJson } from "./convertSolverOutputToCircuitJson"
 
@@ -17,7 +19,13 @@ const inputProblem: InputProblem = {
       width: 1,
       height: 1,
       pins: [
-        { pinId: "U1.1", x: 0.5, y: 0.2, _facingDirection: "x+" },
+        {
+          pinId: "U1.1",
+          displayName: "VCC",
+          x: 0.5,
+          y: 0.2,
+          _facingDirection: "x+",
+        },
         { pinId: "U1.2", x: 0.5, y: -0.2, _facingDirection: "x+" },
       ],
     },
@@ -42,6 +50,28 @@ const inputProblem: InputProblem = {
       pins: [
         { pinId: "LED1.1", x: 3.46, y: 0, _facingDirection: "x-" },
         { pinId: "LED1.2", x: 4.54, y: 0, _facingDirection: "x+" },
+      ],
+    },
+    {
+      chipId: "schematic_component_3",
+      center: { x: 6, y: 0 },
+      width: 2.2,
+      height: 1,
+      pins: [
+        {
+          pinId: "schematic_port_opaque_input",
+          displayName: "VIN",
+          x: 4.9,
+          y: 0,
+          _facingDirection: "x-",
+        },
+        {
+          pinId: "schematic_port_opaque_output",
+          displayName: "VOUT",
+          x: 7.1,
+          y: 0,
+          _facingDirection: "x+",
+        },
       ],
     },
   ],
@@ -120,6 +150,15 @@ class SnapshotTestSolver extends BaseSolver {
 
 test("solver snapshot Circuit JSON is semantic and omits the rats nest", () => {
   const circuitJson = convertSolverOutputToCircuitJson(new SnapshotTestSolver())
+  const inputGraphics = visualizeInputProblem(inputProblem)
+
+  expect(
+    inputGraphics.points?.find((point) => point.x === 4.9 && point.y === 0)
+      ?.label,
+  ).toBe("VIN\nx-")
+  expect(
+    inputGraphics.points?.some((point) => point.label?.includes("opaque")),
+  ).toBe(false)
 
   for (const element of circuitJson) {
     expect(any_circuit_element.safeParse(element).success).toBe(true)
@@ -127,7 +166,7 @@ test("solver snapshot Circuit JSON is semantic and omits the rats nest", () => {
 
   expect(
     circuitJson.filter((element) => element.type === "schematic_component"),
-  ).toHaveLength(3)
+  ).toHaveLength(4)
   const genericBoxComponent = circuitJson.find(
     (element) =>
       element.type === "schematic_component" &&
@@ -146,6 +185,20 @@ test("solver snapshot Circuit JSON is semantic and omits the rats nest", () => {
           genericBoxComponent.schematic_component_id,
     ),
   ).toMatchObject({ distance_from_component_edge: 0.4 })
+  expect(
+    circuitJson.find(
+      (element) =>
+        element.type === "source_port" &&
+        element.source_port_id === "source_port_0_0",
+    ),
+  ).toMatchObject({ name: "VCC", pin_number: 1 })
+  expect(
+    circuitJson.find(
+      (element) =>
+        element.type === "schematic_port" &&
+        element.source_port_id === "source_port_0_0",
+    ),
+  ).toMatchObject({ display_pin_label: "VCC", pin_number: 1 })
   expect(
     circuitJson.find(
       (element) =>
@@ -176,6 +229,15 @@ test("solver snapshot Circuit JSON is semantic and omits the rats nest", () => {
     size: { width: 1.13, height: 0.65 },
     symbol_name: "led_right",
   })
+  expect(
+    circuitJson
+      .filter(
+        (element): element is SourcePort =>
+          element.type === "source_port" &&
+          element.source_component_id === "source_component_3",
+      )
+      .map((sourcePort) => sourcePort.name),
+  ).toEqual(["VIN", "VOUT"])
 
   const capacitorPorts = circuitJson
     .filter(
@@ -216,4 +278,5 @@ test("solver snapshot Circuit JSON is semantic and omits the rats nest", () => {
   expect(svg).toContain('data-circuit-json-type="schematic_component"')
   expect(svg).toContain('data-circuit-json-type="schematic_trace"')
   expect(svg).toContain('data-circuit-json-type="schematic_net_label"')
+  expect(svg).not.toContain("schematic_port_opaque")
 })

--- a/tests/fixtures/convertSolverOutputToCircuitJson.ts
+++ b/tests/fixtures/convertSolverOutputToCircuitJson.ts
@@ -197,9 +197,17 @@ const getRefdes = (chip: InputChip) => {
 const getPinLabel = (pinId: string) =>
   pinId.includes(".") ? pinId.slice(pinId.indexOf(".") + 1) : pinId
 
-const getPinNumber = (pinId: string) => {
-  const label = getPinLabel(pinId)
-  return /^\d+$/.test(label) ? Number(label) : undefined
+const getPinDisplayName = (pin: InputPin) => {
+  if (pin.displayName !== undefined) return pin.displayName || undefined
+  return getPinLabel(pin.pinId)
+}
+
+const getPinNumber = (pin: InputPin) => {
+  const idLabel = getPinLabel(pin.pinId)
+  if (/^\d+$/.test(idLabel)) return Number(idLabel)
+  return pin.displayName && /^\d+$/.test(pin.displayName)
+    ? Number(pin.displayName)
+    : undefined
 }
 
 const getFacingDirection = (pin: InputPin, chip: InputChip): FacingDirection =>
@@ -258,8 +266,8 @@ const getDefaultSymbolBaseName = (refdes: string) => {
 
 const getPinsInNumberOrder = (chip: InputChip) =>
   [...chip.pins].sort((pinA, pinB) => {
-    const pinNumberA = getPinNumber(pinA.pinId)
-    const pinNumberB = getPinNumber(pinB.pinId)
+    const pinNumberA = getPinNumber(pinA)
+    const pinNumberB = getPinNumber(pinB)
     if (pinNumberA === undefined || pinNumberB === undefined) return 0
     return pinNumberA - pinNumberB
   })
@@ -452,10 +460,12 @@ const getSnapshotSymbolGeometry = (
 
   const unusedSymbolPorts = new Set(symbol.ports)
   const matches = chip.pins.map((pin) => {
-    const pinLabel = getPinLabel(pin.pinId)
-    const symbolPort = [...unusedSymbolPorts].find((port) =>
-      port.labels.includes(pinLabel),
-    )
+    const pinDisplayName = getPinDisplayName(pin)
+    const symbolPort = pinDisplayName
+      ? [...unusedSymbolPorts].find((port) =>
+          port.labels.includes(pinDisplayName),
+        )
+      : undefined
     if (symbolPort) unusedSymbolPorts.delete(symbolPort)
     return symbolPort ? { pin, symbolPort } : undefined
   })
@@ -836,8 +846,16 @@ export const convertSolverOutputToCircuitJson = (
       const schematicPortId = `schematic_port_${chipIndex}_${pinIndex}`
       const facingDirection = getFacingDirection(pin, chip)
       const sideOfComponent = facingDirectionToSide(facingDirection)
-      const pinLabel = getPinLabel(pin.pinId)
-      const pinNumber = getPinNumber(pin.pinId)
+      const pinDisplayName = getPinDisplayName(pin)
+      const pinNumber = getPinNumber(pin)
+      const displayPinLabel =
+        pin.displayName !== undefined
+          ? pin.displayName && !/^\d+$/.test(pin.displayName)
+            ? pin.displayName
+            : undefined
+          : pinNumber === undefined
+            ? pinDisplayName
+            : undefined
       const distanceFromComponentEdge = symbolName
         ? Math.min(
             0.2,
@@ -856,7 +874,7 @@ export const convertSolverOutputToCircuitJson = (
         type: "source_port",
         source_port_id: sourcePortId,
         source_component_id: sourceComponentId,
-        name: pinLabel,
+        name: pinDisplayName ?? `pin${pinNumber ?? pinIndex + 1}`,
         pin_number: pinNumber,
       } satisfies SourcePort)
 
@@ -872,7 +890,7 @@ export const convertSolverOutputToCircuitJson = (
         facing_direction: facingDirectionToCircuitJson(facingDirection),
         side_of_component: sideOfComponent,
         distance_from_component_edge: distanceFromComponentEdge,
-        display_pin_label: pinNumber === undefined ? pinLabel : undefined,
+        display_pin_label: displayPinLabel,
         pin_number: pinNumber,
       } satisfies SchematicPort)
 


### PR DESCRIPTION
## Summary

- add optional `InputPin.displayName` as the user-facing schematic-port label while keeping `pinId` as the opaque routing identity
- use `displayName` in the legacy input visualization and semantic Circuit JSON snapshot renderer
- preserve pin-number rendering and backward compatibility for existing inputs without `displayName`
- cover opaque schematic port IDs and verify they do not leak into rendered SVG output when a display name is provided

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`
- `bun test` (210 pass, 4 skip)
- `git diff --check`
