### PR TITLE
Hide rats nest in example51

### DIFF
--- a/site/components/PipelineDebugger.tsx
+++ b/site/components/PipelineDebugger.tsx
@@ -7,13 +7,15 @@ import { PipelineStageTable } from "./PipelineStageTable"
 
 export const PipelineDebugger = ({
   inputProblem,
+  hideRatsNet = false,
 }: {
   inputProblem: InputProblem
+  hideRatsNet?: boolean
 }) => {
   const [, incRenderCount] = useReducer((x) => x + 1, 0)
   const solver = useMemo(
-    () => new SchematicTracePipelineSolver(inputProblem),
-    [],
+    () => new SchematicTracePipelineSolver(inputProblem, { hideRatsNet }),
+    [inputProblem, hideRatsNet],
   )
 
   return (

--- a/site/examples/example51.page.tsx
+++ b/site/examples/example51.page.tsx
@@ -1,4 +1,6 @@
 import { PipelineDebugger } from "site/components/PipelineDebugger"
 import inputProblem from "../../tests/assets/example51.json"
 
-export default () => <PipelineDebugger inputProblem={inputProblem as any} />
+export default () => (
+  <PipelineDebugger inputProblem={inputProblem as any} hideRatsNet />
+)


### PR DESCRIPTION
## Summary

- allow `PipelineDebugger` pages to opt into hiding the input rats nest
- enable the option for `example51`

## Verification

- `bun test tests/examples/example51.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`