### PR TITLE
repro: normal net label branch starts at junction instead of label edge

### DIFF
--- a/tests/repros/__snapshots__/repro-normal-net-label-branch-from-junction.snap.svg
+++ b/tests/repros/__snapshots__/repro-normal-net-label-branch-from-junction.snap.svg
@@ -1,0 +1,93 @@
+<svg width="1200" height="2016" viewBox="0 0 1200 2016" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Solver debug visualization on top and Circuit JSON schematic on the bottom">
+  <g transform="translate(0, 0) scale(1.875, 1.875) translate(0, 0)">
+    <rect width="100%" height="100%" fill="white"/><g><polyline data-points="-6.7,-19 -4.7,-19" data-type="line" data-label="" points="261.6314199395772,335.8418017028289 569.2392199945072,335.8418017028289" fill="none" stroke="hsl(154, 100%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="4 2"/></g><g><polyline data-points="-6.7,-19 -6.5,-19 -6.5,-19.525 -4.5,-19.525 -4.5,-19 -4.7,-19" data-type="line" data-label="" points="261.6314199395772,335.8418017028289 292.39219994507016,335.8418017028289 292.39219994507016,416.588849217248 600.0000000000001,416.588849217248 600.0000000000001,335.8418017028289 569.2392199945072,335.8418017028289" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="-6.5,-19 -6.5,-19.05 -6.34,-19.05 -6.34,-18.749" data-type="line" data-label="" points="292.39219994507016,335.8418017028289 292.39219994507016,343.53199670420236 317.0008239494646,343.53199670420236 317.0008239494646,297.237022795935" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="R8" data-x="-7" data-y="-19" x="169.34907992309832" y="285.8555341939027" width="92.28234001647888" height="99.97253501785235" fill="hsl(78, 100%, 50%, 0.8)" stroke="black" stroke-width="0.006501785714285714"/></g><g><rect data-type="rect" data-label="R7" data-x="-5" data-y="-19" x="476.9568799780281" y="285.8555341939027" width="92.282340016479" height="99.97253501785235" fill="hsl(77, 100%, 50%, 0.8)" stroke="black" stroke-width="0.006501785714285714"/></g><g><rect data-type="rect" data-label="netId: U1_IO22
+globalConnNetId: connectivity_net1" data-x="-7.721" data-y="-19" x="40.00000000000034" y="303.54298269706123" width="129.1952760230704" height="64.59763801153531" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.006501785714285714"/></g><g><rect data-type="rect" data-label="netId: V3V3
+globalConnNetId: connectivity_net0" data-x="-6.34" data-y="-18.509" x="284.7020049436969" y="223.41115078275243" width="64.59763801153531" height="73.82587201318256" fill="#ef444466" stroke="#ef4444" stroke-width="0.006501785714285714"/></g><g><rect data-type="rect" data-label="netId: U1_IO21
+globalConnNetId: connectivity_net2" data-x="-5.801" data-y="-19" x="322.99917605053565" y="303.54298269706123" width="153.80390002746503" height="64.59763801153531" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.006501785714285714"/></g><g><circle data-type="point" data-label="R8.pin1
+x-" data-x="-7.3" data-y="-19" cx="169.34907992309832" cy="335.8418017028289" r="3" fill="hsl(140, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="R8.pin2
+x+" data-x="-6.7" data-y="-19" cx="261.6314199395772" cy="335.8418017028289" r="3" fill="hsl(141, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="R7.pin1
+x-" data-x="-5.3" data-y="-19" cx="476.95687997802816" cy="335.8418017028289" r="3" fill="hsl(349, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="R7.pin2
+x+" data-x="-4.7" data-y="-19" cx="569.2392199945072" cy="335.8418017028289" r="3" fill="hsl(350, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-7.3" data-y="-19" cx="169.34907992309832" cy="335.8418017028289" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="-6.34" data-y="-18.749" cx="317.0008239494646" cy="297.237022795935" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: x-" data-x="-5.3" data-y="-19" cx="476.95687997802816" cy="335.8418017028289" r="3" fill="hsl(40, 100%, 50%, 0.9)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":153.80390002746498,"c":0,"e":1292.1175501235925,"b":0,"d":-153.80390002746498,"f":-2586.4322988190056};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  <g transform="translate(0, 1216)">
+    <style>
+              .boundary { fill: rgb(245, 241, 237); }
+              .schematic-boundary { fill: none; stroke: #fff; }
+              .component { fill: none; stroke: rgb(132, 0, 0); }
+              .chip { fill: rgb(255, 255, 194); stroke: rgb(132, 0, 0); }
+              .component-pin { fill: none; stroke: rgb(132, 0, 0); }
+              .text { font-family: sans-serif; fill: rgb(0, 150, 0); }
+              .pin-number { fill: rgb(169, 0, 0); }
+              .port-label { fill: rgb(0, 100, 100); }
+              .component-name { fill: rgb(0, 100, 100); }
+
+            </style><rect class="boundary" x="0" y="0" width="1200" height="800"/><g class="trace sch-trace" data-layer="base" data-circuit-json-type="schematic_trace" data-schematic-trace-id="schematic_trace_0__stack1"><path d="M 500.98568079765005 434.0441155701001 L 551.8230858305501 434.0441155701001 L 551.8230858305501 567.4923037814624 L 1060.1971361595502 567.4923037814624 L 1060.1971361595502 434.0441155701001 L 1009.3597311266501 434.0441155701001" class="trace-invisible-hover-outline sch-trace-hitbox" stroke="rgb(0, 150, 0)" fill="none" stroke-width="40.669924026320004px" stroke-linecap="round" opacity="0" stroke-linejoin="round"/><path class="sch-trace-path" d="M 500.98568079765005 434.0441155701001 L 551.8230858305501 434.0441155701001 L 551.8230858305501 567.4923037814624 L 1060.1971361595502 567.4923037814624 L 1060.1971361595502 434.0441155701001 L 1009.3597311266501 434.0441155701001" stroke="rgb(0, 150, 0)" fill="none" stroke-width="5.0837405032900005px" stroke-linecap="round" stroke-linejoin="round"/></g><g class="trace sch-trace" data-layer="base" data-circuit-json-type="schematic_trace" data-schematic-trace-id="schematic_trace_1__stack1"><path d="M 551.8230858305501 434.0441155701001 L 551.8230858305501 446.75346682832514 L 592.49300985687 446.75346682832514 L 592.49300985687 370.24317225381037" class="trace-invisible-hover-outline sch-trace-hitbox" stroke="rgb(0, 150, 0)" fill="none" stroke-width="40.669924026320004px" stroke-linecap="round" opacity="0" stroke-linejoin="round"/><path class="sch-trace-path" d="M 551.8230858305501 434.0441155701001 L 551.8230858305501 446.75346682832514 L 592.49300985687 446.75346682832514 L 592.49300985687 370.24317225381037" stroke="rgb(0, 150, 0)" fill="none" stroke-width="5.0837405032900005px" stroke-linecap="round" stroke-linejoin="round"/></g><g class="trace-overlays sch-trace-overlays" data-layer="overlay" data-circuit-json-type="schematic_trace" data-schematic-trace-id="schematic_trace_0__stack1"><circle cx="551.8230858305501" cy="434.0441155701001" r="7.625610754935" class="trace-junction sch-trace-junction" fill="rgb(0, 150, 0)"/></g><g class="trace-overlays sch-trace-overlays" data-layer="overlay" data-circuit-json-type="schematic_trace" data-schematic-trace-id="schematic_trace_1__stack1"/><g class="sch-component" data-circuit-json-type="schematic_component" data-schematic-component-id="schematic_component_0__stack1"><rect class="component-overlay sch-component-overlay" x="348.4734656989501" y="413.7142372974434" width="152.51221509869993" height="40.65975654531337" fill="transparent"/><path class="sch-component-symbol-path" d="M 348.4734656989501 434.0441155701001 L 373.8972519559034 434.0441155701001" stroke="rgb(132, 0, 0)" fill="none" stroke-width="5.0837405032900005px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 475.56189454069676 434.0441155701001 L 500.98568079765005 434.0441155701001" stroke="rgb(132, 0, 0)" fill="none" stroke-width="5.0837405032900005px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 373.8972519559034 413.7142372974434 L 475.56189454069676 413.7142372974434 L 475.56189454069676 454.37399384275676 L 373.8972519559034 454.37399384275676 L 373.8972519559034 413.7142372974434" stroke="rgb(132, 0, 0)" fill="none" stroke-width="5.0837405032900005px" stroke-linecap="round"/><text class="sch-component-name sch-component-text" x="424.7295732483001" y="393.3741915437801" stroke="rgb(245, 241, 237)" stroke-width="5.0837405032900005px" paint-order="stroke" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="middle" dominant-baseline="ideographic" font-size="45.75366452961px">R8</text><text class="sch-component-text" x="424.7295732483001" y="474.71403959642004" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="middle" dominant-baseline="hanging" font-size="45.75366452961px"></text><circle class="component-pin sch-component-pin" cx="348.4734656989501" cy="434.0441155701001" r="5.0837405032900005px" stroke-width="5.0837405032900005px" fill="none" stroke="rgb(132, 0, 0)"/></g><g class="sch-component" data-circuit-json-type="schematic_component" data-schematic-component-id="schematic_component_1__stack1"><rect class="component-overlay sch-component-overlay" x="856.8475160279502" y="413.7142372974434" width="152.51221509869993" height="40.65975654531337" fill="transparent"/><path class="sch-component-symbol-path" d="M 856.8475160279502 434.0441155701001 L 882.2713022849034 434.0441155701001" stroke="rgb(132, 0, 0)" fill="none" stroke-width="5.0837405032900005px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 983.9359448696969 434.0441155701001 L 1009.3597311266501 434.0441155701001" stroke="rgb(132, 0, 0)" fill="none" stroke-width="5.0837405032900005px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 882.2713022849034 413.7142372974434 L 983.9359448696969 413.7142372974434 L 983.9359448696969 454.37399384275676 L 882.2713022849034 454.37399384275676 L 882.2713022849034 413.7142372974434" stroke="rgb(132, 0, 0)" fill="none" stroke-width="5.0837405032900005px" stroke-linecap="round"/><text class="sch-component-name sch-component-text" x="933.1036235773001" y="393.3741915437801" stroke="rgb(245, 241, 237)" stroke-width="5.0837405032900005px" paint-order="stroke" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="middle" dominant-baseline="ideographic" font-size="45.75366452961px">R7</text><text class="sch-component-text" x="933.1036235773001" y="474.71403959642004" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="middle" dominant-baseline="hanging" font-size="45.75366452961px"></text><circle class="component-pin sch-component-pin" cx="856.8475160279502" cy="434.0441155701001" r="5.0837405032900005px" stroke-width="5.0837405032900005px" fill="none" stroke="rgb(132, 0, 0)"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_0_0__stack1"><circle cx="348.4734656989501" cy="434.0441155701001" r="10.167481006580001" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_0_1__stack1"><circle cx="500.98568079765005" cy="434.0441155701001" r="10.167481006580001" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_1_0__stack1"><circle cx="856.8475160279502" cy="434.0441155701001" r="10.167481006580001" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_1_1__stack1"><circle cx="1009.3597311266501" cy="434.0441155701001" r="10.167481006580001" fill="red" opacity="0"/></g><path class="net-label sch-net-label" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_0__stack1" d="
+    M 348.4734656989501,434.0441155701001
+    L 334.7473663400671,459.4628180865501
+    L 127.09351258234827,459.46281808655004
+    L 127.09351258234827,408.62541305365005
+    L 334.7473663400671,408.62541305365005
+    Z
+  " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="5.0837405032900005px"/><text class="net-label-text sch-net-label-text" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_0__stack1" x="325.59663343414513" y="434.0441155701001" fill="rgb(132, 0, 0)" text-anchor="end" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="45.75366452961px" transform="">U1_IO22</text><path class="net-label sch-net-label" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_1__stack1" d="
+    M 592.49300985687,370.24317225381037
+    L 567.07430734042,356.51707289492737
+    L 567.07430734042,219.79834495978162
+    L 617.91171237332,219.79834495978162
+    L 617.91171237332,356.51707289492737
+    Z
+  " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="5.0837405032900005px"/><text class="net-label-text sch-net-label-text" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_1__stack1" x="592.49300985687" y="347.3663399890054" fill="rgb(132, 0, 0)" text-anchor="start" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="45.75366452961px" transform="rotate(-90 592.49300985687 347.3663399890054)">V3V3</text><path class="net-label sch-net-label" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_2__stack1" d="
+    M 856.8475160279502,434.0441155701001
+    L 843.1214166690672,459.4628180865501
+    L 635.4675629113483,459.46281808655004
+    L 635.4675629113483,408.62541305365005
+    L 843.1214166690672,408.62541305365005
+    Z
+  " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="5.0837405032900005px"/><text class="net-label-text sch-net-label-text" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_2__stack1" x="833.9706837631452" y="434.0441155701001" fill="rgb(132, 0, 0)" text-anchor="end" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="45.75366452961px" transform="">U1_IO21</text>
+  </g>
+</svg>

--- a/tests/repros/repro-normal-net-label-branch-from-junction.test.ts
+++ b/tests/repros/repro-normal-net-label-branch-from-junction.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import "tests/fixtures/matcher"
+
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "R8",
+      center: { x: -7, y: -19 },
+      width: 0.6,
+      height: 0.65,
+      pins: [
+        { pinId: "R8.pin1", x: -7.3, y: -19, _facingDirection: "x-" },
+        { pinId: "R8.pin2", x: -6.7, y: -19, _facingDirection: "x+" },
+      ],
+    },
+    {
+      chipId: "R7",
+      center: { x: -5, y: -19 },
+      width: 0.6,
+      height: 0.65,
+      pins: [
+        { pinId: "R7.pin1", x: -5.3, y: -19, _facingDirection: "x-" },
+        { pinId: "R7.pin2", x: -4.7, y: -19, _facingDirection: "x+" },
+      ],
+    },
+  ],
+  directConnections: [],
+  netConnections: [
+    {
+      netId: "V3V3",
+      netLabelText: "V3V3",
+      pinIds: ["R8.pin2", "R7.pin2"],
+      netLabelWidth: 0.48,
+      netLabelHeight: 0.42,
+    },
+    {
+      netId: "U1_IO22",
+      netLabelText: "U1_IO22",
+      pinIds: ["R8.pin1"],
+      netLabelWidth: 0.84,
+      netLabelHeight: 0.42,
+    },
+    {
+      netId: "U1_IO21",
+      netLabelText: "U1_IO21",
+      pinIds: ["R7.pin1"],
+      netLabelWidth: 1,
+      netLabelHeight: 0.42,
+    },
+  ],
+  availableNetLabelOrientations: {
+    V3V3: ["y+"],
+    U1_IO22: ["x-"],
+    U1_IO21: ["x-"],
+  },
+  maxMspPairDistance: 2.4,
+}
+
+test("repro: V3V3 net-label branch does not start at the R8 edge", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem)
+
+  solver.solve()
+
+  expect(
+    solver.netLabelNetLabelCollisionSolver!.getOutput().netLabelPlacements,
+  ).not.toHaveLength(0)
+  expect(
+    solver.inlineNetLabelSolver!.getOutput().inlineNetLabelPlacements,
+  ).toHaveLength(0)
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
Reproduce the V3V3 net-label branch incorrectly growing from an interior junction instead of directly from R8’s edge.

ref img : 
<img width="551" height="243" alt="image" src="https://github.com/user-attachments/assets/eb30a635-bb95-4f09-9a0e-abe5eaf00884" />
