### PR TITLE
Repro PMP11282 stacked endpoint chip detour

### DIFF
--- a/tests/repros/__snapshots__/repro-pmp11282-same-facing-endpoint-chip-detour.snap.svg
+++ b/tests/repros/__snapshots__/repro-pmp11282-same-facing-endpoint-chip-detour.snap.svg
@@ -1,0 +1,66 @@
+<svg width="1200" height="2016" viewBox="0 0 1200 2016" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Solver debug visualization on top and Circuit JSON schematic on the bottom">
+  <g transform="translate(0, 0) scale(1.875, 1.875) translate(0, 0)">
+    <rect width="100%" height="100%" fill="white"/><g><polyline data-points="3.65,4.477125 3.4675,2.305375" data-type="line" data-label="" points="312.62393230621853,75.76275245469787 279.9904206913068,464.1015406721482" fill="none" stroke="hsl(208, 100%, 50%, 0.1)" stroke-width="1px"/></g><g><polyline data-points="3.65,4.477125 3.65,4.677125 3.4675,4.677125 3.4675,2.305375" data-type="line" data-label="" points="312.62393230621853,75.76275245469787 312.62393230621853,40 279.9904206913068,40 279.9904206913068,464.1015406721482" fill="none" stroke="red" stroke-width="1px" stroke-dasharray="4 4"/></g><g><polyline data-points="3.65,4.477125 3.4675,2.305375" data-type="line" data-label="" points="312.62393230621853,75.76275245469787 279.9904206913068,464.1015406721482" fill="none" stroke="blue" stroke-width="1px" stroke-dasharray="5 5"/></g><g><rect data-type="rect" data-label="C510" data-x="3.7825" data-y="4.097125" x="232.15773928314843" y="75.76275245469793" width="208.318033048615" height="135.8984593278518" fill="hsl(97, 100%, 50%, 0.1)" stroke="black" stroke-width="0.005592410714285715"/></g><g><rect data-type="rect" data-label="C517" data-x="3.6" data-y="1.925375" x="199.52422766823673" y="464.10154067214813" width="208.3180330486149" height="135.8984593278518" fill="hsl(104, 100%, 50%, 0.1)" stroke="black" stroke-width="0.005592410714285715"/></g><g><circle data-type="point" data-label="C510.pin1
+y+" data-x="3.65" data-y="4.477125" cx="312.62393230621853" cy="75.76275245469787" r="3" fill="hsl(129, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C510.pin2
+y-" data-x="3.65" data-y="3.717125" cx="312.62393230621853" cy="211.6612117825498" r="3" fill="hsl(130, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C517.pin1
+y+" data-x="3.4675" data-y="2.305375" cx="279.9904206913068" cy="464.1015406721482" r="3" fill="hsl(106, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="C517.pin2
+y-" data-x="3.4675" data-y="1.545375" cx="279.9904206913068" cy="600" r="3" fill="hsl(107, 100%, 50%, 0.8)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":178.81376227348926,"c":0,"e":-340.0462999920172,"b":0,"d":-178.81376227348926,"f":876.3343178733935};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  <g transform="translate(0, 1216)">
+    <style>
+              .boundary { fill: rgb(245, 241, 237); }
+              .schematic-boundary { fill: none; stroke: #fff; }
+              .component { fill: none; stroke: rgb(132, 0, 0); }
+              .chip { fill: rgb(255, 255, 194); stroke: rgb(132, 0, 0); }
+              .component-pin { fill: none; stroke: rgb(132, 0, 0); }
+              .text { font-family: sans-serif; fill: rgb(0, 150, 0); }
+              .pin-number { fill: rgb(169, 0, 0); }
+              .port-label { fill: rgb(0, 100, 100); }
+              .component-name { fill: rgb(0, 100, 100); }
+
+            </style><rect class="boundary" x="0" y="0" width="1200" height="800"/><g class="sch-component" data-circuit-json-type="schematic_component" data-schematic-component-id="schematic_component_0__stack1"><rect class="component-overlay sch-component-overlay" x="578.4223149997358" y="100.68372965446312" width="78.49148665819826" height="147.15314334120404" fill="transparent"/><path class="sch-component-symbol-path" d="M 617.668058328835 247.83687299566716 L 617.668058328835 188.97561565918554" stroke="rgb(132, 0, 0)" fill="none" stroke-width="3.872451140558px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 617.668058328835 159.54498699094475 L 617.668058328835 100.68372965446312" stroke="rgb(132, 0, 0)" fill="none" stroke-width="3.872451140558px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 656.9138016579341 188.97561565918554 L 578.4223149997358 188.97561565918554" stroke="rgb(132, 0, 0)" fill="none" stroke-width="3.872451140558px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 656.9138016579341 159.54498699094475 L 578.4223149997358 159.54498699094475" stroke="rgb(132, 0, 0)" fill="none" stroke-width="3.872451140558px" stroke-linecap="round"/><text class="sch-component-name sch-component-text" x="645.8724108025657" y="125.2092535446638" stroke="rgb(245, 241, 237)" stroke-width="3.872451140558px" paint-order="stroke" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="start" dominant-baseline="ideographic" font-size="34.852060265022px">C510</text><text class="sch-component-text" x="645.8724108025657" y="223.3113491054665" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="start" dominant-baseline="hanging" font-size="34.852060265022px"></text><circle class="component-pin sch-component-pin" cx="617.668058328835" cy="100.68372965446312" r="3.872451140558px" stroke-width="3.872451140558px" fill="none" stroke="rgb(132, 0, 0)"/><circle class="component-pin sch-component-pin" cx="617.668058328835" cy="247.83687299566716" r="3.872451140558px" stroke-width="3.872451140558px" fill="none" stroke="rgb(132, 0, 0)"/></g><g class="sch-component" data-circuit-json-type="schematic_component" data-schematic-component-id="schematic_component_1__stack1"><rect class="component-overlay sch-component-overlay" x="543.086198342144" y="521.183517879805" width="78.49148665819826" height="147.153143341204" fill="transparent"/><path class="sch-component-symbol-path" d="M 582.3319416712432 668.336661221009 L 582.3319416712432 609.4754038845274" stroke="rgb(132, 0, 0)" fill="none" stroke-width="3.872451140558px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 582.3319416712432 580.0447752162866 L 582.3319416712432 521.183517879805" stroke="rgb(132, 0, 0)" fill="none" stroke-width="3.872451140558px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 621.5776850003423 609.4754038845274 L 543.086198342144 609.4754038845274" stroke="rgb(132, 0, 0)" fill="none" stroke-width="3.872451140558px" stroke-linecap="round"/><path class="sch-component-symbol-path" d="M 621.5776850003423 580.0447752162866 L 543.086198342144 580.0447752162866" stroke="rgb(132, 0, 0)" fill="none" stroke-width="3.872451140558px" stroke-linecap="round"/><text class="sch-component-name sch-component-text" x="610.5362941449739" y="545.7090417700056" stroke="rgb(245, 241, 237)" stroke-width="3.872451140558px" paint-order="stroke" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="start" dominant-baseline="ideographic" font-size="34.852060265022px">C517</text><text class="sch-component-text" x="610.5362941449739" y="643.8111373308084" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="start" dominant-baseline="hanging" font-size="34.852060265022px"></text><circle class="component-pin sch-component-pin" cx="582.3319416712432" cy="521.183517879805" r="3.872451140558px" stroke-width="3.872451140558px" fill="none" stroke="rgb(132, 0, 0)"/><circle class="component-pin sch-component-pin" cx="582.3319416712432" cy="668.336661221009" r="3.872451140558px" stroke-width="3.872451140558px" fill="none" stroke="rgb(132, 0, 0)"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_0_0__stack1"><circle cx="617.668058328835" cy="116.1735342166952" r="7.744902281116" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_0_1__stack1"><circle cx="617.668058328835" cy="263.3266775578993" r="7.744902281116" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_1_0__stack1"><circle cx="582.3319416712432" cy="536.673322442037" r="7.744902281116" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_1_1__stack1"><circle cx="582.3319416712432" cy="683.826465783241" r="7.744902281116" fill="red" opacity="0"/></g>
+  </g>
+</svg>

--- a/tests/repros/repro-pmp11282-same-facing-endpoint-chip-detour.test.ts
+++ b/tests/repros/repro-pmp11282-same-facing-endpoint-chip-detour.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import type { MspConnectionPair } from "lib/solvers/MspConnectionPairSolver/MspConnectionPairSolver"
+import { SchematicTraceSingleLineSolver2 } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/SchematicTraceSingleLineSolver2"
+import type { InputChip, InputProblem } from "lib/types/InputProblem"
+import "tests/fixtures/matcher"
+
+const upperCapacitor: InputChip = {
+  chipId: "C510",
+  center: { x: 3.7825, y: 4.097125 },
+  width: 1.165,
+  height: 0.76,
+  pins: [
+    {
+      pinId: "C510.pin1",
+      x: 3.65,
+      y: 4.477125,
+      _facingDirection: "y+",
+    },
+    {
+      pinId: "C510.pin2",
+      x: 3.65,
+      y: 3.717125,
+      _facingDirection: "y-",
+    },
+  ],
+}
+
+const lowerCapacitor: InputChip = {
+  chipId: "C517",
+  center: { x: 3.6, y: 1.925375 },
+  width: 1.165,
+  height: 0.76,
+  pins: [
+    {
+      pinId: "C517.pin1",
+      x: 3.4675,
+      y: 2.305375,
+      _facingDirection: "y+",
+    },
+    {
+      pinId: "C517.pin2",
+      x: 3.4675,
+      y: 1.545375,
+      _facingDirection: "y-",
+    },
+  ],
+}
+
+const pins: MspConnectionPair["pins"] = [
+  { ...upperCapacitor.pins[0]!, chipId: upperCapacitor.chipId },
+  { ...lowerCapacitor.pins[0]!, chipId: lowerCapacitor.chipId },
+]
+
+const connectionPair: MspConnectionPair = {
+  mspPairId: "C510.pin1-C517.pin1",
+  dcConnNetId: "C517.pin1 to C510.pin1",
+  globalConnNetId: "C517.pin1 to C510.pin1",
+  userNetId: "C517.pin1 to C510.pin1",
+  pins,
+}
+
+const inputProblem: InputProblem = {
+  chips: [upperCapacitor, lowerCapacitor],
+  directConnections: [
+    {
+      netId: "C517.pin1 to C510.pin1",
+      pinIds: [pins[0].pinId, pins[1].pinId],
+    },
+  ],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+test("PMP11282 same-facing pins fail to detour around the endpoint chip", () => {
+  const solver = new SchematicTraceSingleLineSolver2({
+    pins,
+    connectionPair,
+    inputProblem,
+    chipMap: {
+      [upperCapacitor.chipId]: upperCapacitor,
+      [lowerCapacitor.chipId]: lowerCapacitor,
+    },
+    preferExteriorDetours: true,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(false)
+  expect(solver.failed).toBe(true)
+  expect(solver.error).toBe("No collision-free path found")
+  expect(solver.solvedTracePath).toBeNull()
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- isolate the PMP11282 C510.pin1 to C517.pin1 routing failure
- preserve the original component dimensions, relative placement, and pin directions
- add an SVG snapshot showing the explicit direct trace missing when its terminal escape crosses the opposite endpoint chip

## Validation
- bun test tests/repros/repro-pmp11282-same-facing-endpoint-chip-detour.test.ts
- bunx tsc --noEmit

This is the reproduction base for the stacked routing fix.