### PR TITLE
test(solvers): add x+ orientation assertion to getAnchoredNetLabelRenderedBounds test

### DIFF
--- a/tests/solvers/InlineNetLabelSolver/get-anchored-net-label-rendered-bounds.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/get-anchored-net-label-rendered-bounds.test.ts
@@ -25,6 +25,18 @@ test("uses the horizontal renderer envelope for x-facing labels", () => {
   expect(horizontalBounds.minY).toBeCloseTo(2.9)
   expect(horizontalBounds.maxY).toBeCloseTo(3.1)
 
+  const horizontalPlusBounds = getAnchoredNetLabelRenderedBounds(
+    createPlacement({
+      orientation: "x+",
+      anchorPoint: { x: 2, y: 3 },
+      center: { x: 2.21, y: 3 },
+    }),
+  )
+  expect(horizontalPlusBounds.minX).toBeCloseTo(2)
+  expect(horizontalPlusBounds.maxX).toBeCloseTo(3.2)
+  expect(horizontalPlusBounds.minY).toBeCloseTo(2.9)
+  expect(horizontalPlusBounds.maxY).toBeCloseTo(3.1)
+
   const verticalBounds = getAnchoredNetLabelRenderedBounds(
     createPlacement({
       orientation: "y+",
@@ -37,3 +49,4 @@ test("uses the horizontal renderer envelope for x-facing labels", () => {
   expect(verticalBounds.minY).toBeCloseTo(3)
   expect(verticalBounds.maxY).toBeCloseTo(4.2)
 })
+

--- a/tests/solvers/InlineNetLabelSolver/get-anchored-net-label-rendered-bounds.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/get-anchored-net-label-rendered-bounds.test.ts
@@ -49,4 +49,3 @@ test("uses the horizontal renderer envelope for x-facing labels", () => {
   expect(verticalBounds.minY).toBeCloseTo(3)
   expect(verticalBounds.maxY).toBeCloseTo(4.2)
 })
-


### PR DESCRIPTION
### Summary of Changes
- Adds explicit unit test coverage for `x+` orientation in `getAnchoredNetLabelRenderedBounds.test.ts`.
- Verifies that horizontal tags facing rightwards properly compute their bounding box starting from the anchor point to the right extent.

### Test Validation
- `bun test tests/solvers/InlineNetLabelSolver/get-anchored-net-label-rendered-bounds.test.ts`: **1/1 passed (12 assertions, 0 failures in 0.19ms)**.
- Full workspace test suite: **189 tests passed cleanly**.