### PR TITLE
fix: prevent color hash overflow

### DIFF
--- a/lib/utils/getColorFromString.ts
+++ b/lib/utils/getColorFromString.ts
@@ -1,7 +1,13 @@
 export const getColorFromString = (string: string, alpha = 1) => {
   // pseudo random number from string
-  const hash = string.split("").reduce((acc, char) => {
-    return acc * 31 + char.charCodeAt(0)
-  }, 0)
+  let hash = 0
+  let useModuloHash = false
+
+  for (const char of string.split("")) {
+    if (hash >= Number.MAX_VALUE / 31) useModuloHash = true
+    if (useModuloHash) hash %= 360
+    hash = hash * 31 + char.charCodeAt(0)
+  }
+
   return `hsl(${hash % 360}, 100%, 50%, ${alpha})`
 }

--- a/tests/functions/getColorFromString.test.ts
+++ b/tests/functions/getColorFromString.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { getColorFromString } from "lib/utils/getColorFromString"
+
+const getHue = (color: string) => {
+  const hue = Number(color.match(/^hsl\((\d+),/)?.[1])
+  expect(Number.isFinite(hue)).toBe(true)
+  return hue
+}
+
+test("returns a valid hue for strings whose hash would overflow", () => {
+  const hue = getHue(getColorFromString("n".repeat(300)))
+
+  expect(hue).toBeGreaterThanOrEqual(0)
+  expect(hue).toBeLessThan(360)
+})
+
+test("keeps long-string colors deterministic and distinguishable", () => {
+  const prefix = "global-connection-".repeat(1_000)
+  const firstColor = getColorFromString(`${prefix}a`, 0.35)
+  const secondColor = getColorFromString(`${prefix}b`, 0.35)
+
+  expect(getColorFromString(`${prefix}a`, 0.35)).toBe(firstColor)
+  expect(getHue(firstColor)).toBeLessThan(360)
+  expect(getHue(secondColor)).toBeLessThan(360)
+  expect(firstColor).not.toBe(secondColor)
+})
+
+test("preserves colors for ordinary identifiers", () => {
+  expect(getColorFromString("U1.13-RFSET.1")).toBe("hsl(328, 100%, 50%, 1)")
+  expect(getColorFromString("net0", 0.75)).toBe("hsl(195, 100%, 50%, 0.75)")
+})


### PR DESCRIPTION
## Summary

- switch to bounded modulo hashing before the numeric accumulator can overflow
- preserve existing color results for ordinary identifiers
- keep long identifiers deterministic and distinguishable
- add regression coverage for the reported 300-character input

Closes #651

## Verification

- bun test tests/functions/getColorFromString.test.ts
- bunx tsc --noEmit
- bun run format:check
- bun test (170 passed, 4 skipped)