### PR TITLE
test(solver): add two-pin terminal stub routing validation test

### DIFF
--- a/tests/solvers/InlineNetLabelSolver/get-anchored-net-label-rendered-bounds.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/get-anchored-net-label-rendered-bounds.test.ts
@@ -36,4 +36,16 @@ test("uses the horizontal renderer envelope for x-facing labels", () => {
   expect(verticalBounds.maxX).toBeCloseTo(2.21)
   expect(verticalBounds.minY).toBeCloseTo(3)
   expect(verticalBounds.maxY).toBeCloseTo(4.2)
+
+  const verticalDownBounds = getAnchoredNetLabelRenderedBounds(
+    createPlacement({
+      orientation: "y-",
+      anchorPoint: { x: 2, y: 3 },
+      center: { x: 2, y: 2.4 },
+    }),
+  )
+  expect(verticalDownBounds.minX).toBeCloseTo(1.79)
+  expect(verticalDownBounds.maxX).toBeCloseTo(2.21)
+  expect(verticalDownBounds.minY).toBeCloseTo(1.8)
+  expect(verticalDownBounds.maxY).toBeCloseTo(3)
 })

--- a/tests/solvers/InlineNetLabelSolver/opposite-side-placement.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/opposite-side-placement.test.ts
@@ -69,3 +69,64 @@ test("an inline label tries the opposite side when the preferred side is blocked
   expect(solver.inlineNetLabelPlacements[0]!.side).toBe("y-")
   expect(solver.inlineNetLabelPlacements[0]!.center.y).toBeLessThan(0)
 })
+
+test("an inline label uses preferred side when no obstacle is present", () => {
+  const inputProblem: InputProblem = {
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: -2, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U1.1", x: -1.5, y: 0 }],
+      },
+      {
+        chipId: "U2",
+        center: { x: 2, y: 0 },
+        width: 1,
+        height: 1,
+        pins: [{ pinId: "U2.1", x: 1.5, y: 0 }],
+      },
+    ],
+    directConnections: [
+      {
+        netId: "SIGNAL",
+        pinIds: ["U1.1", "U2.1"],
+        allowInlineNetLabel: true,
+        inlineNetLabelWidth: 0.8,
+        inlineNetLabelHeight: 0.12,
+      },
+    ],
+    netConnections: [],
+    textBoxes: [],
+    availableNetLabelOrientations: { SIGNAL: ["x-", "x+"] },
+  }
+  const trace: SolvedTracePath = {
+    mspPairId: "U1.1-U2.1",
+    mspConnectionPairIds: ["U1.1-U2.1"],
+    dcConnNetId: "SIGNAL",
+    globalConnNetId: "SIGNAL",
+    userNetId: "SIGNAL",
+    pins: [
+      { pinId: "U1.1", chipId: "U1", x: -1.5, y: 0 },
+      { pinId: "U2.1", chipId: "U2", x: 1.5, y: 0 },
+    ],
+    pinIds: ["U1.1", "U2.1"],
+    tracePath: [
+      { x: -1.5, y: 0 },
+      { x: 1.5, y: 0 },
+    ],
+  }
+
+  const solver = new InlineNetLabelSolver({
+    inputProblem,
+    traces: [trace],
+    netLabelPlacements: [],
+  })
+  solver.solve()
+
+  expect(solver.inlineNetLabelPlacements).toHaveLength(1)
+  expect(solver.inlineNetLabelPlacements[0]!.side).toBe("y+")
+  expect(solver.inlineNetLabelPlacements[0]!.center.y).toBeGreaterThan(0)
+})
+

--- a/tests/solvers/InlineNetLabelSolver/opposite-side-placement.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/opposite-side-placement.test.ts
@@ -129,4 +129,3 @@ test("an inline label uses preferred side when no obstacle is present", () => {
   expect(solver.inlineNetLabelPlacements[0]!.side).toBe("y+")
   expect(solver.inlineNetLabelPlacements[0]!.center.y).toBeGreaterThan(0)
 })
-

--- a/tests/solvers/InlineNetLabelSolver/two-pin-terminal-stubs-atomic.test.ts
+++ b/tests/solvers/InlineNetLabelSolver/two-pin-terminal-stubs-atomic.test.ts
@@ -80,5 +80,8 @@ test("two-pin terminal stubs fall back atomically when one endpoint is obstructe
   solver.solve()
 
   expect(solver.inlineNetLabelPlacements).toHaveLength(0)
-  expect(solver.getOutput().netLabelPlacements).toHaveLength(2)
+  const outputPlacements = solver.getOutput().netLabelPlacements
+  expect(outputPlacements).toHaveLength(2)
+  expect(outputPlacements[0]!.pinIds).toEqual(["U1.1"])
+  expect(outputPlacements[1]!.pinIds).toEqual(["U2.1"])
 })


### PR DESCRIPTION
### Summary
- InlineNetLabelSolver two-pin terminal stub assertions.
- `bun test`: 4/4 passed.