### PR TITLE
fix: handle empty problem in ChipObstacleSpatialIndex (#657)

### DIFF
--- a/lib/data-structures/ChipObstacleSpatialIndex.ts
+++ b/lib/data-structures/ChipObstacleSpatialIndex.ts
@@ -10,7 +10,10 @@ export interface SpatiallyIndexedChip extends InputChip {
 
 export class ChipObstacleSpatialIndex {
   chips: Array<SpatiallyIndexedChip>
-  spatialIndex: Flatbush
+  // Null when there are no chips to index: Flatbush throws on a zero-item
+  // index ("Unexpected numItems value: 0"), so an empty problem is
+  // represented as the absence of an index rather than an empty one.
+  spatialIndex: Flatbush | null
   spatialIndexIdToChip: Map<number, SpatiallyIndexedChip>
 
   constructor(chips: InputChip[]) {
@@ -21,7 +24,13 @@ export class ChipObstacleSpatialIndex {
     }))
 
     this.spatialIndexIdToChip = new Map()
-    this.spatialIndex = new Flatbush(chips.length)
+
+    if (this.chips.length === 0) {
+      this.spatialIndex = null
+      return
+    }
+
+    this.spatialIndex = new Flatbush(this.chips.length)
 
     for (const chip of this.chips) {
       chip.spatialIndexId = this.spatialIndex.add(
@@ -37,6 +46,8 @@ export class ChipObstacleSpatialIndex {
   }
 
   getChipsInBounds(bounds: Bounds): Array<InputChip & { bounds: Bounds }> {
+    if (!this.spatialIndex) return []
+
     const chipSpatialIndexIds = this.spatialIndex.search(
       bounds.minX,
       bounds.minY,

--- a/tests/repros/empty-input.test.ts
+++ b/tests/repros/empty-input.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+// Regression test for #657: the pipeline crashed with
+// "Unexpected numItems value: 0" when given a problem with no chips, because
+// ChipObstacleSpatialIndex built a zero-item Flatbush index.
+
+const emptyProblem: InputProblem = {
+  chips: [],
+  directConnections: [],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+}
+
+test("pipeline solves an empty problem without crashing", () => {
+  const solver = new SchematicTracePipelineSolver(emptyProblem)
+  expect(() => solver.solve()).not.toThrow()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})
+
+test("pipeline solves a problem with no connections but with chips", () => {
+  const solver = new SchematicTracePipelineSolver({
+    ...emptyProblem,
+    chips: [
+      {
+        chipId: "U1",
+        center: { x: 0, y: 0 },
+        width: 2,
+        height: 2,
+        pins: [{ pinId: "U1.1", x: 1, y: 0 }],
+      },
+    ],
+  })
+  expect(() => solver.solve()).not.toThrow()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})


### PR DESCRIPTION
Closes #657.

### Root cause

The pipeline crashed with `Unexpected numItems value: 0` on any problem with no chips. The origin is `ChipObstacleSpatialIndex`, which always did:

```ts
this.spatialIndex = new Flatbush(chips.length)
```

Flatbush throws when constructed with `0` items, so an empty `chips` array crashes the whole pipeline before any solver logic runs. (The file/solver names in the issue — `CapacityMeshSolver.ts`, `DirectLineSolver.ts` — don't exist in this repo; the actual source is this spatial index.)

### Fix

Guard the empty case at the source rather than adding an early return to every solver:

- skip building the Flatbush index when there are no chips (`spatialIndex` becomes `null`)
- short-circuit `getChipsInBounds()` to return `[]` when there is no index

This matches the pattern already used in `AvailableNetOrientationObstacleIndex`, which returns `null` for zero-length label/trace-segment indexes. Because it fixes the root cause, it also handles a fully-empty problem (`chips: []`, no connections), not just the empty-connections case.

All access to the index goes through `getChipsInBounds()` / `doesOrthogonalLineIntersectChip()` (verified — nothing reads `.spatialIndex` directly), so the null case is fully contained.

### Tests

Added `tests/repros/empty-input.test.ts`:
- pipeline solves a fully empty problem without throwing
- pipeline solves a problem with chips but no connections

Verification:
- `bun test` → **305 pass / 0 fail** (was crashing before)
- `bunx tsc --noEmit` → clean
- `bunx biome format` → clean
