### PR TITLE
keep rerouted labels on their original trace row

### DIFF
--- a/lib/solvers/SameNetJunctionAlignmentSolver/alignSameNetJunctions.ts
+++ b/lib/solvers/SameNetJunctionAlignmentSolver/alignSameNetJunctions.ts
@@ -7,6 +7,11 @@ import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/Sche
 import { isPathCollidingWithObstacles } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
 import { getObstacleRects } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/rect"
 import { getMovedAnchorPointForReroute } from "lib/solvers/Example28Solver/getMovedAnchorPointForReroute"
+import {
+  findSegmentContainingPoint,
+  getSegments,
+  projectPointToSegment,
+} from "lib/solvers/Example28Solver/geometry"
 import { moveAttachedLabelsToReroutedTrace } from "lib/solvers/Example28Solver/labelMovement"
 import {
   rectsOverlap,
@@ -202,6 +207,34 @@ const moveAttachedLabels = ({
     reroutedTracePath,
     netLabelPlacements: attachedLabels,
   })
+  for (const [index, label] of attachedLabels.entries()) {
+    if (label.orientation !== "y+" && label.orientation !== "y-") continue
+    const originalSegment = findSegmentContainingPoint(
+      trace.tracePath,
+      label.anchorPoint,
+    )
+    if (originalSegment?.orientation !== "horizontal") continue
+    const sameRowSegment = getSegments(reroutedTracePath).find(
+      (segment) =>
+        segment.orientation === "horizontal" &&
+        nearlyEqual(segment.start.y, label.anchorPoint.y),
+    )
+    if (!sameRowSegment) continue
+
+    const anchorPoint = projectPointToSegment(
+      label.anchorPoint,
+      sameRowSegment.start,
+      sameRowSegment.end,
+    )
+    movedAttachedLabels[index] = {
+      ...label,
+      anchorPoint,
+      center: {
+        x: label.center.x + anchorPoint.x - label.anchorPoint.x,
+        y: label.center.y + anchorPoint.y - label.anchorPoint.y,
+      },
+    }
+  }
   const movedLabelByIndex = new Map(
     attachedLabelIndexes.map((labelIndex, index) => [
       labelIndex,

--- a/tests/repros/__snapshots__/repro-hub-usb-sheet.snap.svg
+++ b/tests/repros/__snapshots__/repro-hub-usb-sheet.snap.svg
@@ -34,7 +34,7 @@ globalConnNetId: connectivity_net32" data-x="6.9110000000000005" data-y="1.69000
 globalConnNetId: connectivity_net32" data-x="9.559000000000001" data-y="-1.19" x="503.8209502843515" y="336.4681709778023" width="24.656026417171176" height="4.109337736195187" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.04866964285714285"/></g><g><rect data-type="rect" data-label="netId: HUB_XTALO
 globalConnNetId: connectivity_net33" data-x="6.9110000000000005" data-y="1.8900000000000003" x="449.4133186571272" y="273.18436984039624" width="24.65602641717112" height="4.109337736195187" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.04866964285714285"/></g><g><rect data-type="rect" data-label="netId: HUB_XTALO
 globalConnNetId: connectivity_net33" data-x="10.9" data-y="1.129" x="531.3740598055404" y="288.82039992661896" width="24.65602641717112" height="4.109337736195187" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.04866964285714285"/></g><g><rect data-type="rect" data-label="netId: HUB_XTALI
-globalConnNetId: connectivity_net34" data-x="7.765000000000001" data-y="2.690000000000001" x="477.23353513116865" y="246.47367455512747" width="4.109337736195187" height="24.656026417171176" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.04866964285714285"/></g><g><rect data-type="rect" data-label="netId: VBUS_5V
+globalConnNetId: connectivity_net34" data-x="8.05" data-y="2.8160000000000003" x="483.08934140524684" y="243.88479178132448" width="4.10933773619513" height="24.656026417171176" fill="hsl(80, 100%, 50%, 0.35)" stroke="black" stroke-width="0.04866964285714285"/></g><g><rect data-type="rect" data-label="netId: VBUS_5V
 globalConnNetId: connectivity_net36" data-x="4.419" data-y="-4.2940000000000005" x="400.6765731058522" y="397.9849568886443" width="19.724821133736896" height="8.629609246009863" fill="#ef444466" stroke="#ef4444" stroke-width="0.04866964285714285"/></g><g><rect data-type="rect" data-label="INLINE netId: USB2_P1_DM
 axis: x
 side: y+" data-x="-4.91" data-y="4.0280000000000005" x="209.8183819482664" y="230.07741698770863" width="18.08108603925885" height="2.465602641717112" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.04866964285714285"/></g><g><rect data-type="rect" data-label="INLINE netId: USB2_P1_DM
@@ -282,7 +282,7 @@ orientation: x+" data-x="6.3100000000000005" data-y="1.6900000000000002" cx="449
 orientation: x-" data-x="10.16" data-y="-1.19" cx="528.4975233902037" cy="338.52283984589985" r="3" fill="hsl(80, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
 orientation: x+" data-x="6.3100000000000005" data-y="1.8900000000000003" cx="449.39277196844625" cy="275.2390387084938" r="3" fill="hsl(80, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
 orientation: x+" data-x="10.3" data-y="1.129" cx="531.3740598055404" cy="290.8750687947165" r="3" fill="hsl(80, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
-orientation: y+" data-x="7.765000000000001" data-y="2.0900000000000007" cx="479.2882039992662" cy="271.1297009722986" r="3" fill="hsl(80, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
+orientation: y+" data-x="8.05" data-y="2.216" cx="485.1440102733444" cy="268.5408181984957" r="3" fill="hsl(80, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="anchorPoint
 orientation: y+" data-x="4.419" data-y="-4.5040000000000004" cx="410.53898367272063" cy="406.6145661346542" r="3" fill="hsl(80, 100%, 50%, 0.9)"/></g><g><circle data-type="point" data-label="inline anchor
 USB2_P1_DM" data-x="-4.91" data-y="3.918" cx="218.8589249678958" cy="233.57035406347455" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
 USB2_P1_DM" data-x="2.37" data-y="2.590000000000001" cx="368.4388185654009" cy="260.8563566318106" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
@@ -527,13 +527,13 @@ USB3_HUB_TX_N" data-x="11.32" data-y="-4.260000000000001" cx="552.3316822601358"
     L 1036.4172813485077,344.4678609062697
     Z
   " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="0.842992623814px"/><text class="net-label-text sch-net-label-text" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_32__stack1" x="1037.934668071373" y="340.25289778719974" fill="rgb(132, 0, 0)" text-anchor="start" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="7.586933614326px" transform="">XXXXXXXXX</text><path class="net-label sch-net-label" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_33__stack1" d="
-    M 927.2918861957855,299.74710221293697
-    L 923.0769230767155,297.47102212863916
-    L 923.0769230767155,248.3582718652355
-    L 931.5068493148556,248.3582718652355
-    L 931.5068493148556,297.47102212863916
+    M 939.3045310851351,294.4362486829088
+    L 935.089567966065,292.160168598611
+    L 935.089567966065,243.04741833520734
+    L 943.5194942042051,243.04741833520734
+    L 943.5194942042051,292.160168598611
     Z
-  " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="0.842992623814px"/><text class="net-label-text sch-net-label-text" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_33__stack1" x="927.2918861957855" y="295.953635405774" fill="rgb(132, 0, 0)" text-anchor="start" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="7.586933614326px" transform="rotate(-90 927.2918861957855 295.953635405774)">XXXXXXXXX</text><path class="net-label sch-net-label" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_34__stack1" d="
+  " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="0.842992623814px"/><text class="net-label-text sch-net-label-text" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_33__stack1" x="939.3045310851351" y="290.6427818757458" fill="rgb(132, 0, 0)" text-anchor="start" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="7.586933614326px" transform="rotate(-90 939.3045310851351 290.6427818757458)">XXXXXXXXX</text><path class="net-label sch-net-label" data-circuit-json-type="schematic_net_label" data-schematic-net-label-id="schematic_net_label_34__stack1" d="
     M 786.2592202317032,577.6817702844128
     L 782.0442571126332,575.405690200115
     L 782.0442571126332,560.9511766771176

--- a/tests/repros/repro-hub-usb-sheet.test.ts
+++ b/tests/repros/repro-hub-usb-sheet.test.ts
@@ -6,6 +6,8 @@ import type { InputChip, InputProblem, PinId } from "lib/types/InputProblem"
 import "tests/fixtures/matcher"
 import inputProblemJson from "./assets/repro-hub-usb-sheet.input.json"
 
+const EXPECTED_HUB_XTALI_LABEL_Y = 2.216
+
 // Captured from @tsci/mohan-bee.hub 1.0.12 using @tscircuit/core 0.0.1816.
 // Only opaque schematic component IDs were replaced with unique source names.
 test("repro hub USB sheet schematic trace routing", () => {
@@ -48,9 +50,13 @@ test("repro hub USB sheet schematic trace routing", () => {
   const tracesAtSameChipGroundLabel = output.traces.filter((trace) =>
     tracePathContainsPoint(trace.tracePath, sameChipGroundLabel.anchorPoint),
   )
+  const hubXtaliLabel = output.netLabelPlacements.find(
+    (label) => label.netId === "HUB_XTALI",
+  )!
 
   expect(sameChipGroundLabel.orientation).toBe("y-")
   expect(sameChipGroundLabel.anchorPoint.x).toBeCloseTo(verticalHostPoint.x)
   expect(tracesAtSameChipGroundLabel).toHaveLength(1)
+  expect(hubXtaliLabel.anchorPoint.y).toBeCloseTo(EXPECTED_HUB_XTALI_LABEL_Y)
   expect(solver).toMatchSolverSnapshot(import.meta.path)
 })


### PR DESCRIPTION
### Motivation
- Same-net junction alignment could move a vertical net label onto a nearby parallel trace row.

### Before
- `HUB_XTALI` jumped downward when its original horizontal segment was shortened.

### After
- Vertical labels remain on their original horizontal row when that row still exists.
- The existing hub repro snapshot and assertion cover the regression.