### PR TITLE
Reproduce unnecessary RF1 trace dogleg

### DIFF
--- a/tests/repros/__snapshots__/repro-rf1-unnecessary-dogleg.snap.svg
+++ b/tests/repros/__snapshots__/repro-rf1-unnecessary-dogleg.snap.svg
@@ -1,0 +1,72 @@
+<svg width="1200" height="2016" viewBox="0 0 1200 2016" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Solver debug visualization on top and Circuit JSON schematic on the bottom">
+  <g transform="translate(0, 0) scale(1.875, 1.875) translate(0, 0)">
+    <rect width="100%" height="100%" fill="white"/><g><polyline data-points="3.4,-7 5.157985400000001,-6.997375450000001" data-type="line" data-label="" points="163.11835958113113,299.30281055733576 386.25266743224313,298.96968654636817" fill="none" stroke="hsl(21, 100%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="3.4,-7 3.4,-7.2 4.957985400000002,-7.2 4.957985400000002,-6.997375450000001 5.157985400000001,-6.997375450000001" data-type="line" data-label="" points="163.11835958113113,299.30281055733576 163.11835958113113,324.6880393369505 360.8674386526286,324.6880393369505 360.8674386526286,298.96968654636817 386.25266743224313,298.96968654636817" fill="none" stroke="purple" stroke-width="1px"/></g><g><polyline data-points="2.6,-7 2.6,-7.76" data-type="line" data-label="" points="61.57744446267253,299.30281055733576 61.57744446267253,395.7666799198714" fill="none" stroke="purple" stroke-width="1px"/></g><g><rect data-type="rect" data-label="schematic_component_0" data-x="2.9979" data-y="-6.961574540324975" x="61.044354658300676" y="289.5484197092121" width="102.07400492283045" height="9.754390848123649" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.007878597499999999"/></g><g><rect data-type="rect" data-label="schematic_component_1" data-x="6" data-y="-7" x="386.2526674322432" y="244.2333200801284" width="213.74733256775687" height="110.1389809544147" fill="hsl(24, 100%, 50%, 0.8)" stroke="black" stroke-width="0.007878597499999999"/></g><g><rect data-type="rect" data-label="INLINE netId: RF1
+axis: x
+side: y+" data-x="4.178992700000001" data-y="-7.09" x="241.68471609318817" y="303.11059487427804" width="40.61636604738351" height="15.231137267768645" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.007878597499999999"/></g><g><rect data-type="rect" data-label="INLINE netId: RF_OUT
+axis: y
+side: x-" data-x="2.49" data-y="-7.38" x="40.000000000000085" y="311.995424947143" width="15.231137267768815" height="71.07864058292114" fill="hsl(40, 100%, 50%, 0.35)" stroke="black" stroke-width="0.007878597499999999"/></g><text data-type="text" data-label="RF1" data-x="4.178992700000001" data-y="-7.09" x="261.9928991168799" y="310.72616350816236" fill="green" font-size="15.231137267768789" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">RF1</text><text data-type="text" data-label="RF_OUT" data-x="2.49" data-y="-7.1" x="47.61556863388449" y="311.9954249471431" fill="green" font-size="15.231137267768789" font-family="sans-serif" text-anchor="end" dominant-baseline="central" transform="rotate(-90, 47.61556863388449, 311.9954249471431)">RF_OUT</text><g><circle data-type="point" data-label="2
+y-" data-x="3.4" data-y="-7" cx="163.11835958113113" cy="299.30281055733576" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="1
+y-" data-x="2.6" data-y="-7" cx="61.57744446267253" cy="299.30281055733576" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="anode
+x-" data-x="5.157985400000001" data-y="-6.997375450000001" cx="386.25266743224313" cy="298.96968654636817" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="cathode
+x+" data-x="6.842014599999999" data-y="-7.00262455" cx="600" cy="299.63593456830347" r="3" fill="hsl(248, 100%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="inline anchor
+RF1" data-x="4.178992700000001" data-y="-7.2" cx="261.9928991168799" cy="324.6880393369505" r="3" fill="green"/></g><g><circle data-type="point" data-label="inline anchor
+RF_OUT" data-x="2.6" data-y="-7.38" cx="61.57744446267253" cy="347.5347452386036" r="3" fill="green"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":126.92614389807325,"c":0,"e":-268.4305296723179,"b":0,"d":-126.92614389807325,"f":-589.1801967291769};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  <g transform="translate(0, 1216)">
+    <style>
+              .boundary { fill: rgb(245, 241, 237); }
+              .schematic-boundary { fill: none; stroke: #fff; }
+              .component { fill: none; stroke: rgb(132, 0, 0); }
+              .chip { fill: rgb(255, 255, 194); stroke: rgb(132, 0, 0); }
+              .component-pin { fill: none; stroke: rgb(132, 0, 0); }
+              .text { font-family: sans-serif; fill: rgb(0, 150, 0); }
+              .pin-number { fill: rgb(169, 0, 0); }
+              .port-label { fill: rgb(0, 100, 100); }
+              .component-name { fill: rgb(0, 100, 100); }
+
+            </style><rect class="boundary" x="0" y="0" width="1200" height="800"/><g class="trace sch-trace" data-layer="base" data-circuit-json-type="schematic_trace" data-schematic-trace-id="schematic_trace_0__stack1"><path d="M 344.08840925458 360.1765754313001 L 344.08840925458 402.52731759564017 L 673.997599110611 402.52731759564017 L 673.997599110611 359.62081722956304 L 716.3483412749508 359.62081722956304" class="trace-invisible-hover-outline sch-trace-hitbox" stroke="rgb(0, 150, 0)" fill="none" stroke-width="33.880593731472px" stroke-linecap="round" opacity="0" stroke-linejoin="round"/><path class="sch-trace-path" d="M 344.08840925458 360.1765754313001 L 344.08840925458 402.52731759564017 L 673.997599110611 402.52731759564017 L 673.997599110611 359.62081722956304 L 716.3483412749508 359.62081722956304" stroke="rgb(0, 150, 0)" fill="none" stroke-width="4.235074216434px" stroke-linecap="round" stroke-linejoin="round"/></g><g class="trace sch-trace" data-layer="base" data-circuit-json-type="schematic_trace" data-schematic-trace-id="schematic_trace_1__stack1"><path d="M 174.68544059722007 360.1765754313001 L 174.68544059722007 521.109395655792" class="trace-invisible-hover-outline sch-trace-hitbox" stroke="rgb(0, 150, 0)" fill="none" stroke-width="33.880593731472px" stroke-linecap="round" opacity="0" stroke-linejoin="round"/><path class="sch-trace-path" d="M 174.68544059722007 360.1765754313001 L 174.68544059722007 521.109395655792" stroke="rgb(0, 150, 0)" fill="none" stroke-width="4.235074216434px" stroke-linecap="round" stroke-linejoin="round"/></g><g class="trace-overlays sch-trace-overlays" data-layer="overlay" data-circuit-json-type="schematic_trace" data-schematic-trace-id="schematic_trace_0__stack1"/><g class="trace-overlays sch-trace-overlays" data-layer="overlay" data-circuit-json-type="schematic_trace" data-schematic-trace-id="schematic_trace_1__stack1"/><g class="sch-component" data-circuit-json-type="schematic_component" data-schematic-component-id="schematic_component_0__stack1"><rect class="component chip sch-component-body" x="173.7960750117689" y="341.45215621399893" width="170.29233424281108" height="21.17537108216993" stroke-width="4.235074216434px" fill="rgb(255, 255, 194)" stroke="rgb(132, 0, 0)"/><rect class="component-overlay sch-component-overlay" x="173.7960750117689" y="341.45215621399893" width="170.29233424281108" height="21.17537108216993" fill="transparent"/><line class="component-pin sch-component-pin sch-port-line" x1="344.08840925458" y1="360.1765754313001" x2="344.08840925458" y2="360.1765754313001" stroke-width="4.235074216434px"/><g class="sch-port" data-schematic-port-id="source_port_0_0__stack1"><rect x="339.853335038146" y="355.9415012148661" width="8.470148432868" height="8.470148432868" opacity="0"/></g><text class="pin-number sch-pin-number" x="339.853335038146" y="360.1765754313001" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="31.763056623254997px" transform="rotate(-90 339.853335038146 360.1765754313001)">2</text><line class="component-pin sch-component-pin sch-port-line" x1="174.68544059722007" y1="360.1765754313001" x2="174.68544059722007" y2="360.1765754313001" stroke-width="4.235074216434px"/><g class="sch-port" data-schematic-port-id="source_port_0_1__stack1"><rect x="170.45036638078608" y="355.9415012148661" width="8.470148432868" height="8.470148432868" opacity="0"/></g><text class="pin-number sch-pin-number" x="170.45036638078608" y="360.1765754313001" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="31.763056623254997px" transform="rotate(-90 170.45036638078608 360.1765754313001)">1</text></g><g class="sch-component" data-circuit-json-type="schematic_component" data-schematic-component-id="schematic_component_1__stack1"><rect class="component chip sch-component-body" x="801.049825603631" y="268.30291880329037" width="187.19646357473812" height="183.74731325601942" stroke-width="4.235074216434px" fill="rgb(255, 255, 194)" stroke="rgb(132, 0, 0)"/><rect class="component-overlay sch-component-overlay" x="801.049825603631" y="268.30291880329037" width="187.19646357473812" height="183.74731325601942" fill="transparent"/><line class="component-pin sch-component-pin sch-port-line" x1="801.049825603631" y1="359.62081722956304" x2="716.3483412749508" y2="359.62081722956304" stroke-width="4.235074216434px"/><g class="sch-port" data-schematic-port-id="source_port_1_0__stack1"><rect x="712.1132670585168" y="355.38574301312906" width="8.470148432868" height="8.470148432868" opacity="0"/></g><text class="pin-number sch-pin-number" x="758.6990834392909" y="355.3857430131293" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="31.763056623254997px" transform=""></text><text class="pin-number sch-pin-label" x="822.2251966858009" y="359.62081722956304" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="start" dominant-baseline="middle" font-size="31.763056623254997px" transform="">anode</text><line class="component-pin sch-component-pin sch-port-line" x1="988.2462891783691" y1="360.7323336330371" x2="1068.7126992906153" y2="360.7323336330371" stroke-width="4.235074216434px"/><g class="sch-port" data-schematic-port-id="source_port_1_1__stack1"><circle class="component-pin sch-component-pin sch-port-terminal" cx="1072.9477735070493" cy="360.7323336330371" r="4.235074216434" stroke-width="4.235074216434px"/><rect x="1068.7126992906153" y="356.49725941660313" width="8.470148432868" height="8.470148432868" opacity="0"/></g><text class="pin-number sch-pin-number" x="1030.5970313427092" y="356.49725941660336" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="31.763056623254997px" transform=""></text><text class="pin-number sch-pin-label" x="967.0709180961992" y="360.7323336330371" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="end" dominant-baseline="middle" font-size="31.763056623254997px" transform="">cathode</text></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_0_0__stack1"><circle cx="344.08840925458" cy="360.1765754313001" r="8.470148432868" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_0_1__stack1"><circle cx="174.68544059722007" cy="360.1765754313001" r="8.470148432868" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_1_0__stack1"><circle cx="716.3483412749508" cy="359.62081722956304" r="8.470148432868" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="source_port_1_1__stack1"><circle cx="1072.9477735070493" cy="360.7323336330371" r="8.470148432868" fill="red" opacity="0"/></g><text class="sch-text" x="509.04300418259555" y="379.234409405253" fill="#047857" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="25.410445298604px" transform="rotate(0, 509.04300418259555, 379.234409405253)">XXX</text><text class="sch-text" x="151.39253240683303" y="440.64298554354605" fill="#047857" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="25.410445298604px" transform="rotate(-90, 151.39253240683303, 440.64298554354605)">XXXXXX</text>
+  </g>
+</svg>

--- a/tests/repros/assets/repro-rf1-unnecessary-dogleg.input.json
+++ b/tests/repros/assets/repro-rf1-unnecessary-dogleg.input.json
@@ -1,0 +1,90 @@
+{
+  "chips": [
+    {
+      "chipId": "schematic_component_0",
+      "center": {
+        "x": 2.9979,
+        "y": -6.961574540324975
+      },
+      "width": 0.8041999999999998,
+      "height": 0.07685091935005062,
+      "pins": [
+        {
+          "pinId": "schematic_port_0",
+          "displayName": "2",
+          "x": 3.4,
+          "y": -7
+        },
+        {
+          "pinId": "schematic_port_1",
+          "displayName": "1",
+          "x": 2.6,
+          "y": -7
+        }
+      ],
+      "sectionId": "RadioFrontEnd"
+    },
+    {
+      "chipId": "schematic_component_1",
+      "center": {
+        "x": 6,
+        "y": -7
+      },
+      "width": 1.6840291999999977,
+      "height": 0.8677406999999988,
+      "pins": [
+        {
+          "pinId": "schematic_port_2",
+          "displayName": "anode",
+          "x": 5.157985400000001,
+          "y": -6.997375450000001,
+          "_facingDirection": "x-"
+        },
+        {
+          "pinId": "schematic_port_3",
+          "displayName": "cathode",
+          "x": 6.842014599999999,
+          "y": -7.00262455,
+          "_facingDirection": "x+"
+        }
+      ],
+      "sectionId": "RadioFrontEnd"
+    }
+  ],
+  "directConnections": [
+    {
+      "netId": "RF1",
+      "anchoredNetLabelWidth": 0.48,
+      "allowInlineNetLabel": true,
+      "inlineNetLabelHeight": 0.12,
+      "inlineNetLabelWidth": 0.32,
+      "pinIds": [
+        "schematic_port_0",
+        "schematic_port_2"
+      ]
+    }
+  ],
+  "netConnections": [
+    {
+      "netId": "RF_OUT",
+      "isGround": false,
+      "netLabelWidth": 0.84,
+      "anchoredNetLabelWidth": 0.84,
+      "allowInlineNetLabel": true,
+      "inlineNetLabelHeight": 0.12,
+      "inlineNetLabelWidth": 0.56,
+      "pinIds": [
+        "schematic_port_1"
+      ]
+    }
+  ],
+  "textBoxes": [],
+  "availableNetLabelOrientations": {
+    "RF_OUT": [
+      "x-",
+      "x+"
+    ]
+  },
+  "maxMspPairDistance": 2.4,
+  "_hideRatsNet": false
+}

--- a/tests/repros/repro-rf1-unnecessary-dogleg.test.ts
+++ b/tests/repros/repro-rf1-unnecessary-dogleg.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import "tests/fixtures/matcher"
+import inputProblem from "./assets/repro-rf1-unnecessary-dogleg.input.json"
+
+// Captured from @tscircuit/core 0.0.1829 at commit b761dc8.
+// The nearly level RF1 endpoints should produce an effectively straight trace,
+// rather than a clearance-sized dogleg between the two inductors.
+test("repro RF1 unnecessary dogleg between aligned inductors", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+
+  solver.solve()
+
+  expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- add a focused reproduction of the unnecessary dogleg on the `RF1` trace between two nominally aligned inductors
- use the exact `InputProblem` emitted by `@tscircuit/core` 0.0.1829 at commit `b761dc8`
- retain the adjacent `RF_OUT` label while excluding unrelated MCU and antenna circuitry
- add a solver SVG snapshot showing the clearance-sized bend caused by an endpoint Y difference of about 0.0026 schematic units

This PR contains only the reproduction and no solver implementation changes.

## Verification
- `bun test tests/repros/repro-rf1-unnecessary-dogleg.test.ts`
- `bun test` (311 passed, 4 skipped)
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`