### PR TITLE
fix: detect collisions for nearly axis-aligned segments (closes #1099)

### DIFF
--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions.ts
@@ -3,6 +3,13 @@ import type { RectBounds } from "./rect"
 
 const EPS = 1e-9
 
+/**
+ * Segments skewed by less than this are treated as axis-aligned for collision
+ * purposes. Real schematic geometry is on a 0.001-ish grid, so anything under
+ * this is float noise or an off-grid pin, never a deliberate diagonal.
+ */
+const NEARLY_AXIS_ALIGNED_TOLERANCE = 1e-3
+
 export const isVertical = (a: Point, b: Point, eps = EPS) =>
   Math.abs(a.x - b.x) < eps
 export const isHorizontal = (a: Point, b: Point, eps = EPS) =>
@@ -16,7 +23,31 @@ export const segmentIntersectsRect = <TRect extends RectBounds>(
 ): boolean => {
   const vert = isVertical(a, b, eps)
   const horz = isHorizontal(a, b, eps)
-  if (!vert && !horz) return false
+  if (!vert && !horz) {
+    // A segment can miss both fast paths while still being an intended
+    // axis-aligned run: a pin whose coordinate sits a few 1e-5 off the routing
+    // grid is enough. Treating those as "no collision" let traces pass straight
+    // through a chip body, so classify by the dominant axis instead.
+    const dx = Math.abs(a.x - b.x)
+    const dy = Math.abs(a.y - b.y)
+    if (dx < NEARLY_AXIS_ALIGNED_TOLERANCE && dx < dy) {
+      return segmentIntersectsRect(
+        { x: a.x, y: a.y },
+        { x: a.x, y: b.y },
+        r,
+        eps,
+      )
+    }
+    if (dy < NEARLY_AXIS_ALIGNED_TOLERANCE && dy < dx) {
+      return segmentIntersectsRect(
+        { x: a.x, y: a.y },
+        { x: b.x, y: a.y },
+        r,
+        eps,
+      )
+    }
+    return false
+  }
 
   if (vert) {
     const x = a.x

--- a/tests/repros/near-axis-aligned-trace-through-chip.test.ts
+++ b/tests/repros/near-axis-aligned-trace-through-chip.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test"
+import { segmentIntersectsRect } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+import { SchematicTracePipelineSolver } from "lib/solvers/SchematicTracePipelineSolver/SchematicTracePipelineSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+
+// SJ2.1 sits at x=5.3999378 while R3.2 sits at x=5.4, so the recovered trace
+// between them is skewed by ~6e-5. That is far below the routing grid but far
+// above the 1e-9 epsilon used to classify axis-aligned segments, so the segment
+// used to match neither fast path in segmentIntersectsRect and was reported as
+// colliding with nothing. The trace then ran straight through
+// schematic_component_8.
+const inputProblem: InputProblem = {
+  chips: [
+    {
+      chipId: "schematic_component_4",
+      center: { x: 5.4, y: 2.4 },
+      width: 0.3041465,
+      height: 0.9,
+      pins: [
+        {
+          pinId: "SJ2.1",
+          x: 5.3999378,
+          y: 1.9499999999999997,
+          _facingDirection: "y-",
+        },
+      ],
+    },
+    {
+      chipId: "schematic_component_5",
+      center: { x: 5.555, y: 1.2 },
+      width: 1.21,
+      height: 0.6,
+      pins: [{ pinId: "R3.2", x: 5.4, y: 1.5, _facingDirection: "y+" }],
+    },
+    {
+      chipId: "schematic_component_8",
+      center: { x: 5.555, y: 1.2 },
+      width: 0.555,
+      height: 0.9,
+      pins: [],
+    },
+  ],
+  directConnections: [
+    { pinIds: ["SJ2.1", "R3.2"], netId: ".SJ2 > .pin1 to .R3 > .pin2" },
+  ],
+  netConnections: [],
+  availableNetLabelOrientations: {},
+} as unknown as InputProblem
+
+test("a nearly-vertical segment still collides with a rect it passes through", () => {
+  const chipRect = { minX: 5.2775, maxX: 5.8325, minY: 0.75, maxY: 1.65 }
+  const skewedStart = { x: 5.3999378, y: 1.9499999999999997 }
+  const skewedEnd = { x: 5.4, y: 1.5000000000000004 }
+
+  expect(segmentIntersectsRect(skewedStart, skewedEnd, chipRect)).toBe(true)
+  // A truly diagonal segment is still out of scope for this test.
+  expect(
+    segmentIntersectsRect({ x: 0, y: 0 }, { x: 100, y: 100 }, chipRect),
+  ).toBe(false)
+})
+
+test("recovered traces do not run through a chip they do not terminate on", () => {
+  const solver = new SchematicTracePipelineSolver(inputProblem as any)
+  solver.solve()
+
+  const traces = solver.netLabelToTraceSolver!.getOutput().traces
+  const blockingChip = inputProblem.chips.find(
+    (chip) => chip.chipId === "schematic_component_8",
+  )!
+  const minX = blockingChip.center.x - blockingChip.width / 2
+  const maxX = blockingChip.center.x + blockingChip.width / 2
+  const minY = blockingChip.center.y - blockingChip.height / 2
+  const maxY = blockingChip.center.y + blockingChip.height / 2
+  const margin = 1e-3
+
+  for (const trace of traces) {
+    for (let index = 0; index + 1 < trace.tracePath.length; index++) {
+      const start = trace.tracePath[index]!
+      const end = trace.tracePath[index + 1]!
+      const crossesChipInterior =
+        Math.max(start.x, end.x) > minX + margin &&
+        Math.min(start.x, end.x) < maxX - margin &&
+        Math.max(start.y, end.y) > minY + margin &&
+        Math.min(start.y, end.y) < maxY - margin
+      expect(crossesChipInterior).toBe(false)
+    }
+  }
+})


### PR DESCRIPTION
Closes #1099

## Problem

`segmentIntersectsRect` classifies a segment as vertical or horizontal using `EPS = 1e-9`, then returns `false` for anything that matches neither. Pin coordinates are not always exactly on the routing grid, so a segment can be skewed by ~6e-5: far below the schematic grid, but five orders of magnitude above `1e-9`. Those segments matched neither fast path and were reported as colliding with nothing.

`UnroutedTraceRecoverySolver` accepts the first candidate that passes `pathCollidesWithObstacles`, so a skewed candidate was accepted and emitted as the final trace, running straight through a chip body it does not terminate on.

## Fix

When a segment matches neither fast path, classify it by its dominant axis if the off-axis deviation is under `1e-3` and test it as the axis-aligned segment it was meant to be. Genuinely diagonal segments still return `false`, so the change is limited to sub-grid skew.

The `1e-3` threshold sits below the schematic grid, so anything under it is float noise or an off-grid pin, never a deliberate diagonal.

## Tests

`tests/repros/near-axis-aligned-trace-through-chip.test.ts` covers both levels:

- the helper directly, asserting a skewed segment collides with a rect it passes through while a true diagonal still does not
- the pipeline end to end, asserting no trace segment crosses the interior of a chip it does not terminate on

Both assertions fail on `main` and pass with this change.

`bun test`: 343 pass, 4 skip, 0 fail (`main` is also 0 fail, so no regressions).
`bunx tsc --noEmit`: clean.
No snapshots changed.

## Provenance

Found by differential fuzzing over the fixtures in `tests/bug-reports` and `tests/examples`, judging each mutated variant against its base fixture's baseline. Two independent fuzzed inputs reduce to this same root cause. The reproducer in the test is the delta-debugged minimum: 3 chips, 1 connection.

This change was prepared with AI assistance and reviewed by the author.
