### PR TITLE
fix: treat isGround aliases as ground, not only the name GND

### DIFF
--- a/lib/solvers/MspConnectionPairSolver/getGroundConnectionPolicy.ts
+++ b/lib/solvers/MspConnectionPairSolver/getGroundConnectionPolicy.ts
@@ -2,6 +2,7 @@ import { ConnectivityMap } from "connectivity-map"
 import type { InputProblem, PinId } from "lib/types/InputProblem"
 import { getPinDirection } from "../SchematicTraceLinesSolver/SchematicTraceSingleLineSolver/getPinDirection"
 import { getConnectivityMapsFromInputProblem } from "./getConnectivityMapFromInputProblem"
+import { getGroundGlobalConnNetIds } from "./getGroundGlobalConnNetIds"
 
 // Keep nearby ground connections, but do not extend the usual 1 mm local
 // routing range vertically just because a sheet allows long signal traces.
@@ -10,7 +11,7 @@ const MAX_LOCAL_GROUND_BRANCH_OFFSET = 1
 /** Avoid return wires between staggered, net-only ground-facing branches. */
 export const getGroundConnectionPolicy = (inputProblem: InputProblem) => {
   const { netConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
-  const groundNetId = netConnMap.getNetConnectedToId("GND")
+  const groundNetIds = getGroundGlobalConnNetIds(inputProblem, netConnMap)
   // Net identifiers do not constitute physical edges: two separate direct
   // connections may have the same netId without requesting a wire between them.
   const physicalConnMap = new ConnectivityMap({})
@@ -35,7 +36,7 @@ export const getGroundConnectionPolicy = (inputProblem: InputProblem) => {
   const groundFacingPins = [...pins.values()].filter(
     ({ pin, chip }) =>
       chip.pins.length === 2 &&
-      netConnMap.getNetConnectedToId(pin.pinId) === groundNetId &&
+      groundNetIds.has(netConnMap.getNetConnectedToId(pin.pinId) ?? "") &&
       (pin._facingDirection ?? getPinDirection(pin, chip)) === "y-",
   )
   // A deliberately wired, level bank of two-pin loads already has its own
@@ -106,9 +107,9 @@ export const getGroundConnectionPolicy = (inputProblem: InputProblem) => {
     const secondGlobalNetId = netConnMap.getNetConnectedToId(secondPinId)
     if (areSeparateExplicitGroundIslands(firstPinId, secondPinId)) return false
     if (
-      !groundNetId ||
-      firstGlobalNetId !== groundNetId ||
-      secondGlobalNetId !== groundNetId
+      !firstGlobalNetId ||
+      firstGlobalNetId !== secondGlobalNetId ||
+      !groundNetIds.has(firstGlobalNetId)
     ) {
       return true
     }

--- a/lib/solvers/MspConnectionPairSolver/getGroundGlobalConnNetIds.ts
+++ b/lib/solvers/MspConnectionPairSolver/getGroundGlobalConnNetIds.ts
@@ -1,0 +1,27 @@
+import type { ConnectivityMap } from "connectivity-map"
+import type { InputProblem } from "lib/types/InputProblem"
+
+/**
+ * Ground policy used to key off the literal net name "GND", so aliases that
+ * core already marks `isGround` (AGND, VSS, USB_GND, …) were treated as
+ * ordinary signal nets. Collect every connectivity id that is either the
+ * canonical "GND" name or an `isGround` net connection.
+ */
+export const getGroundGlobalConnNetIds = (
+  inputProblem: InputProblem,
+  netConnMap: ConnectivityMap,
+): Set<string> => {
+  const ids = new Set<string>()
+  const add = (key: string | undefined) => {
+    if (!key) return
+    const id = netConnMap.getNetConnectedToId(key)
+    if (id) ids.add(id)
+  }
+  add("GND")
+  for (const net of inputProblem.netConnections) {
+    if (!net.isGround) continue
+    add(net.netId)
+    for (const pinId of net.pinIds) add(pinId)
+  }
+  return ids
+}

--- a/lib/solvers/SameNetJunctionAlignmentSolver/placeGroundRailLabelsAtOuterEnd.ts
+++ b/lib/solvers/SameNetJunctionAlignmentSolver/placeGroundRailLabelsAtOuterEnd.ts
@@ -1,5 +1,6 @@
 import { traceCrossesBoundsInterior } from "lib/solvers/AvailableNetOrientationSolver/geometry"
 import { getConnectivityMapsFromInputProblem } from "lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem"
+import { getGroundGlobalConnNetIds } from "lib/solvers/MspConnectionPairSolver/getGroundGlobalConnNetIds"
 import type { NetLabelPlacement } from "lib/solvers/NetLabelPlacementSolver/NetLabelPlacementSolver"
 import {
   getCenterFromAnchor,
@@ -30,8 +31,8 @@ export const placeGroundRailLabelsAtOuterEnd = ({
   netLabelPlacements: NetLabelPlacement[]
 }): NetLabelPlacement[] => {
   const { netConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
-  const groundNetId = netConnMap.getNetConnectedToId("GND")
-  if (!groundNetId) return netLabelPlacements
+  const groundNetIds = getGroundGlobalConnNetIds(inputProblem, netConnMap)
+  if (groundNetIds.size === 0) return netLabelPlacements
   const chipMap = new Map(inputProblem.chips.map((chip) => [chip.chipId, chip]))
   const traceMap = Object.fromEntries(
     traces.map((trace) => [trace.mspPairId, trace]),
@@ -40,7 +41,7 @@ export const placeGroundRailLabelsAtOuterEnd = ({
   const output = [...netLabelPlacements]
 
   for (const rail of traces) {
-    if (rail.globalConnNetId !== groundNetId) continue
+    if (!groundNetIds.has(rail.globalConnNetId)) continue
     const [a, b] = rail.pins
     if (
       a.chipId === b.chipId ||
@@ -63,7 +64,7 @@ export const placeGroundRailLabelsAtOuterEnd = ({
       continue
 
     for (const feed of traces) {
-      if (feed.globalConnNetId !== groundNetId) continue
+      if (!groundNetIds.has(feed.globalConnNetId)) continue
       const shared = feed.pins.find((pin) => rail.pinIds.includes(pin.pinId))
       const icPin = feed.pins.find(
         (pin) =>
@@ -79,7 +80,7 @@ export const placeGroundRailLabelsAtOuterEnd = ({
       for (let index = 0; index < output.length; index++) {
         const label = output[index]!
         if (
-          label.globalConnNetId !== groundNetId ||
+          !groundNetIds.has(label.globalConnNetId) ||
           label.orientation !== "y-" ||
           !label.mspConnectionPairIds.some(
             (id) => id === feed.mspPairId || id === rail.mspPairId,

--- a/lib/solvers/UnroutedTraceRecoverySolver/UnroutedTraceRecoverySolver.ts
+++ b/lib/solvers/UnroutedTraceRecoverySolver/UnroutedTraceRecoverySolver.ts
@@ -3,6 +3,7 @@ import { distance, doSegmentsIntersect } from "@tscircuit/math-utils"
 import { calculateElbow } from "calculate-elbow"
 import { BaseSolver } from "lib/solvers/BaseSolver/BaseSolver"
 import { getConnectivityMapsFromInputProblem } from "lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem"
+import { getGroundGlobalConnNetIds } from "lib/solvers/MspConnectionPairSolver/getGroundGlobalConnNetIds"
 import {
   DEFAULT_MAX_MSP_PAIR_DISTANCE,
   type MspConnectionPair,
@@ -24,7 +25,6 @@ import type { FacingDirection } from "lib/utils/dir"
 
 const ROUTE_CLEARANCE = 0.2
 const COORDINATE_TOLERANCE = 1e-9
-const GROUND_NET_ID = "GND"
 
 const pointsAreEqual = (firstPoint: Point, secondPoint: Point): boolean => {
   return (
@@ -476,7 +476,7 @@ export class UnroutedTraceRecoverySolver extends BaseSolver {
   private failedConnectionPairs: MspConnectionPair[]
   private queuedConnectionPairs: MspConnectionPair[]
   private maxConnectionDistance: number
-  private groundGlobalConnNetId?: string
+  private groundGlobalConnNetIds: Set<string>
   public solvedUnroutedTraces: SolvedTracePath[] = []
 
   constructor(
@@ -496,8 +496,10 @@ export class UnroutedTraceRecoverySolver extends BaseSolver {
     const { netConnMap } = getConnectivityMapsFromInputProblem(
       this.inputProblem,
     )
-    this.groundGlobalConnNetId =
-      netConnMap.getNetConnectedToId(GROUND_NET_ID) ?? undefined
+    this.groundGlobalConnNetIds = getGroundGlobalConnNetIds(
+      this.inputProblem,
+      netConnMap,
+    )
   }
 
   override getConstructorParams() {
@@ -510,7 +512,7 @@ export class UnroutedTraceRecoverySolver extends BaseSolver {
       this.solved = true
       return
     }
-    if (connectionPair.globalConnNetId === this.groundGlobalConnNetId) {
+    if (this.groundGlobalConnNetIds.has(connectionPair.globalConnNetId)) {
       return
     }
     if (

--- a/tests/solvers/MspConnectionPairSolver/getGroundGlobalConnNetIds.test.ts
+++ b/tests/solvers/MspConnectionPairSolver/getGroundGlobalConnNetIds.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { getConnectivityMapsFromInputProblem } from "lib/solvers/MspConnectionPairSolver/getConnectivityMapFromInputProblem"
+import { getGroundGlobalConnNetIds } from "lib/solvers/MspConnectionPairSolver/getGroundGlobalConnNetIds"
+import type { InputProblem } from "lib/types/InputProblem"
+
+const pins = (names: string[]) =>
+  names.map((name, index) => ({
+    pinId: name,
+    x: index,
+    y: 0,
+  }))
+
+const chip = (
+  chipId: string,
+  pinNames: string[],
+): InputProblem["chips"][0] => ({
+  chipId,
+  center: { x: 0, y: 0 },
+  width: 0.4,
+  height: 0.4,
+  pins: pins(pinNames),
+})
+
+test("includes canonical GND and every isGround alias", () => {
+  const inputProblem: InputProblem = {
+    chips: [chip("U", ["U.1", "U.2", "U.3"])],
+    directConnections: [],
+    netConnections: [
+      { netId: "GND", pinIds: ["U.1"] },
+      { netId: "AGND", pinIds: ["U.2"], isGround: true },
+      { netId: "VCC", pinIds: ["U.3"] },
+    ],
+    availableNetLabelOrientations: {
+      GND: ["y-"],
+      AGND: ["y-"],
+      VCC: ["y+"],
+    },
+  }
+  const { netConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
+  const ids = getGroundGlobalConnNetIds(inputProblem, netConnMap)
+  expect(ids.has(netConnMap.getNetConnectedToId("GND")!)).toBe(true)
+  expect(ids.has(netConnMap.getNetConnectedToId("AGND")!)).toBe(true)
+  expect(ids.has(netConnMap.getNetConnectedToId("VCC")!)).toBe(false)
+})
+
+test("does not treat an unmarked alias as ground", () => {
+  const inputProblem: InputProblem = {
+    chips: [chip("U", ["U.1"])],
+    directConnections: [],
+    netConnections: [{ netId: "RETURN", pinIds: ["U.1"] }],
+    availableNetLabelOrientations: { RETURN: ["y-"] },
+  }
+  const { netConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
+  expect(getGroundGlobalConnNetIds(inputProblem, netConnMap).size).toBe(0)
+})

--- a/tests/solvers/MspConnectionPairSolver/local-ground-branches.test.ts
+++ b/tests/solvers/MspConnectionPairSolver/local-ground-branches.test.ts
@@ -87,6 +87,14 @@ test("does not apply the ground rule to power or signal nets", () => {
   expect(getGroundConnectionPolicy(inputProblem)("B.2", "C.2")).toBe(true)
 })
 
+test("applies the ground rail rule to a marked alias that is not named GND", () => {
+  const inputProblem = createParallelGroundRailProblem()
+  inputProblem.netConnections[0]!.netId = "AGND"
+  inputProblem.netConnections[0]!.isGround = true
+  inputProblem.availableNetLabelOrientations = { AGND: ["y-"] }
+  expect(getGroundConnectionPolicy(inputProblem)("B.2", "C.2")).toBe(false)
+})
+
 test("infers ground-facing pins when explicit directions are absent", () => {
   const inputProblem = createParallelGroundRailProblem()
   for (const chip of inputProblem.chips) {

--- a/tests/solvers/SameNetJunctionAlignmentSolver/ground-rail-label.test.ts
+++ b/tests/solvers/SameNetJunctionAlignmentSolver/ground-rail-label.test.ts
@@ -5,10 +5,15 @@ import { placeGroundRailLabelsAtOuterEnd } from "lib/solvers/SameNetJunctionAlig
 import type { SolvedTracePath } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceLinesSolver"
 import { createParallelGroundRailProblem } from "tests/fixtures/parallel-ground-rail"
 
-const createFixture = () => {
+const createFixture = (netId = "GND", isGround = false) => {
   const inputProblem = createParallelGroundRailProblem()
+  if (netId !== "GND" || isGround) {
+    inputProblem.netConnections[0]!.netId = netId
+    inputProblem.netConnections[0]!.isGround = isGround
+    inputProblem.availableNetLabelOrientations = { [netId]: ["y-"] }
+  }
   const { netConnMap } = getConnectivityMapsFromInputProblem(inputProblem)
-  const globalConnNetId = netConnMap.getNetConnectedToId("GND")!
+  const globalConnNetId = netConnMap.getNetConnectedToId(netId)!
   const pins = new Map(
     inputProblem.chips.flatMap((chip) =>
       chip.pins.map(
@@ -25,7 +30,7 @@ const createFixture = () => {
     mspConnectionPairIds: [mspPairId],
     globalConnNetId,
     dcConnNetId: globalConnNetId,
-    userNetId: "GND",
+    userNetId: netId,
     pinIds,
     pins: [pins.get(pinIds[0])!, pins.get(pinIds[1])!],
     tracePath: path.map(([x, y]) => ({ x: x!, y: y! })),
@@ -55,7 +60,7 @@ const createFixture = () => {
     {
       globalConnNetId,
       dcConnNetId: globalConnNetId,
-      netId: "GND",
+      netId,
       mspConnectionPairIds: ["feed"],
       pinIds: ["U.GND", "B.2"],
       orientation: "y-",
@@ -103,6 +108,14 @@ for (const mirror of [1, -1]) {
     ).toEqual(labels)
   })
 }
+
+test("places a marked AGND rail label at the outer column", () => {
+  const fixture = createFixture("AGND", true)
+  const labels = placeGroundRailLabelsAtOuterEnd(fixture)
+  expect(labels[0]!.anchorPoint).toEqual({ x: 0, y: 0.6 })
+  expect(labels[0]!.mspConnectionPairIds).toEqual(["rail"])
+  expect(labels[0]!.netId).toBe("AGND")
+})
 
 test("label placement is independent of trace and endpoint ordering", () => {
   const fixture = createFixture()

--- a/tests/solvers/UnroutedTraceRecoverySolver/skip-ground.test.ts
+++ b/tests/solvers/UnroutedTraceRecoverySolver/skip-ground.test.ts
@@ -28,3 +28,40 @@ test("does not recover the canonical ground connectivity net", () => {
   expect(failedConnectionPairs).not.toHaveLength(0)
   expect(recoverySolver.solvedUnroutedTraces).toHaveLength(0)
 })
+
+test("does not recover a marked ground alias that is not named GND", () => {
+  const aliased = structuredClone(inputProblem) as any
+  for (const net of aliased.netConnections) {
+    if (net.netId !== "GND") continue
+    net.netId = "AGND"
+    net.isGround = true
+  }
+  aliased.availableNetLabelOrientations = {
+    VCC: aliased.availableNetLabelOrientations.VCC,
+    AGND: aliased.availableNetLabelOrientations.GND,
+  }
+
+  const pipelineSolver = new SchematicTracePipelineSolver(aliased)
+  pipelineSolver.solveUntilPhase("unroutedTraceRecoverySolver")
+
+  const failedConnectionPairs =
+    pipelineSolver.schematicTraceLinesSolver!.failedConnectionPairs.map(
+      (connectionPair) => {
+        return {
+          ...connectionPair,
+          userNetId: undefined,
+        }
+      },
+    )
+  const recoverySolver = new UnroutedTraceRecoverySolver({
+    inputProblem: pipelineSolver.inputProblem,
+    failedConnectionPairs,
+    alreadySolvedTraces:
+      pipelineSolver.longDistancePairSolver!.getOutput().allTracesMerged,
+  })
+
+  recoverySolver.solve()
+
+  expect(failedConnectionPairs).not.toHaveLength(0)
+  expect(recoverySolver.solvedUnroutedTraces).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

Ground rail policy, unrouted-trace recovery skip, and outer-column GND label placement all looked up the literal net name `"GND"`. Core already sets `isGround` on aliases (`AGND`, `VSS`, `USB_GND`, …), so those nets were treated as ordinary signals.

This collects every connectivity id that is either the canonical `GND` name (existing fixtures) or an `isGround` net connection, and uses that set in the three call sites.

Fixes #747

## Test plan

- [x] `bun test` (352 pass, 4 skip)
- [x] `tsc --noEmit`
- [x] New coverage: AGND + `isGround` applies rail policy, skips recovery, and moves the shared rail label to the outer column
- [x] Canonical `GND` without `isGround` still works
- [x] Unmarked aliases such as `RETURN` / `VDD` are not treated as ground