### PR TITLE
fix: near-axis-aligned segments no longer escape obstacle collision

### DIFF
--- a/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions.ts
+++ b/lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions.ts
@@ -16,7 +16,12 @@ export const segmentIntersectsRect = <TRect extends RectBounds>(
 ): boolean => {
   const vert = isVertical(a, b, eps)
   const horz = isHorizontal(a, b, eps)
-  if (!vert && !horz) return false
+  if (!vert && !horz) {
+    // Near-axis-aligned segments (jittered pin coordinates) previously fell
+    // through as collision-free here. Slanted segments must still be tested
+    // against the rect instead of being declared collision-free.
+    return segmentIntersectsRectSlanted(a, b, r, eps)
+  }
 
   if (vert) {
     const x = a.x
@@ -33,6 +38,46 @@ export const segmentIntersectsRect = <TRect extends RectBounds>(
     const overlap = Math.min(segMaxX, r.maxX) - Math.max(segMinX, r.minX)
     return overlap > eps
   }
+}
+
+/**
+ * General segment/AABB intersection via slab (Liang-Barsky) clipping.
+ * Only used for non-axis-aligned segments; axis-aligned fast paths above
+ * keep the historical overlap semantics (strictly inside counts, touching
+ * an edge does not).
+ */
+const segmentIntersectsRectSlanted = <TRect extends RectBounds>(
+  a: Point,
+  b: Point,
+  r: TRect,
+  eps = EPS,
+): boolean => {
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  let tMin = 0
+  let tMax = 1
+  const clip = (p: number, q: number): boolean => {
+    if (Math.abs(p) <= eps) return q > eps
+    const t = q / p
+    if (p < 0) {
+      if (t > tMax) return false
+      if (t > tMin) tMin = t
+    } else {
+      if (t < tMin) return false
+      if (t < tMax) tMax = t
+    }
+    return true
+  }
+
+  if (!clip(-dx, a.x - r.minX)) return false
+  if (!clip(dx, r.maxX - a.x)) return false
+  if (!clip(-dy, a.y - r.minY)) return false
+  if (!clip(dy, r.maxY - a.y)) return false
+
+  // A degenerate intersection interval (tMin ~= tMax) means the segment
+  // merely touches an edge or corner — matching the axis-aligned paths'
+  // "touching does not count" semantics, require a real overlap.
+  return tMax - tMin > eps
 }
 
 export const segmentOverlapsRectBoundary = <TRect extends RectBounds>(

--- a/tests/solvers/SchematicTraceSingleLineSolver2/segment-intersects-rect-near-axis.test.ts
+++ b/tests/solvers/SchematicTraceSingleLineSolver2/segment-intersects-rect-near-axis.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { segmentIntersectsRect } from "lib/solvers/SchematicTraceLinesSolver/SchematicTraceSingleLineSolver2/collisions"
+
+// https://github.com/tscircuit/schematic-trace-solver/issues/1099
+// Real pin coordinates are not always exactly on the routing grid: a segment
+// between x = 5.3999378 and x = 5.4 has dx = 6.22e-5 — far below the schematic
+// grid but five orders of magnitude above the 1e-9 axis-alignment EPS. Such
+// segments used to bypass every obstacle check.
+
+const rect = {
+  minX: 0,
+  maxX: 2,
+  minY: 0,
+  maxY: 2,
+}
+
+test("nearly vertical segment crossing a chip body is a collision", () => {
+  // dx = 6.22e-5 (from issue), dy = 4 — passes straight through the rect
+  expect(
+    segmentIntersectsRect({ x: 0.5 + 6.22e-5, y: -1 }, { x: 0.5, y: 3 }, rect),
+  ).toBe(true)
+})
+
+test("nearly horizontal segment crossing a chip body is a collision", () => {
+  expect(
+    segmentIntersectsRect({ x: -1, y: 1 + 6.22e-5 }, { x: 3, y: 1 }, rect),
+  ).toBe(true)
+})
+
+test("nearly vertical segment outside the rect stays collision-free", () => {
+  expect(
+    segmentIntersectsRect({ x: 2.5, y: -1 }, { x: 2.5 + 6.22e-5, y: 3 }, rect),
+  ).toBe(false)
+})
+
+test("slanted segment through the rect interior is a collision", () => {
+  expect(segmentIntersectsRect({ x: -1, y: -1 }, { x: 3, y: 3 }, rect)).toBe(
+    true,
+  )
+})
+
+test("slanted segment missing the rect is collision-free", () => {
+  expect(segmentIntersectsRect({ x: -1, y: 2.5 }, { x: 3, y: 6 }, rect)).toBe(
+    false,
+  )
+})
+
+test("slanted segment touching only a corner is collision-free", () => {
+  // Glances off the top-right corner without entering the interior
+  expect(
+    segmentIntersectsRect({ x: 2.2, y: 1.8 }, { x: 1.8, y: 2.2 }, rect),
+  ).toBe(false)
+})


### PR DESCRIPTION
Fixes #1099

`/attempt #1099`

## Root cause
`segmentIntersectsRect` returned `false` for every segment that is neither exactly vertical nor exactly horizontal. Real pin coordinates are not always exactly on the routing grid — a pin at `x = 5.3999378` connected to one at `x = 5.4` produces a segment with `dx = 6.22e-5`: far below the schematic grid, yet five orders of magnitude above the `1e-9` axis-alignment EPS. Such segments passed every obstacle check, and `UnroutedTraceRecoverySolver` accepted the first skewed candidate as collision-free.

## Fix
Non-axis-aligned segments now run a slab (Liang-Barsky) clip against the obstacle rect. The axis-aligned fast paths keep their historical semantics:
- a real interior overlap counts as a collision,
- a segment that merely touches an edge or corner does not (`tMax - tMin > eps` on the slanted path).

## Verification
- New regression tests in `tests/solvers/SchematicTraceSingleLineSolver2/segment-intersects-rect-near-axis.test.ts` cover: near-vertical/near-horizontal segments crossing a chip body (previously `false`, now `true`), near-axis segments outside the rect, slanted crossings, and corner-touching glances (still collision-free).
- Full suite: **353 pass, 0 fail** (347 pass pre-existing + 6 new tests); no snapshot changes — routing output is unchanged for exactly axis-aligned inputs.