### PR TITLE
test(segments): add stationary repetitive coordinate sequence handling spec

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,13 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+
+test("getAxisAlignedSegments handles stationary repetitive coordinate sequences safely", () => {
+  const result = getAxisAlignedSegments([
+    { x: 2, y: 2 },
+    { x: 2, y: 2 },
+    { x: 2, y: 2 },
+  ])
+  expect(result).toEqual([])
+})
+


### PR DESCRIPTION
### Summary
- Adds unit test to `tests/functions/getAxisAlignedSegments.test.ts` verifying that stationary zero-distance coordinate sequences return empty segment lists without exceptions.