### PR TITLE
test(segments): add closed rectangular perimeter loop axis-aligned specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,21 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+
+test("getAxisAlignedSegments decomposes closed rectangular perimeter loop", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+    { x: 4, y: 4 },
+    { x: 0, y: 4 },
+    { x: 0, y: 0 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["x", 4],
+    ["y", 4],
+    ["x", 4],
+    ["y", 4],
+  ])
+})
+


### PR DESCRIPTION
### Summary
- Adds unit test verification for `getAxisAlignedSegments` when handling closed rectangular coordinate loops.
- Validates alternating orthogonal axis assignments (`x`, `y`, `x`, `y`) and equal segment magnitudes for closed loop bounding boxes.

### Testing
- Asserts axes decomposition and segment lengths.