### PR TITLE
test(segments): add orthogonal U-shaped detour axis-aligned specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,19 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+
+test("getAxisAlignedSegments processes orthogonal U-shaped detour", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 0, y: 10 },
+    { x: 6, y: 10 },
+    { x: 6, y: 0 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["y", 10],
+    ["x", 6],
+    ["y", 10],
+  ])
+})
+


### PR DESCRIPTION
### Summary
- Extends test coverage for `getAxisAlignedSegments` to assert correct segmentation of a 3-segment orthogonal U-shaped detour.
- Ensures non-collinear parallel segments retain independent identity with proper axis tags and length values.

### Testing
- Asserts decomposed axis sequence (`y`, `x`, `y`) and segment lengths.