### PR TITLE
test(segments): add alternating multi-turn S-route axis-aligned specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,23 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+
+test("getAxisAlignedSegments decomposes multi-turn alternating S-route", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+    { x: 4, y: 3 },
+    { x: 8, y: 3 },
+    { x: 8, y: 6 },
+    { x: 12, y: 6 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["x", 4],
+    ["y", 3],
+    ["x", 4],
+    ["y", 3],
+    ["x", 4],
+  ])
+})
+


### PR DESCRIPTION
### Summary
- Extends test verification for `getAxisAlignedSegments` to cover complex alternating multi-turn S-curve polyline paths.
- Asserts strict alternating orthogonal axis identification (`x`, `y`, `x`, `y`, `x`) and correct segment span calculations.

### Testing
- Asserts axes sequence and segment lengths match path coordinates.