### PR TITLE
test(segments): add perimeter box with connector stub axis-aligned specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,21 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+
+test("getAxisAlignedSegments processes orthogonal perimeter box with connector stub", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 5, y: 0 },
+    { x: 5, y: 5 },
+    { x: 0, y: 5 },
+    { x: 0, y: 8 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["x", 5],
+    ["y", 5],
+    ["x", 5],
+    ["y", 3],
+  ])
+})
+


### PR DESCRIPTION
### Summary
- Adds unit test coverage for `getAxisAlignedSegments` handling orthogonal boundary boxes featuring an extended connector stub.
- Asserts proper separation of perpendicular box boundaries and subsequent protruding vertical trace lines.

### Testing
- Validates sequence length, axis assignment (`x`, `y`, `x`, `y`), and exact coordinate spans.