### PR TITLE
test(solver): add multi-step staircase axis-aligned segment specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,17 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+test("getAxisAlignedSegments handles multi-step staircases with alternating axes", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 4 },
+    { x: 5, y: 4 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["y", 4],
+    ["x", 3],
+    ["x", 2],
+  ])
+})


### PR DESCRIPTION
### Summary
- Adds unit test verification for multi-step alternating axis point runs in `getAxisAlignedSegments`.
- Validates sorting by descending segment length and axis assignment.

### Testing
- Checked segment lengths and axis tagging.