### PR TITLE
test(solver): add U-shaped orthogonal path segment extraction specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,17 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+test("getAxisAlignedSegments handles U-shaped paths correctly", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 0, y: 5 },
+    { x: 4, y: 5 },
+    { x: 4, y: 0 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["y", 5],
+    ["y", 5],
+    ["x", 4],
+  ])
+})


### PR DESCRIPTION
### Summary
- Adds test coverage for U-shaped orthogonal routes in `getAxisAlignedSegments`.
- Validates segment length ordering and axis recognition.

### Testing
- Tested with bun test.