### PR TITLE
test(solver): add multi-turn S-curve orthogonal route specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,17 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+test("getAxisAlignedSegments processes multi-turn S-curves correctly", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: 6 },
+    { x: 8, y: 6 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["y", 6],
+    ["x", 5],
+    ["x", 3],
+  ])
+})


### PR DESCRIPTION
### Summary
- Adds test cases for multi-turn S-curve coordinate paths in `getAxisAlignedSegments`.
- Validates segment lengths and descending sort ordering.

### Testing
- Tested with bun test.