### PR TITLE
test(solver): add non-axis-aligned diagonal step filtering specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,14 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+test("getAxisAlignedSegments ignores purely non-axis-aligned diagonal steps", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 5, y: 5 },
+    { x: 5, y: 10 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["y", 5],
+  ])
+})


### PR DESCRIPTION
### Summary
- Adds test coverage verifying that non-orthogonal diagonal step pairs are ignored by `getAxisAlignedSegments`.

### Testing
- Tested with bun test.