### PR TITLE
test(solver): add inward concentric square spiral segment extraction specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,21 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+test("getAxisAlignedSegments handles inward concentric square spiral routes", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 2, y: 10 },
+    { x: 2, y: 2 },
+    { x: 8, y: 2 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["x", 10],
+    ["y", 10],
+    ["x", 8],
+    ["y", 8],
+    ["x", 6],
+  ])
+})


### PR DESCRIPTION
### Summary
- Adds test coverage for multi-layer concentric square spiral routes in `getAxisAlignedSegments`.
- Validates segment lengths, axes, and descending sort ordering.

### Testing
- Tested with bun test.