### PR TITLE
test(solver): add T-junction coordinate segment decomposition specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,17 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+test("getAxisAlignedSegments handles T-shaped branch step runs", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 5 },
+    { x: 10, y: 5 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["x", 10],
+    ["y", 10],
+    ["y", 5],
+  ])
+})


### PR DESCRIPTION
### Summary
- Adds unit test verification for `getAxisAlignedSegments` handling T-junction and backtracking segment paths.

### Testing
- Tested with bun test.