### PR TITLE
test(solver): add four-way cross junction segment decomposition specs

### DIFF
--- a/tests/functions/getAxisAlignedSegments.test.ts
+++ b/tests/functions/getAxisAlignedSegments.test.ts
@@ -54,3 +54,18 @@ test("getAxisAlignedSegments returns nothing for degenerate paths", () => {
     ]),
   ).toEqual([])
 })
+test("getAxisAlignedSegments handles four-way cross junction paths", () => {
+  const segments = getAxisAlignedSegments([
+    { x: 0, y: 5 },
+    { x: 10, y: 5 },
+    { x: 5, y: 5 },
+    { x: 5, y: 0 },
+    { x: 5, y: 10 },
+  ])
+
+  expect(segments.map((s) => [s.axis, s.length])).toEqual([
+    ["x", 10],
+    ["y", 10],
+    ["y", 5],
+  ])
+})


### PR DESCRIPTION
### Summary
- Adds test coverage for four-way intersecting cross-junction routes in `getAxisAlignedSegments`.
- Validates overlap reduction and segment sorting.

### Testing
- Tested with bun test.