### PR TITLE
test(solver): add asymmetric pin layout bounding calculation specs

### DIFF
--- a/tests/day2-w20-asymmetric-pin.test.ts
+++ b/tests/day2-w20-asymmetric-pin.test.ts
@@ -1,0 +1,19 @@
+import test, { expect } from "bun:test"
+import { findSchematicRoute } from "../lib/index"
+
+test("schematic-trace-solver - asymmetric pin layout bounding calculation", () => {
+  const points = [
+    { x: -50, y: 10 },
+    { x: 120, y: 85 },
+  ]
+  const obstacles: any[] = []
+  const result = findSchematicRoute({
+    points,
+    obstacles,
+    gridSize: 2,
+  } as any)
+
+  expect(result).toBeDefined()
+  expect(result.routes).toBeDefined()
+  expect(result.routes.length).toBeGreaterThanOrEqual(1)
+})


### PR DESCRIPTION
### Summary\n- Adds test verification for `findSchematicRoute` spanning asymmetric aspect ratios across wide coordinates.\n\n### Testing\n- Tested with bun test.