### PR TITLE
test(solver): add multi-point serpentine routing path specs

### DIFF
--- a/tests/day2-w23-serpentine.test.ts
+++ b/tests/day2-w23-serpentine.test.ts
@@ -1,0 +1,21 @@
+import test, { expect } from "bun:test"
+import { findSchematicRoute } from "../lib/index"
+
+test("schematic-trace-solver - multi-point serpentine routing path", () => {
+  const points = [
+    { x: 0, y: 0 },
+    { x: 10, y: 30 },
+    { x: 20, y: 0 },
+    { x: 30, y: 30 },
+  ]
+  const obstacles: any[] = []
+  const result = findSchematicRoute({
+    points,
+    obstacles,
+    gridSize: 1,
+  } as any)
+
+  expect(result).toBeDefined()
+  expect(result.routes).toBeDefined()
+  expect(result.routes.length).toBeGreaterThanOrEqual(1)
+})


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `findSchematicRoute` traversing multi-point alternating serpentine coordinate sequences.\n\n### Testing\n- Tested with bun test.