### PR TITLE
test(solver): add sub-grid fractional coordinate precision routing specs

### DIFF
--- a/tests/day3-w11-fractional-coord.test.ts
+++ b/tests/day3-w11-fractional-coord.test.ts
@@ -1,0 +1,21 @@
+import test, { expect } from "bun:test"
+import { findSchematicRoute } from "../lib/index"
+
+test("schematic-trace-solver - sub-grid fractional coordinate precision routing", () => {
+  const points = [
+    { x: 0.25, y: 0.75 },
+    { x: 35.5, y: 18.25 },
+  ]
+  const obstacles = [
+    { cx: 17.5, cy: 9.0, w: 10.5, h: 8.5 },
+  ]
+  const result = findSchematicRoute({
+    points,
+    obstacles,
+    gridSize: 0.25,
+  } as any)
+
+  expect(result).toBeDefined()
+  expect(result.routes).toBeDefined()
+  expect(result.routes.length).toBeGreaterThanOrEqual(1)
+})


### PR DESCRIPTION
### Summary\n- Adds test verification for `findSchematicRoute` resolving fine 0.25 fractional grid step routes.\n\n### Testing\n- Tested with bun test.